### PR TITLE
feat: restore overrides, caching, and ffmpeg support

### DIFF
--- a/docs/ISSUES_TODO.md
+++ b/docs/ISSUES_TODO.md
@@ -1,0 +1,24 @@
+- [ ] Restore trim/change_fps overrides in CLI and vs_core
+  - Context: `OverridesConfig` is validated but `_init_clips` never applies trims or FPS maps, unlike legacy `trim_dict`/`change_fps` behaviour.
+  - Repro: Add overrides to `config.toml`; run CLI; clips open without adjustments.【F:frame_compare.py†L87-L145】【F:src/vs_core.py†L93-L113】【F:legacy/compv4_improved.py†L94-L134】
+  - Acceptance criteria: Per-file trims and fps overrides applied deterministically (including "set" semantics) with unit tests.
+  - Labels: enhancement, parity, core
+  - Size: M
+- [ ] Respect naming preferences for labels and filenames
+  - Context: `NamingConfig.always_full_filename` and `prefer_guessit` are ignored when listing clips or generating screenshot names.
+  - Repro: Set `always_full_filename=false` in config; CLI still prints full filenames and screenshots use raw names.【F:frame_compare.py†L132-L135】【F:src/screenshot.py†L84-L88】【F:legacy/compv4_improved.py†L48-L53】
+  - Acceptance criteria: CLI and screenshot outputs honour naming toggles with regression tests.
+  - Labels: enhancement, parity, ux
+  - Size: S
+- [ ] Implement frame metrics caching per `save_frames_data`
+  - Context: `save_frames_data`/`frame_data_filename` survive validation but no metrics file is written or read on subsequent runs.
+  - Repro: Enable `save_frames_data`; rerun CLI; analysis recomputes metrics every time.【F:src/analysis.py†L171-L264】【F:legacy/compv4_improved.py†L34-L37】【F:legacy/compv4_improved.py†L144-L149】
+  - Acceptance criteria: Metrics cached alongside comparisons with invalidation when inputs change; tests cover cold/hot paths.
+  - Labels: enhancement, performance
+  - Size: M
+- [ ] Honour `use_ffmpeg` toggle or fail fast
+  - Context: Config exposes `use_ffmpeg` but screenshot module ignores it, leaving users without ffmpeg fallback.
+  - Repro: Set `use_ffmpeg=true`; run CLI on system without VapourSynth; placeholders generated instead of ffmpeg renders.【F:src/datatypes.py†L35-L42】【F:src/screenshot.py†L84-L185】【F:legacy/compv4_improved.py†L44-L47】
+  - Acceptance criteria: Either implement ffmpeg-based writer parity or raise a clear error when requested dependency missing.
+  - Labels: enhancement, parity
+  - Size: M

--- a/docs/PARITY_MATRIX.csv
+++ b/docs/PARITY_MATRIX.csv
@@ -1,0 +1,39 @@
+Feature,Legacy Location/Ref,Modern Module,Parity (Yes/Partial/No),Notes / Gaps,Suggested Fix/Owner/Size(S/M/L)
+RAM limit enforcement,legacy/compv4_improved.py:L22-L369,src/vs_core.py,No,"RuntimeConfig.ram_limit_mb never applied to VapourSynth core; legacy set vs.core.max_cache_size.",Core team: apply limit during clip init (S)
+Frame count (dark/bright/motion),legacy/compv4_improved.py:L25-L29,src/analysis.py,Yes,"Counts map directly to AnalysisConfig frame selection parameters.",Maintain
+User-defined frames,user_frames= legacy/compv4_improved.py:L29-L31,src/analysis.py,Yes,"User frames appended before heuristics via AnalysisConfig.user_frames.",Maintain
+Random frame sampling,legacy/compv4_improved.py:L31-L33,src/analysis.py,Yes,"Random RNG seeded from config replicates legacy randomness knobs.",Maintain
+Save frame metrics cache,legacy/compv4_improved.py:L34-L37,src/analysis.py,No,"save_frames/frame_filename options exist but data is never persisted or reused.",Core team: implement caching around frame_data_filename (M)
+Screenshot frame info overlay,legacy/compv4_improved.py:L38-L41,src/screenshot.py,Yes,"add_frame_info toggles overlay similar to legacy frame_info flag.",Maintain
+Screenshot upscale alignment,legacy/compv4_improved.py:L40-L47,src/screenshot.py,Yes,"upscale/single_res/mod_crop mirror legacy options for scaling.",Maintain
+Screenshot FFmpeg toggle,legacy/compv4_improved.py:L44-L47,src/screenshot.py,No,"use_ffmpeg flag unused; no ffmpeg writer implemented.",Media pipeline: add ffmpeg writer or validation (M)
+PNG compression semantics,legacy/compv4_improved.py:L46-L47,src/screenshot.py,Partial,"Only three presets (0/1/2) supported; legacy allowed 0-2 for fpng and 0-100 for ffmpeg.",Clarify docs or expand mapping (S)
+Always use full filename,legacy/compv4_improved.py:L48-L51,frame_compare.py / src/screenshot.py,No,"NamingConfig.always_full_filename ignored when listing files or naming screenshots.",Core team: thread naming config through CLI and screenshot naming (S)
+Prefer GuessIt toggle,legacy/compv4_improved.py:L52-L53,frame_compare.py / src/utils.py,No,"CLI/screenshot paths call parse_filename_metadata without passing prefer_guessit override.",Core team: pass config flag to parse_filename_metadata (S)
+Analysis downscale height,legacy/compv4_improved.py:L55-L56,src/analysis.py,Yes,"downscale_height enforced before stats collection.",Maintain
+Analysis sampling step,legacy/compv4_improved.py:L57-L58,src/analysis.py,Yes,"step applied to index stride identical to legacy.",Maintain
+HDR to SDR analysis toggle,legacy/compv4_improved.py:L59-L60,src/analysis.py / src/vs_core.py,Yes,"analyze_in_sdr passes clip through tonemapping when enabled.",Maintain
+Quantile vs bands toggle,legacy/compv4_improved.py:L61-L69,src/analysis.py,Yes,"use_quantiles selects quantiles vs fixed brightness bands.",Maintain
+Dark/bright quantile thresholds,legacy/compv4_improved.py:L63-L65,src/analysis.py,Yes,"Quantile thresholds applied when enabled.",Maintain
+Motion absolute diff option,legacy/compv4_improved.py:L66-L67,src/analysis.py,Yes,"motion_use_absdiff changes diff expression path.",Maintain
+Motion scenecut quantile,legacy/compv4_improved.py:L68-L69,src/analysis.py,Yes,"motion_scenecut_quantile filters high motion frames as configured.",Maintain
+Modulus-aware crop,legacy/compv4_improved.py:L70-L73,src/screenshot.py,Yes,"plan_mod_crop mirrors modulus and letterbox handling.",Maintain
+Letterbox/pillarbox awareness,legacy/compv4_improved.py:L70-L73,src/screenshot.py,Yes,"letterbox_pillarbox_aware handled in crop planning.",Maintain
+Automatic slow.pics upload,legacy/compv4_improved.py:L76-L92,frame_compare.py / src/slowpics.py,Yes,"auto_upload triggers upload_comparison with public/private flags.",Maintain
+Slow.pics NSFW/public flags,legacy/compv4_improved.py:L78-L90,src/slowpics.py,Yes,"is_hentai/is_public map to payload flags.",Maintain
+TMDB ID metadata,legacy/compv4_improved.py:L81-L82,src/slowpics.py,Yes,"tmdbId forwarded in create_payload.",Maintain
+Remove-after days,legacy/compv4_improved.py:L83-L84,src/slowpics.py,Yes,"removeAfterDays payload mirrors legacy behaviour.",Maintain
+Webhook notifications,legacy/compv4_improved.py:L85-L86,src/slowpics.py,Yes,"webhook_url triggers webhook API call.",Maintain
+Open browser toggle,legacy/compv4_improved.py:L87-L88,frame_compare.py,Yes,"open_in_browser toggles webbrowser.open.",Maintain
+Create URL shortcut,legacy/compv4_improved.py:L89-L90,src/slowpics.py,Yes,"create_url_shortcut writes .url file.",Maintain
+Delete screenshots after upload,legacy/compv4_improved.py:L91-L92,frame_compare.py,Yes,"delete_screen_dir_after_upload removes directory on success.",Maintain
+Trim start overrides,legacy/compv4_improved.py:L94-L112,frame_compare.py / src/vs_core.py,No,"OverridesConfig.trim validated but never applied to clips.",Core team: map overrides to init_clip arguments (M)
+Trim end overrides,legacy/compv4_improved.py:L94-L112,frame_compare.py / src/vs_core.py,No,"trim_end entries unused; no support for end-frame adjustments.",Core team: translate trim_end to Clip Trim last args (M)
+Change FPS overrides,legacy/compv4_improved.py:L114-L134,frame_compare.py / src/vs_core.py,No,"change_fps map ignored; clips opened without fps adjustments or follow-the-set behaviour.",Core team: compute per-clip fps_map and apply (M)
+Analyze clip selection override,legacy/compv4_improved.py:L136-L140,frame_compare.py,Yes,"analyze_clip hint passed into _pick_analyze_file.",Maintain
+Random seed stability,legacy/compv4_improved.py:L144-L145,src/analysis.py,Yes,"random_seed seeds RNG for deterministic selection.",Maintain
+Frame data filename,legacy/compv4_improved.py:L146-L149,src/datatypes.py / src/analysis.py,No,"frame_data_filename required by validation but never read or written.",Core team: use path when persisting metrics (M)
+Screenshot directory name,legacy/compv4_improved.py:L148-L149,frame_compare.py / src/screenshot.py,Yes,"directory_name controls output path identical to screen_dirname.",Maintain
+Minimum frame separation,legacy/compv4_improved.py:L150-L151,src/analysis.py,Yes,"screen_separation_sec enforces spacing via dedupe.",Maintain
+Motion diff radius,legacy/compv4_improved.py:L152-L154,src/analysis.py,Yes,"motion_diff_radius used in smoothing window.",Maintain
+Tonemap parameter presets,legacy/compv4_improved.py:L187-L199,src/vs_core.py,Partial,"Modern code hardcodes bt2390 defaults with no config hook for TM presets or overlay flags.",Config: expose tonemap settings in AnalysisConfig or dedicated struct (M)

--- a/docs/REVIEW.md
+++ b/docs/REVIEW.md
@@ -1,0 +1,60 @@
+# Summary (TL;DR)
+- Config schema is rich but several knobs (naming, overrides, caching, ffmpeg) are disconnected from the CLI pipeline, leaving notable parity gaps with the legacy script.【F:src/datatypes.py†L31-L102】【F:frame_compare.py†L132-L188】【F:src/screenshot.py†L84-L185】【F:legacy/compv4_improved.py†L22-L154】
+- Core modules are well-factored with typed exceptions and defensive fallbacks, yet runtime safeguards (ram limit, slow.pics resilience) and configuration-driven behaviour need hardening for production use.【F:src/config_loader.py†L26-L123】【F:src/analysis.py†L75-L264】【F:src/vs_core.py†L48-L203】
+- Test suite passes but omits CLI, override, and error-path coverage; adding parity/golden tests is required before cutting over from the legacy tool.【f3ab21†L1-L3】
+
+# Repo Overview
+The project modernises the legacy `compv4_improved.py` workflow into a Click-powered CLI (`frame_compare.py`) that orchestrates configuration loading, VapourSynth clip init, frame analysis, screenshot generation, and optional slow.pics uploads.【F:frame_compare.py†L13-L193】 Supporting modules include config parsing (`src/config_loader.py`), structured dataclasses (`src/datatypes.py`), filename parsing utilities (`src/utils.py`), analysis heuristics (`src/analysis.py`), screenshot planning (`src/screenshot.py`), slow.pics API client (`src/slowpics.py`), and VapourSynth helpers (`src/vs_core.py`).【F:src/config_loader.py†L10-L123】【F:src/datatypes.py†L6-L102】【F:src/utils.py†L8-L167】【F:src/analysis.py†L13-L264】【F:src/screenshot.py†L12-L186】【F:src/slowpics.py†L13-L115】【F:src/vs_core.py†L14-L203】 The bundled `config.toml` mirrors dataclass defaults, providing end-user entry points.【F:config.toml†L1-L59】
+
+# Architecture Review
+- **`src/config_loader`** – Handles UTF-8 BOM stripping, boolean coercion, and range validation, raising `ConfigError` on invalid input.【F:src/config_loader.py†L26-L123】 Validation covers overrides but the application never consumes those mappings, so they effectively dead-end.
+- **`src/datatypes`** – Dataclasses capture legacy settings but several fields (`save_frames_data`, `frame_data_filename`, `use_ffmpeg`, naming prefs, overrides, runtime.ram_limit) have no downstream consumers, signalling incomplete wiring.【F:src/datatypes.py†L10-L102】【F:frame_compare.py†L132-L188】【F:src/screenshot.py†L84-L185】
+- **`src/utils`** – Isolates GuessIt/Anitopy parsing with safe import fallbacks and deterministic label construction; however, consumers always use defaults because they ignore `NamingConfig` overrides.【F:src/utils.py†L41-L167】【F:frame_compare.py†L132-L135】
+- **`src/analysis`** – Provides quantile-based selection with deterministic RNG and VapourSynth fallbacks.【F:src/analysis.py†L75-L264】 Yet `files` parameter and caching hooks remain unused, and `_generate_metrics_fallback` produces synthetic data without logging, complicating debugging.
+- **`src/screenshot`** – Plans modulus-aware crops and scales, wraps VapourSynth saves, and falls back to placeholder files on unexpected errors.【F:src/screenshot.py†L24-L185】 `parse_filename_metadata` is called without respect to naming config or `use_ffmpeg`, so toggles don’t change behaviour.
+- **`src/slowpics`** – Encapsulates API interactions with explicit timeouts and shortcut creation.【F:src/slowpics.py†L20-L115】 Missing retry/backoff and webhook error handling reduces robustness compared to legacy script’s manual flow.
+- **`src/vs_core`** – Clean separation of clip init, trims, FPS mapping, HDR detection, and tonemapping defaults.【F:src/vs_core.py†L48-L203】 No integration exists with override maps or runtime ram limit, and tonemap parameters aren’t exposed via config.
+- **`frame_compare` CLI** – Friendly messaging and summary output, but it mutates config dataclasses directly, exits on first failure, and never applies overrides (trim/change_fps), naming toggles, or ram limit that users expect from legacy behaviour.【F:frame_compare.py†L104-L193】
+
+# Quality Findings
+- Positive: Modules declare typed exceptions, prefer dependency injection for optional libraries, and include docstrings/type hints throughout.【F:src/config_loader.py†L22-L123】【F:src/vs_core.py†L14-L203】
+- Issues:
+  - `RuntimeConfig.ram_limit_mb`, naming preferences, screenshot `use_ffmpeg`, and override maps are unused, leading to confusing configs and parity loss.【F:src/datatypes.py†L31-L102】【F:frame_compare.py†L132-L188】【F:src/screenshot.py†L84-L185】
+  - `analysis.select_frames` swallows all VapourSynth errors and silently uses deterministic sine/cosine fallbacks; lack of logging obscures degraded runs.【F:src/analysis.py†L181-L185】
+  - `frame_compare` relies on `sys.exit`, which is acceptable for CLI, but there’s no structured logging or exit codes summarised for automation consumers.【F:frame_compare.py†L104-L193】
+  - No enforcement of `runtime.ram_limit_mb` akin to legacy `vs.core.max_cache_size`, losing a reliability safeguard.【F:legacy/compv4_improved.py†L22-L369】【F:src/vs_core.py†L48-L113】
+
+# Functional Parity Findings
+Key divergences vs. legacy `compv4_improved.py` (see `docs/PARITY_MATRIX.csv` for full matrix):
+- Trim/FPS override dictionaries (`trim_dict`, `trim_dict_end`, `change_fps`) exist in config but are never applied when opening clips, so users cannot align sources as before.【F:legacy/compv4_improved.py†L94-L134】【F:frame_compare.py†L87-L145】【F:src/vs_core.py†L93-L203】
+- Naming toggles (`always_full_filename`, `prefer_guessit`) are ignored in CLI listing and screenshot filenames, forcing full filenames regardless of config.【F:legacy/compv4_improved.py†L48-L53】【F:src/datatypes.py†L65-L66】【F:frame_compare.py†L132-L135】【F:src/screenshot.py†L84-L88】
+- Legacy caching knobs (`save_frames`, `frame_filename`) and ram limit enforcement are not implemented, so repeated runs reanalyse clips and risk higher memory use.【F:legacy/compv4_improved.py†L34-L37】【F:legacy/compv4_improved.py†L144-L149】【F:src/analysis.py†L171-L264】【F:src/vs_core.py†L48-L113】
+- FFmpeg rendering path is stubbed: `use_ffmpeg` only toggles a flag with no alternate writer, losing compatibility with environments lacking VapourSynth/Pillow.【F:legacy/compv4_improved.py†L44-L47】【F:src/datatypes.py†L35-L42】【F:src/screenshot.py†L84-L185】
+
+# Test & CI Findings
+- `uv run python -m pytest -q` passes (26 tests) under Python 3.11, matching CI expectations.【f3ab21†L1-L3】
+- Coverage gaps: no tests execute the CLI end-to-end, validate override application, exercise HDR tonemap failures, or hit slow.pics error scenarios (missing XSRF token, webhook failures). `docs/TEST_GAPS.md` outlines concrete additions.
+- CI runs only on Ubuntu 3.11; no Windows or Python 3.12 matrix, and no lint/static analysis steps beyond `pytest`.
+
+# Enhancement Proposals
+(Priority P0 highest urgency)
+1. **P0 – Wire overrides/naming/runtime knobs**: Apply `cfg.overrides` when creating clips, respect `NamingConfig` in CLI/screenshot labelling, and enforce `ram_limit_mb` via `vs.core.max_cache_size` to restore parity and reliability.【F:src/datatypes.py†L31-L102】【F:frame_compare.py†L87-L188】【F:src/vs_core.py†L48-L203】 (Size: M)
+2. **P0 – Implement screenshot writer selection**: Honour `use_ffmpeg`, adding an FFmpeg fallback or emitting a config error when requested but unavailable.【F:legacy/compv4_improved.py†L44-L47】【F:src/screenshot.py†L84-L185】 (Size: M)
+3. **P0 – Add frame data caching**: Use `save_frames_data`/`frame_data_filename` to persist analysis metrics and skip recomputation when unchanged.【F:legacy/compv4_improved.py†L34-L37】【F:src/datatypes.py†L10-L28】【F:src/analysis.py†L171-L264】 (Size: M)
+4. **P1 – Strengthen slow.pics client**: Introduce retries, webhook error handling, and redaction of sensitive URLs in logs for robustness.【F:src/slowpics.py†L20-L115】 (Size: S)
+5. **P1 – Structured logging & dry-run**: Replace bare `print` calls with logging (levels) and add a `--dry-run` path to inspect planned actions without side effects.【F:frame_compare.py†L95-L193】 (Size: M)
+6. **P1 – Testing enhancements**: Add CLI integration tests (using sample media/mocks), slow.pics HTTP mocks for 4xx/5xx, and property-based tests for filename parsing quantiles.【F:tests/test_slowpics.py†L1-L88】【F:tests/test_utils.py†L1-L87】 (Size: M)
+7. **P2 – CI & tooling**: Extend workflow to Python 3.12/Windows, add artifact upload for generated screenshots, and integrate `ruff`/`black` checks for consistent style.【F:.github/workflows/ci.yml†L1-L28】 (Size: M)
+8. **P2 – Documentation**: Document unsupported features (ffmpeg, caching) until implemented, and add troubleshooting for VapourSynth/Pillow installation gaps.【F:README.md†L1-L171】 (Size: S)
+
+# Risks & Trade-offs
+- Implementing overrides and caching touches core orchestration and may require redesigning `frame_compare._init_clips` to accept per-file metadata, increasing complexity and testing surface.【F:frame_compare.py†L87-L188】
+- FFmpeg fallback must match VapourSynth output fidelity; ensuring deterministic PNG naming across writers demands rigorous tests.【F:src/screenshot.py†L146-L186】
+- Enforcing ram limits globally can impact multi-run workflows if not scoped carefully, particularly when multiple comparisons run within one interpreter.【F:src/vs_core.py†L48-L113】
+
+# Next Actions
+1. Implement config parity fixes: overrides, naming prefs, ram limit, and ffmpeg toggle semantics (blocker for release).
+2. Build caching layer for frame metrics respecting `save_frames_data` & `frame_data_filename`.
+3. Expand automated tests per `docs/TEST_GAPS.md`, including CLI integration and slow.pics failure cases.
+4. Enhance CI matrix (Python versions, Windows) and add lint/static analysis steps.
+5. Update documentation to reflect current feature set and migration caveats.

--- a/docs/TEST_GAPS.md
+++ b/docs/TEST_GAPS.md
@@ -1,0 +1,12 @@
+| Area/Module | Missing Test | Type (unit/integration/golden) | How to implement (1–3 bullets) | Priority |
+| --- | --- | --- | --- | --- |
+| `frame_compare` CLI | Happy-path orchestration using sample clips and mocked VapourSynth/slow.pics | integration | - Patch `vs_core.init_clip`, `generate_screenshots`, and `upload_comparison` to deterministic fakes<br>- Run CLI via `CliRunner` with temp input dir<br>- Assert summary output and exit code 0 | P0 |
+| `frame_compare` overrides | Verify `cfg.overrides` applied to clips (trim/fps) | unit | - Inject fake `vs_core.init_clip` capturing kwargs<br>- Provide config with trim/change_fps overrides<br>- Assert expected clip adjustments triggered | P0 |
+| `src/config_loader` | Validate `_coerce_bool` and `change_fps` error paths for bad values | unit | - Feed TOML snippets with invalid booleans/fps lists<br>- Expect `ConfigError` messages covering offending keys | P1 |
+| `src/analysis.select_frames` | Quantile vs fixed-band behaviour and fallback logging | unit | - Supply synthetic brightness/motion arrays to force thresholds<br>- Toggle `use_quantiles` False<br>- Assert frame picks change and fallback warning emitted | P1 |
+| `src/analysis` caching | Persistence round-trip once implemented | golden | - Run selection writing metrics file<br>- Re-run with cached data and assert no recomputation/log message | P1 |
+| `src/screenshot.generate_screenshots` | Placeholder fallback when writer raises generic exception | unit | - Monkeypatch `_save_frame_with_vapoursynth` to raise `RuntimeError`<br>- Ensure placeholder file exists and warning logged | P1 |
+| `src/slowpics.upload_comparison` | Missing XSRF token and webhook failure handling | unit | - Use fake session without cookie<br>- Assert `SlowpicsAPIError` surfaces with context<br>- Add case where webhook endpoint returns 500 | P0 |
+| `src/vs_core.process_clip_for_screenshot` | HDR detection via numeric props and missing libplacebo | unit | - Provide fake clip with HDR primaries/transfer codes<br>- Simulate missing `core.libplacebo` to assert `ClipProcessError` | P1 |
+| `src/utils.parse_filename_metadata` | Respect `prefer_guessit=False` / `always_full_filename=False` combos | unit | - Force GuessIt failure and ensure Anitopy output used<br>- Verify labels shorten when config disables full filename | P1 |
+| CI workflow | Cross-platform and Python version matrix smoke test | integration | - Extend GitHub Actions matrix to include Windows + Python 3.12<br>- Capture artifact of generated screenshots for manual inspection | P2 |

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import sys
 import shutil
 import webbrowser
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import click
 from rich import print
@@ -14,7 +16,7 @@ from src.config_loader import ConfigError, load_config
 from src.datatypes import AppConfig
 from src.utils import parse_filename_metadata
 from src import vs_core
-from src.analysis import select_frames
+from src.analysis import FrameMetricsCacheInfo, select_frames
 from src.screenshot import generate_screenshots, ScreenshotError
 from src.slowpics import SlowpicsAPIError, upload_comparison
 
@@ -51,11 +53,48 @@ SUPPORTED_EXTS = (
 )
 
 
+@dataclass
+class _ClipPlan:
+    path: Path
+    metadata: Dict[str, str]
+    trim_start: int = 0
+    trim_end: Optional[int] = None
+    fps_override: Optional[Tuple[int, int]] = None
+    use_as_reference: bool = False
+    clip: Optional[object] = None
+    effective_fps: Optional[Tuple[int, int]] = None
+    applied_fps: Optional[Tuple[int, int]] = None
+
+
 def _discover_media(root: Path) -> List[Path]:
     return [p for p in os_sorted(root.iterdir()) if p.suffix.lower() in SUPPORTED_EXTS]
 
 
-def _pick_analyze_file(files: Sequence[Path], target: str | None) -> Path:
+def _parse_metadata(files: Sequence[Path], naming_cfg) -> List[Dict[str, str]]:
+    metadata: List[Dict[str, str]] = []
+    for file in files:
+        info = parse_filename_metadata(
+            file.name,
+            prefer_guessit=naming_cfg.prefer_guessit,
+            always_full_filename=naming_cfg.always_full_filename,
+        )
+        metadata.append(info)
+    _dedupe_labels(metadata, files, naming_cfg.always_full_filename)
+    return metadata
+
+
+def _dedupe_labels(metadata: Sequence[Dict[str, str]], files: Sequence[Path], prefer_full_name: bool) -> None:
+    counts = Counter((meta.get("label") or "") for meta in metadata)
+    for idx, meta in enumerate(metadata):
+        label = meta.get("label") or ""
+        if not label:
+            meta["label"] = files[idx].name
+            continue
+        if counts[label] > 1:
+            meta["label"] = files[idx].name if prefer_full_name else files[idx].name
+
+
+def _pick_analyze_file(files: Sequence[Path], metadata: Sequence[Mapping[str, str]], target: str | None) -> Path:
     if not files:
         raise ValueError("No files to analyze")
     target = (target or "").strip()
@@ -73,9 +112,9 @@ def _pick_analyze_file(files: Sequence[Path], target: str | None) -> Path:
     for idx, file in enumerate(files):
         if file.name.lower() == target_lower or file.stem.lower() == target_lower:
             return file
-        metadata = parse_filename_metadata(file.name)
-        for key in ("label", "release_group", "anime_title"):
-            value = metadata.get(key) or ""
+        meta = metadata[idx]
+        for key in ("label", "release_group", "anime_title", "file_name"):
+            value = str(meta.get(key) or "")
             if value and value.lower() == target_lower:
                 return file
         if target_lower == str(idx):
@@ -84,12 +123,133 @@ def _pick_analyze_file(files: Sequence[Path], target: str | None) -> Path:
     return files[0]
 
 
-def _init_clips(files: Sequence[Path]) -> List[object]:
-    clips: List[object] = []
-    for file in files:
-        clip = vs_core.init_clip(str(file))
-        clips.append(clip)
-    return clips
+def _normalise_override_mapping(raw: Mapping[str, object]) -> Dict[str, object]:
+    normalised: Dict[str, object] = {}
+    for key, value in raw.items():
+        key_str = str(key).strip().lower()
+        if key_str:
+            normalised[key_str] = value
+    return normalised
+
+
+def _match_override(
+    index: int,
+    file: Path,
+    metadata: Mapping[str, str],
+    mapping: Mapping[str, object],
+) -> Optional[object]:
+    candidates = [
+        str(index),
+        file.name,
+        file.stem,
+        metadata.get("release_group", ""),
+        metadata.get("file_name", ""),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        value = mapping.get(candidate.lower())
+        if value is not None:
+            return value
+    return None
+
+
+def _build_plans(files: Sequence[Path], metadata: Sequence[Dict[str, str]], cfg: AppConfig) -> List[_ClipPlan]:
+    trim_map = _normalise_override_mapping(cfg.overrides.trim)
+    trim_end_map = _normalise_override_mapping(cfg.overrides.trim_end)
+    fps_map = _normalise_override_mapping(cfg.overrides.change_fps)
+
+    plans: List[_ClipPlan] = []
+    for idx, file in enumerate(files):
+        meta = dict(metadata[idx])
+        plan = _ClipPlan(path=file, metadata=meta)
+
+        trim_val = _match_override(idx, file, meta, trim_map)
+        if trim_val is not None:
+            plan.trim_start = int(trim_val)
+
+        trim_end_val = _match_override(idx, file, meta, trim_end_map)
+        if trim_end_val is not None:
+            plan.trim_end = int(trim_end_val)
+
+        fps_val = _match_override(idx, file, meta, fps_map)
+        if isinstance(fps_val, str):
+            if fps_val.lower() == "set":
+                plan.use_as_reference = True
+        elif isinstance(fps_val, list):
+            if len(fps_val) == 2:
+                plan.fps_override = (int(fps_val[0]), int(fps_val[1]))
+        elif fps_val is not None:
+            raise ValueError("Unsupported change_fps override type")
+
+        plans.append(plan)
+
+    return plans
+
+
+def _extract_clip_fps(clip: object) -> Tuple[int, int]:
+    num = getattr(clip, "fps_num", None)
+    den = getattr(clip, "fps_den", None)
+    if isinstance(num, int) and isinstance(den, int) and den:
+        return (num, den)
+    return (24000, 1001)
+
+
+def _init_clips(plans: Sequence[_ClipPlan], runtime_cfg) -> None:
+    vs_core.set_ram_limit(runtime_cfg.ram_limit_mb)
+
+    reference_index = next((idx for idx, plan in enumerate(plans) if plan.use_as_reference), None)
+    reference_fps: Optional[Tuple[int, int]] = None
+
+    if reference_index is not None:
+        plan = plans[reference_index]
+        clip = vs_core.init_clip(
+            str(plan.path),
+            trim_start=plan.trim_start,
+            trim_end=plan.trim_end,
+        )
+        plan.clip = clip
+        plan.effective_fps = _extract_clip_fps(clip)
+        reference_fps = plan.effective_fps
+
+    for idx, plan in enumerate(plans):
+        if idx == reference_index and plan.clip is not None:
+            continue
+        fps_override = plan.fps_override
+        if fps_override is None and reference_fps is not None and idx != reference_index:
+            fps_override = reference_fps
+
+        clip = vs_core.init_clip(
+            str(plan.path),
+            trim_start=plan.trim_start,
+            trim_end=plan.trim_end,
+            fps_map=fps_override,
+        )
+        plan.clip = clip
+        plan.applied_fps = fps_override
+        plan.effective_fps = _extract_clip_fps(clip)
+
+
+def _build_cache_info(root: Path, plans: Sequence[_ClipPlan], cfg: AppConfig, analyze_index: int) -> Optional[FrameMetricsCacheInfo]:
+    if not cfg.analysis.save_frames_data:
+        return None
+
+    analyzed = plans[analyze_index]
+    fps_num, fps_den = analyzed.effective_fps or (24000, 1001)
+    if fps_den <= 0:
+        fps_den = 1
+
+    cache_path = (root / cfg.analysis.frame_data_filename).resolve()
+    return FrameMetricsCacheInfo(
+        path=cache_path,
+        files=[plan.path.name for plan in plans],
+        analyzed_file=analyzed.path.name,
+        release_group=analyzed.metadata.get("release_group", ""),
+        trim_start=analyzed.trim_start,
+        trim_end=analyzed.trim_end,
+        fps_num=fps_num,
+        fps_den=fps_den,
+    )
 
 
 def _print_summary(files: Sequence[Path], frames: Sequence[int], out_dir: Path, url: str | None) -> None:
@@ -129,23 +289,42 @@ def main(config_path: str, input_dir: str | None) -> None:
         print("[red]Need at least two video files to compare.[/red]")
         sys.exit(1)
 
-    labels = [parse_filename_metadata(file.name).get("label") or file.name for file in files]
+    metadata = _parse_metadata(files, cfg.naming)
+    labels = [meta.get("label") or file.name for meta, file in zip(metadata, files)]
     print("[green]Files detected:[/green]")
     for label, file in zip(labels, files):
         print(f"  - {label} ({file.name})")
 
-    analyze_path = _pick_analyze_file(files, cfg.analysis.analyze_clip)
+    plans = _build_plans(files, metadata, cfg)
+    analyze_path = _pick_analyze_file(files, metadata, cfg.analysis.analyze_clip)
 
     try:
-        clips = _init_clips(files)
+        _init_clips(plans, cfg.runtime)
     except vs_core.ClipInitError as exc:
         print(f"[red]Failed to open clip:[/red] {exc}")
         sys.exit(1)
 
-    analyze_clip = clips[files.index(analyze_path)]
+    clips = [plan.clip for plan in plans]
+    if any(clip is None for clip in clips):
+        print("[red]Internal error:[/red] Clip initialisation failed")
+        sys.exit(1)
+
+    analyze_index = [plan.path for plan in plans].index(analyze_path)
+    analyze_clip = plans[analyze_index].clip
+    if analyze_clip is None:
+        print("[red]Internal error:[/red] Missing clip for analysis")
+        sys.exit(1)
+
+    cache_info = _build_cache_info(root, plans, cfg, analyze_index)
 
     try:
-        frames = select_frames(analyze_clip, cfg.analysis, [f.name for f in files], analyze_path.name)
+        frames = select_frames(
+            analyze_clip,
+            cfg.analysis,
+            [plan.path.name for plan in plans],
+            analyze_path.name,
+            cache_info=cache_info,
+        )
     except Exception as exc:
         print(f"[red]Frame selection failed:[/red] {exc}")
         sys.exit(1)
@@ -156,7 +335,14 @@ def main(config_path: str, input_dir: str | None) -> None:
 
     out_dir = (root / cfg.screenshots.directory_name).resolve()
     try:
-        image_paths = generate_screenshots(clips, frames, [str(f) for f in files], out_dir, cfg.screenshots)
+        image_paths = generate_screenshots(
+            clips,
+            frames,
+            [str(plan.path) for plan in plans],
+            [plan.metadata for plan in plans],
+            out_dir,
+            cfg.screenshots,
+        )
     except ScreenshotError as exc:
         print(f"[red]Screenshot generation failed:[/red] {exc}")
         sys.exit(1)
@@ -169,7 +355,7 @@ def main(config_path: str, input_dir: str | None) -> None:
             print(f"[red]slow.pics upload failed:[/red] {exc}")
             sys.exit(1)
 
-    _print_summary(files, frames, out_dir, slowpics_url)
+    _print_summary([plan.path for plan in plans], frames, out_dir, slowpics_url)
 
     if slowpics_url:
         if cfg.slowpics.open_in_browser:

--- a/src/analysis.py
+++ b/src/analysis.py
@@ -4,10 +4,28 @@
 
 import math
 import random
-from typing import List, Sequence, Tuple
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
 
 from .datatypes import AnalysisConfig
 from . import vs_core
+
+
+@dataclass(frozen=True)
+class FrameMetricsCacheInfo:
+    """Context needed to load/save cached frame metrics for analysis."""
+
+    path: Path
+    files: Sequence[str]
+    analyzed_file: str
+    release_group: str
+    trim_start: int
+    trim_end: Optional[int]
+    fps_num: int
+    fps_den: int
 
 
 def _quantile(sequence: Sequence[float], q: float) -> float:
@@ -31,6 +49,106 @@ def _quantile(sequence: Sequence[float], q: float) -> float:
     fraction = position - lower_index
     return sorted_vals[lower_index] * (1 - fraction) + sorted_vals[upper_index] * fraction
 
+
+def _config_fingerprint(cfg: AnalysisConfig) -> str:
+    """Return a stable hash for config fields that influence metrics generation."""
+
+    relevant = {
+        "frame_count_dark": cfg.frame_count_dark,
+        "frame_count_bright": cfg.frame_count_bright,
+        "frame_count_motion": cfg.frame_count_motion,
+        "downscale_height": cfg.downscale_height,
+        "step": cfg.step,
+        "analyze_in_sdr": cfg.analyze_in_sdr,
+        "use_quantiles": cfg.use_quantiles,
+        "dark_quantile": cfg.dark_quantile,
+        "bright_quantile": cfg.bright_quantile,
+        "motion_use_absdiff": cfg.motion_use_absdiff,
+        "motion_scenecut_quantile": cfg.motion_scenecut_quantile,
+        "screen_separation_sec": cfg.screen_separation_sec,
+        "motion_diff_radius": cfg.motion_diff_radius,
+        "random_seed": cfg.random_seed,
+    }
+    payload = json.dumps(relevant, sort_keys=True).encode("utf-8")
+    return hashlib.sha1(payload).hexdigest()
+
+
+def _load_cached_metrics(
+    info: FrameMetricsCacheInfo, cfg: AnalysisConfig
+) -> Optional[tuple[List[tuple[int, float]], List[tuple[int, float]]]]:
+    path = info.path
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+    if data.get("version") != 1:
+        return None
+    if data.get("config_hash") != _config_fingerprint(cfg):
+        return None
+    if data.get("files") != list(info.files):
+        return None
+    if data.get("analyzed_file") != info.analyzed_file:
+        return None
+
+    cached_group = str(data.get("release_group") or "").lower()
+    if cached_group != (info.release_group or "").lower():
+        return None
+
+    if data.get("trim_start") != info.trim_start:
+        return None
+    if data.get("trim_end") != info.trim_end:
+        return None
+
+    fps = data.get("fps") or []
+    if list(fps) != [info.fps_num, info.fps_den]:
+        return None
+
+    try:
+        brightness = [(int(idx), float(val)) for idx, val in data.get("brightness", [])]
+        motion = [(int(idx), float(val)) for idx, val in data.get("motion", [])]
+    except (TypeError, ValueError):
+        return None
+
+    if not brightness:
+        return None
+
+    return brightness, motion
+
+
+def _save_cached_metrics(
+    info: FrameMetricsCacheInfo,
+    cfg: AnalysisConfig,
+    brightness: Sequence[tuple[int, float]],
+    motion: Sequence[tuple[int, float]],
+) -> None:
+    path = info.path
+    payload = {
+        "version": 1,
+        "config_hash": _config_fingerprint(cfg),
+        "files": list(info.files),
+        "analyzed_file": info.analyzed_file,
+        "release_group": info.release_group,
+        "trim_start": info.trim_start,
+        "trim_end": info.trim_end,
+        "fps": [info.fps_num, info.fps_den],
+        "brightness": [(int(idx), float(val)) for idx, val in brightness],
+        "motion": [(int(idx), float(val)) for idx, val in motion],
+    }
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        # Failing to persist cache data should not abort the pipeline.
+        return
 
 def dedupe(frames: Sequence[int], min_separation_sec: float, fps: float) -> List[int]:
     """Remove frames closer than *min_separation_sec* seconds apart (in order)."""
@@ -160,7 +278,13 @@ def _smooth_motion(values: List[tuple[int, float]], radius: int) -> List[tuple[i
     return smoothed
 
 
-def select_frames(clip, cfg: AnalysisConfig, files: List[str], file_under_analysis: str) -> List[int]:
+def select_frames(
+    clip,
+    cfg: AnalysisConfig,
+    files: List[str],
+    file_under_analysis: str,
+    cache_info: Optional[FrameMetricsCacheInfo] = None,
+) -> List[int]:
     """Select frame indices for comparison using quantiles and motion heuristics."""
 
     num_frames = int(getattr(clip, "num_frames", 0))
@@ -178,10 +302,17 @@ def select_frames(clip, cfg: AnalysisConfig, files: List[str], file_under_analys
     step = max(1, int(cfg.step))
     indices = list(range(0, num_frames, step))
 
-    try:
-        brightness, motion = _collect_metrics_vapoursynth(analysis_clip, cfg, indices)
-    except Exception:
-        brightness, motion = _generate_metrics_fallback(indices, cfg)
+    cached_metrics = _load_cached_metrics(cache_info, cfg) if cache_info is not None else None
+
+    if cached_metrics is not None:
+        brightness, motion = cached_metrics
+    else:
+        try:
+            brightness, motion = _collect_metrics_vapoursynth(analysis_clip, cfg, indices)
+        except Exception:
+            brightness, motion = _generate_metrics_fallback(indices, cfg)
+        if cache_info is not None:
+            _save_cached_metrics(cache_info, cfg, brightness, motion)
 
     brightness_values = [val for _, val in brightness]
 

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+import types
+
+import pytest
+from click.testing import CliRunner
+
+import frame_compare
+from src.datatypes import (
+    AnalysisConfig,
+    AppConfig,
+    NamingConfig,
+    OverridesConfig,
+    PathsConfig,
+    RuntimeConfig,
+    ScreenshotConfig,
+    SlowpicsConfig,
+)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _make_config(input_dir: Path) -> AppConfig:
+    return AppConfig(
+        analysis=AnalysisConfig(
+            frame_count_dark=1,
+            frame_count_bright=1,
+            frame_count_motion=1,
+            random_frames=0,
+            user_frames=[],
+        ),
+        screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
+        slowpics=SlowpicsConfig(auto_upload=False),
+        naming=NamingConfig(always_full_filename=False, prefer_guessit=False),
+        paths=PathsConfig(input_dir=str(input_dir)),
+        runtime=RuntimeConfig(ram_limit_mb=4096),
+        overrides=OverridesConfig(
+            trim={"0": 5},
+            trim_end={"BBB - 01.mkv": -12},
+            change_fps={"BBB - 01.mkv": "set"},
+        ),
+    )
+
+
+def test_cli_applies_overrides_and_naming(tmp_path, monkeypatch, runner):
+    first = tmp_path / "AAA - 01.mkv"
+    second = tmp_path / "BBB - 01.mkv"
+    for file in (first, second):
+        file.write_bytes(b"data")
+
+    cfg = _make_config(tmp_path)
+
+    monkeypatch.setattr(frame_compare, "load_config", lambda _: cfg)
+
+    parse_calls = []
+
+    def fake_parse(name, **kwargs):
+        parse_calls.append((name, kwargs))
+        if name.startswith("AAA"):
+            return {"label": "AAA Short", "release_group": "AAA", "file_name": name}
+        return {"label": "BBB Short", "release_group": "BBB", "file_name": name}
+
+    monkeypatch.setattr(frame_compare, "parse_filename_metadata", fake_parse)
+
+    ram_limits = []
+    monkeypatch.setattr(frame_compare.vs_core, "set_ram_limit", lambda limit_mb: ram_limits.append(limit_mb))
+
+    init_calls = []
+
+    def fake_init_clip(path, *, trim_start=0, trim_end=None, fps_map=None):
+        clip = types.SimpleNamespace(
+            path=path,
+            width=1920,
+            height=1080,
+            fps_num=24000,
+            fps_den=1001,
+        )
+        init_calls.append((path, trim_start, trim_end, fps_map))
+        return clip
+
+    monkeypatch.setattr(frame_compare.vs_core, "init_clip", fake_init_clip)
+
+    cache_infos = []
+
+    def fake_select(clip, analysis_cfg, files, file_under_analysis, cache_info=None):
+        cache_infos.append(cache_info)
+        return [10, 20]
+
+    monkeypatch.setattr(frame_compare, "select_frames", fake_select)
+
+    generated_metadata = []
+
+    def fake_generate(clips, frames, files, metadata, out_dir, cfg_screens):
+        generated_metadata.append(metadata)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return [str(out_dir / f"shot_{idx}.png") for idx in range(len(frames) * len(files))]
+
+    monkeypatch.setattr(frame_compare, "generate_screenshots", fake_generate)
+
+    result = runner.invoke(frame_compare.main, ["--config", "dummy"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "AAA Short" in result.output
+    assert "BBB Short" in result.output
+
+    assert ram_limits == [cfg.runtime.ram_limit_mb]
+
+    assert len(init_calls) == 2
+    # Reference clip (BBB) initialised without fps override but with trim_end applied
+    assert init_calls[0] == (str(second), 0, -12, None)
+    # First clip adopts reference fps and trim override
+    assert init_calls[1] == (str(first), 5, None, (24000, 1001))
+
+    assert generated_metadata and generated_metadata[0][0]["label"].startswith("AAA")
+    assert generated_metadata[0][1]["label"].startswith("BBB")
+
+    assert cache_infos and cache_infos[0].path == (tmp_path / cfg.analysis.frame_data_filename).resolve()
+    assert cache_infos[0].files == ["AAA - 01.mkv", "BBB - 01.mkv"]
+    assert len(parse_calls) == 2

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -35,11 +35,12 @@ def test_generate_screenshots_filenames(tmp_path, monkeypatch):
 
     frames = [5, 25]
     files = ["example_video.mkv"]
-    created = screenshot.generate_screenshots([clip], frames, files, tmp_path, cfg)
+    metadata = [{"label": "Example Release"}]
+    created = screenshot.generate_screenshots([clip], frames, files, metadata, tmp_path, cfg)
     assert len(created) == len(frames)
     for path in created:
         assert Path(path).exists()
-        assert Path(path).name.startswith("example_video")
+        assert Path(path).name.startswith("Example Release")
 
     assert len(calls) == len(frames)
 
@@ -50,11 +51,11 @@ def test_compression_flag_passed(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_writer(clip, frame_idx, crop, scaled, path, cfg):
-        captured[frame_idx] = screenshot._map_compression_level(cfg.compression_level)
+    def fake_writer(source, frame_idx, crop, scaled, path, cfg, width, height):
+        captured[frame_idx] = screenshot._map_ffmpeg_compression(cfg.compression_level)
         path.write_text("ffmpeg", encoding="utf-8")
 
-    monkeypatch.setattr(screenshot, "_save_frame_with_vapoursynth", fake_writer)
+    monkeypatch.setattr(screenshot, "_save_frame_with_ffmpeg", fake_writer)
 
-    screenshot.generate_screenshots([clip], [10], ["video.mkv"], tmp_path, cfg)
+    screenshot.generate_screenshots([clip], [10], ["video.mkv"], [{"label": "video"}], tmp_path, cfg)
     assert captured[10] == 9


### PR DESCRIPTION
## Summary
- apply naming preferences, overrides, and cache context through the CLI to match legacy behaviour end-to-end
- persist and reuse analysis metrics via FrameMetricsCacheInfo to avoid recomputation on reruns
- add FFmpeg screenshot support and enforce VapourSynth trim/ram semantics with regression coverage for the new pathways

## Testing
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca2abcd44c8321b08ffa7692b556ed