### PR TITLE
fix: align ffmpeg screenshots with trim offsets

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -342,6 +342,7 @@ def main(config_path: str, input_dir: str | None) -> None:
             [plan.metadata for plan in plans],
             out_dir,
             cfg.screenshots,
+            [(plan.trim_start, plan.trim_end) for plan in plans],
         )
     except ScreenshotError as exc:
         print(f"[red]Screenshot generation failed:[/red] {exc}")

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -91,9 +91,11 @@ def test_cli_applies_overrides_and_naming(tmp_path, monkeypatch, runner):
     monkeypatch.setattr(frame_compare, "select_frames", fake_select)
 
     generated_metadata = []
+    generated_trims = []
 
-    def fake_generate(clips, frames, files, metadata, out_dir, cfg_screens):
+    def fake_generate(clips, frames, files, metadata, out_dir, cfg_screens, trims=None):
         generated_metadata.append(metadata)
+        generated_trims.append(trims)
         out_dir.mkdir(parents=True, exist_ok=True)
         return [str(out_dir / f"shot_{idx}.png") for idx in range(len(frames) * len(files))]
 
@@ -114,6 +116,7 @@ def test_cli_applies_overrides_and_naming(tmp_path, monkeypatch, runner):
 
     assert generated_metadata and generated_metadata[0][0]["label"].startswith("AAA")
     assert generated_metadata[0][1]["label"].startswith("BBB")
+    assert generated_trims == [[(5, None), (0, -12)]]
 
     assert cache_infos and cache_infos[0].path == (tmp_path / cfg.analysis.frame_data_filename).resolve()
     assert cache_infos[0].files == ["AAA - 01.mkv", "BBB - 01.mkv"]


### PR DESCRIPTION
## Summary
- offset FFmpeg frame extraction by the clip's trim offsets to mirror VapourSynth output
- plumb trim metadata through `generate_screenshots` with validation and regression coverage

## Testing
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca338957388321b48f014c4b060680