### PR TITLE
Sanitize screenshot labels for cross-platform filenames

### DIFF
--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -6,11 +6,14 @@ import logging
 import os
 import shutil
 import subprocess
+import re
 from functools import partial
 from pathlib import Path
 from typing import Callable, List, Mapping, Sequence, Tuple
 
 from .datatypes import ScreenshotConfig
+
+_INVALID_LABEL_PATTERN = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 
 
 logger = logging.getLogger(__name__)
@@ -236,8 +239,11 @@ def _plan_geometry(clips: Sequence[object], cfg: ScreenshotConfig) -> List[dict[
 
 
 def _sanitise_label(label: str) -> str:
-    cleaned = label.replace(os.sep, "_").replace("/", "_")
-    return cleaned.strip() or "comparison"
+    cleaned = _INVALID_LABEL_PATTERN.sub("_", label)
+    if os.name == "nt":
+        cleaned = cleaned.rstrip(" .")
+    cleaned = cleaned.strip()
+    return cleaned or "comparison"
 
 
 def _derive_labels(source: str, metadata: Mapping[str, str]) -> tuple[str, str]:

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -12,6 +12,21 @@ class FakeClip:
         self.height = height
 
 
+def test_sanitise_label_replaces_forbidden_characters(monkeypatch):
+    monkeypatch.setattr(screenshot.os, "name", "nt")
+    raw = 'Group: Episode? 01*<>"| '
+    cleaned = screenshot._sanitise_label(raw)
+    assert cleaned
+    for forbidden in ':?*<>"|':
+        assert forbidden not in cleaned
+    assert not cleaned.endswith((" ", "."))
+
+
+def test_sanitise_label_falls_back_when_blank():
+    cleaned = screenshot._sanitise_label("   ")
+    assert cleaned == "comparison"
+
+
 def test_plan_mod_crop_modulus():
     left, top, right, bottom = screenshot.plan_mod_crop(1919, 1079, mod=4, letterbox_pillarbox_aware=True)
     new_w = 1919 - left - right


### PR DESCRIPTION
## Summary
- replace the screenshot label sanitizer with a regex that strips characters Windows forbids and trims trailing dots/spaces
- add regression tests covering forbidden character removal and fallback behaviour

## Testing
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb6afb152883219403ea4f29916d08