### PR TITLE
docs: rewrite README with config and usage reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,201 +1,261 @@
 # Frame Compare
-Automated video frame selection, screenshots, and optional slow.pics upload.
 
-## Badges
-<!-- TODO: Add GitHub Actions CI badge once the public repository URL is known. -->
+Automated frame comparison pipeline that samples representative scenes, renders aligned screenshots, and optionally publishes a slow.pics collection.
 
-## TL;DR
-- Discover comparison-worthy frames across multiple sources and gather consistent screenshots in one pass.
-- `uv run python frame_compare.py --config config.toml --input .`
-- Tune behaviour in `config.toml`; every option is validated against the dataclasses in `src/datatypes.py`.
+## TL;DR Quickstart
+```bash
+uv sync
+cp config.toml.template config.toml
+uv run python frame_compare.py --config config.toml --input comparison_videos
+```
+You should see `Comparison ready` followed by the selected frames, output directory, and slow.pics URL (when enabled).
 
 ## Features
-- Quantile- and motion-driven frame selection algorithms with deterministic seeds for reproducible runs.
-- Geometry planning, modulus-aware cropping, and screenshot writers with placeholder fallbacks when native deps are missing.
-- Optional slow.pics upload workflow with webhook support and automatic shortcut creation.
-- Centralised TOML configuration with strict validation and reasonable defaults.
-- Continuous integration via GitHub Actions running `uv sync --group dev --frozen` and `pytest`.
-- Documented VS Code task flow so you can wire common commands into your IDE quickly.
+- Deterministic frame selection that combines quantile-based brightness picks, smoothed motion scoring, user pins, and seeded randomness, while caching metrics for reruns.【F:src/analysis.py†L89-L116】【F:src/analysis.py†L472-L543】
+- Configurable selection windows that respect per-clip trims, ignore/skip timing, and collapse to a safe fallback when sources disagree.【F:frame_compare.py†L229-L306】【F:src/analysis.py†L520-L566】
+- VapourSynth integration with optional HDR→SDR tonemapping, FFmpeg screenshot fallback, modulus-aware cropping, and placeholder creation when writers fail.【F:src/analysis.py†L551-L575】【F:src/vs_core.py†L158-L214】【F:src/screenshot.py†L107-L205】【F:src/screenshot.py†L272-L360】
+- Automatic slow.pics uploads with webhook retries, `.url` shortcut generation, and strict naming validation so every frame lands in the right slot.【F:src/slowpics.py†L40-L115】【F:src/slowpics.py†L117-L204】
+- Rich CLI that discovers clips, deduplicates labels, applies trims/FPS overrides consistently, and cleans up rendered images after upload when requested.【F:frame_compare.py†L78-L175】【F:frame_compare.py†L307-L478】【F:frame_compare.py†L640-L789】
 
-### Restored parity highlights
-- **Trim-aware screenshots** – both VapourSynth and FFmpeg writers now respect `[overrides.trim]`, `[overrides.trim_end]`, and `[overrides.change_fps]` so every frame index matches the legacy script.
-- **Global upscale planning** – `single_res` and `upscale=true` mirror the legacy tallest-height behaviour, keeping mixed-resolution comparisons aligned.
-- **Quarter-gap motion heuristic** – motion picks are spaced with the classic quarter-gap window to maximise variety just like `legacy/compv4_improved.py`.
-- **Label deduplication** – GuessIt/Anitopy fallbacks and short-label suffixing reproduce the original naming policy so uploads stay readable.
-- **Frame metric caching** – `save_frames_data` and `frame_data_filename` persist selection data, letting repeat runs skip expensive recomputation.
+## Installation
+### Requirements
+- Python 3.11 (>=3.11,<3.12).【F:pyproject.toml†L3-L5】
+- Runtime tools depending on your workflow:
+  - VapourSynth with the `lsmas` plugin and (optionally) `libplacebo` for HDR tonemapping.【F:src/vs_core.py†L66-L148】【F:src/vs_core.py†L186-L228】
+  - FFmpeg when `screenshots.use_ffmpeg=true` (the CLI checks for the executable).【F:src/screenshot.py†L330-L360】
+  - `requests-toolbelt` is installed via `pyproject.toml` for slow.pics uploads; the code warns if it is missing.【F:pyproject.toml†L6-L14】【F:src/slowpics.py†L117-L135】
+  - Optional: `pyperclip` to copy the slow.pics URL to your clipboard.【F:frame_compare.py†L812-L825】
 
-## Project structure
-```
-.
-├─ frame_compare.py          — Click-based CLI orchestrating analysis, screenshots, and uploads.
-├─ config.toml               — Sample configuration matching the dataclass defaults.
-├─ comparison_videos/        — Example input directory referenced by the default config.
-├─ legacy/compv4_improved.py — Legacy implementation kept for reference during migration.
-├─ src/
-│  ├─ datatypes.py           — Configuration dataclasses and defaults.
-│  ├─ config_loader.py       — TOML loader with type coercion and validation.
-│  ├─ utils.py               — Filename metadata parsing helpers (GuessIt/Anitopy).
-│  ├─ analysis.py            — Frame scoring, quantiles, and selection heuristics.
-│  ├─ screenshot.py          — Cropping, scaling, and screenshot rendering orchestration.
-│  ├─ slowpics.py            — Slow.pics API client for automated uploads.
-│  └─ vs_core.py             — VapourSynth clip initialisation and HDR→SDR tonemapping helpers.
-└─ tests/                    — Pytest suite covering analysis, config, screenshot, slow.pics, and vs_core.
-```
-
-## Quickstart
-Run the project with Python 3.11+ and [uv](https://github.com/astral-sh/uv). These commands install dependencies, execute tests, and launch the CLI:
-
+### Install Python dependencies with uv
 ```bash
-uv lock
-uv sync --group dev
-uv run python -m pytest -q
-# Run against the sample clips bundled in comparison_videos/
-uv run python frame_compare.py --config config.toml --input .
+uv sync
+```
+This resolves the application dependencies listed in `pyproject.toml`. Add `--group dev` when you also want linting and test tools.【F:pyproject.toml†L16-L22】
+
+### Provision VapourSynth
+- **Inside the virtual environment**: install a wheel that matches your interpreter, e.g. `uv pip install VapourSynth`.
+- **Using a system install**: install VapourSynth through your platform’s packages, then expose its Python modules by either
+  - setting the `VAPOURSYNTH_PYTHONPATH` environment variable, or
+  - listing search folders in `[runtime.vapoursynth_python_paths]` (they are prepended to `sys.path`).【F:src/vs_core.py†L34-L82】
+
+Ensure the interpreter ABI matches the VapourSynth build; otherwise imports will raise `ClipInitError` with guidance on the missing module.【F:src/vs_core.py†L84-L132】
+
+### FFmpeg workflow
+Keep `screenshots.use_ffmpeg=false` to render through VapourSynth. When set to `true`, make sure `ffmpeg` is on `PATH`; otherwise a `ScreenshotWriterError` is raised.【F:src/screenshot.py†L312-L360】
+
+## Configuration
+The CLI reads a UTF-8 TOML file and instantiates the dataclasses in `src/datatypes.py`. `_sanitize_section` coerces booleans, validates keys, and applies range checks for every section.【F:src/config_loader.py†L24-L109】 All fields have defaults, but you should at least point `[paths].input_dir` to a folder containing **two or more** video files.
+
+### Minimal config
+```toml
+[paths]
+input_dir = "comparison_videos"
 ```
 
-```powershell
-uv lock
-uv sync --group dev
-uv run python -m pytest -q
-# Point to any folder containing your sources
-uv run python frame_compare.py --config config.toml --input .
+### Full config example
+```toml
+[analysis]
+frame_count_dark = 20
+frame_count_bright = 10
+frame_count_motion = 15
+user_frames = []
+random_frames = 15
+save_frames_data = true
+downscale_height = 480
+step = 2
+analyze_in_sdr = true
+use_quantiles = true
+dark_quantile = 0.20
+bright_quantile = 0.80
+motion_use_absdiff = false
+motion_scenecut_quantile = 0.0
+screen_separation_sec = 6
+motion_diff_radius = 4
+analyze_clip = ""
+random_seed = 20202020
+frame_data_filename = "generated.compframes"
+skip_head_seconds = 0.0
+skip_tail_seconds = 0.0
+ignore_lead_seconds = 0.0
+ignore_trail_seconds = 0.0
+min_window_seconds = 5.0
+
+[screenshots]
+directory_name = "screens"
+add_frame_info = true
+use_ffmpeg = false
+compression_level = 1
+upscale = true
+single_res = 0
+mod_crop = 2
+letterbox_pillarbox_aware = true
+
+[slowpics]
+auto_upload = false
+collection_name = ""
+is_hentai = false
+is_public = true
+tmdb_id = ""
+remove_after_days = 0
+webhook_url = ""
+open_in_browser = true
+create_url_shortcut = true
+delete_screen_dir_after_upload = true
+
+[naming]
+always_full_filename = true
+prefer_guessit = true
+
+[paths]
+input_dir = "comparison_videos"
+
+[runtime]
+ram_limit_mb = 8000
+vapoursynth_python_paths = []
+
+[overrides]
+trim = {}
+trim_end = {}
+change_fps = {}
 ```
 
-> ℹ️ VapourSynth, libplacebo, and ffmpeg deliver full-fidelity screenshots; without them the tool still runs, saving placeholder files through the built-in fallbacks.
+### Config reference
+#### `[analysis]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `frame_count_dark` | int | 20 | No | Number of darkest frames to keep; uses quantiles or fallback ranges. Must be ≥0.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L622-L653】|
+| `frame_count_bright` | int | 10 | No | Number of brightest frames to keep using the same logic as dark picks.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L653-L670】|
+| `frame_count_motion` | int | 15 | No | Motion peaks after smoothing; quarter-gap spacing is applied via `screen_separation_sec/4`.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L670-L698】|
+| `user_frames` | list[int] | `[]` | No | Pinned frames that bypass scoring; out-of-window frames are dropped with a warning.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L566-L619】|
+| `random_frames` | int | 15 | No | Additional random picks seeded by `random_seed` and filtered by separation rules.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L698-L717】|
+| `save_frames_data` | bool | true | No | Persist metrics and selections to `frame_data_filename` for cache reuse.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L360-L451】|
+| `downscale_height` | int | 480 | No | Resizes clips before analysis; must be ≥64 if non-zero.【F:src/datatypes.py†L10-L31】【F:src/config_loader.py†L111-L138】|
+| `step` | int | 2 | No | Sampling stride used when iterating frames; must be ≥1.【F:src/datatypes.py†L10-L31】【F:src/config_loader.py†L111-L118】|
+| `analyze_in_sdr` | bool | true | No | Tonemap HDR sources through `vs_core.process_clip_for_screenshot`.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L551-L560】|
+| `use_quantiles` | bool | true | No | Toggle quantile thresholds; `false` enables fixed brightness bands.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L622-L670】|
+| `dark_quantile` | float | 0.20 | No | Quantile for dark picks when `use_quantiles=true`.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L622-L633】|
+| `bright_quantile` | float | 0.80 | No | Quantile for bright picks when `use_quantiles=true`.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L633-L670】|
+| `motion_use_absdiff` | bool | false | No | Switch between absolute differences and edge-enhanced diffs for motion metrics.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L420-L449】|
+| `motion_scenecut_quantile` | float | 0.0 | No | Drops motion values above this quantile to avoid extreme scene cuts.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L676-L692】|
+| `screen_separation_sec` | int | 6 | No | Minimum spacing between frames (also scales the motion gap). Must be ≥0.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L609-L669】|
+| `motion_diff_radius` | int | 4 | No | Radius for smoothing motion metrics before ranking.【F:src/datatypes.py†L10-L31】【F:src/analysis.py†L462-L471】|
+| `analyze_clip` | str | `""` | No | Filename, label, or index controlling which source drives analysis.【F:src/datatypes.py†L10-L31】【F:frame_compare.py†L178-L227】|
+| `random_seed` | int | 20202020 | No | Seed for deterministic randomness; must be ≥0.【F:src/datatypes.py†L10-L31】【F:src/config_loader.py†L118-L129】|
+| `frame_data_filename` | str | `"generated.compframes"` | No | Cache filename (must be non-empty). Stored next to the input root.【F:src/datatypes.py†L10-L31】【F:frame_compare.py†L408-L451】|
+| `skip_head_seconds` | float | 0.0 | No | Skips early frames after scoring; must be ≥0.【F:src/datatypes.py†L20-L31】【F:src/config_loader.py†L129-L138】|
+| `skip_tail_seconds` | float | 0.0 | No | Skips trailing frames after scoring; must be ≥0.【F:src/datatypes.py†L20-L31】【F:src/config_loader.py†L129-L138】|
+| `ignore_lead_seconds` | float | 0.0 | No | Trims the comparison window’s start before selection; must be ≥0.【F:src/datatypes.py†L20-L31】【F:src/config_loader.py†L129-L138】|
+| `ignore_trail_seconds` | float | 0.0 | No | Trims the comparison window’s end before selection; must be ≥0.【F:src/datatypes.py†L20-L31】【F:src/config_loader.py†L129-L138】|
+| `min_window_seconds` | float | 5.0 | No | Ensures the ignore window leaves at least this much footage; must be ≥0.【F:src/datatypes.py†L20-L31】【F:src/config_loader.py†L129-L138】|
 
-### Common run patterns
-| Scenario | Command | Notes |
-| --- | --- | --- |
-| Default (analysis + screenshots) | `uv run python frame_compare.py --config config.toml --input PATH` | Reads config, renders screenshots, honours slow.pics flags. |
-| Alternate config profile | `uv run python frame_compare.py --config profiles/hdr.toml --input PATH` | Keep multiple TOML profiles for HDR/anime/live-action tuned defaults. |
-| Temporary input override | `uv run python frame_compare.py --config config.toml --input "D:/captures"` | Leaves `config.toml` unchanged while targeting another folder. |
-| Re-using cached metrics | Run twice with `analysis.save_frames_data=true` | The second run loads `analysis.frame_data_filename` and skips recompute. |
-| Upload-only rerun | Disable screenshot stages once PNGs exist | Set `analysis.frame_count_* = 0`, keep `save_frames_data=false`, and rely on existing renders. |
+#### `[screenshots]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `directory_name` | str | `"screens"` | No | Folder (under the input root) where PNGs are written.【F:src/datatypes.py†L33-L43】【F:frame_compare.py†L587-L635】|
+| `add_frame_info` | bool | true | No | Overlay frame index/picture type (VapourSynth) or drawtext (FFmpeg).【F:src/datatypes.py†L33-L43】【F:src/screenshot.py†L144-L205】【F:src/screenshot.py†L330-L360】|
+| `use_ffmpeg` | bool | false | No | Use FFmpeg for rendering when VapourSynth is unavailable or trimmed frames require source indexes.【F:src/datatypes.py†L33-L43】【F:src/screenshot.py†L300-L360】|
+| `compression_level` | int | 1 | No | Compression preset: 0 (fast), 1 (balanced), 2 (small). Other values raise `ConfigError`.【F:src/datatypes.py†L33-L43】【F:src/config_loader.py†L138-L144】【F:src/screenshot.py†L231-L260】|
+| `upscale` | bool | true | No | Allow scaling above source height (global tallest clip by default).【F:src/datatypes.py†L33-L43】【F:src/screenshot.py†L205-L244】|
+| `single_res` | int | 0 | No | Force a specific output height (`0` keeps clip-relative planning).【F:src/datatypes.py†L33-L43】【F:src/screenshot.py†L205-L244】|
+| `mod_crop` | int | 2 | No | Crop to maintain dimensions divisible by this modulus; must be ≥0.【F:src/datatypes.py†L33-L43】【F:src/config_loader.py†L138-L142】【F:src/screenshot.py†L156-L205】|
+| `letterbox_pillarbox_aware` | bool | true | No | Bias cropping toward letterbox/pillarbox bars when trimming.【F:src/datatypes.py†L33-L43】【F:src/screenshot.py†L156-L205】|
 
-Pair these commands with per-run overrides by editing `config.toml` or by storing alternate configs under `profiles/`.
+#### `[slowpics]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `auto_upload` | bool | false | No | Upload automatically after screenshots finish.【F:src/datatypes.py†L45-L58】【F:frame_compare.py†L702-L789】|
+| `collection_name` | str | `""` | No | Custom collection title sent to slow.pics.【F:src/datatypes.py†L45-L58】【F:src/slowpics.py†L150-L204】|
+| `is_hentai` | bool | false | No | Marks the collection as hentai for filtering.【F:src/datatypes.py†L45-L58】【F:src/slowpics.py†L150-L204】|
+| `is_public` | bool | true | No | Controls slow.pics visibility.【F:src/datatypes.py†L45-L58】【F:src/slowpics.py†L150-L204】|
+| `tmdb_id` | str | `""` | No | Optional TMDB identifier.【F:src/datatypes.py†L45-L58】【F:src/slowpics.py†L150-L204】|
+| `remove_after_days` | int | 0 | No | Schedule deletion after N days; must be ≥0.【F:src/datatypes.py†L45-L58】【F:src/config_loader.py†L142-L146】|
+| `webhook_url` | str | `""` | No | Webhook notified after upload; retries with backoff.【F:src/datatypes.py†L45-L58】【F:src/slowpics.py†L40-L75】【F:src/slowpics.py†L198-L204】|
+| `open_in_browser` | bool | true | No | Launch slow.pics URL with `webbrowser.open` on success.【F:src/datatypes.py†L45-L58】【F:frame_compare.py†L800-L812】|
+| `create_url_shortcut` | bool | true | No | Save a `.url` shortcut next to screenshots.【F:src/datatypes.py†L45-L58】【F:src/slowpics.py†L198-L204】|
+| `delete_screen_dir_after_upload` | bool | true | No | Delete rendered screenshots after a successful upload.【F:src/datatypes.py†L45-L58】【F:frame_compare.py†L812-L823】|
 
-## Usage
+#### `[naming]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `always_full_filename` | bool | true | No | Use the original filename as the label instead of parsed metadata.【F:src/datatypes.py†L60-L69】【F:frame_compare.py†L133-L175】|
+| `prefer_guessit` | bool | true | No | Prefer GuessIt over Anitopy when deriving metadata; falls back automatically.【F:src/datatypes.py†L60-L69】【F:src/utils.py†L46-L122】|
+
+#### `[paths]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `input_dir` | str | `"."` | No | Root directory containing the comparison clips. Update this or use `--input` per run.【F:src/datatypes.py†L71-L77】【F:frame_compare.py†L331-L381】|
+
+#### `[runtime]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `ram_limit_mb` | int | 8000 | No | Applies `core.max_cache_size` on VapourSynth; must be >0.【F:src/datatypes.py†L79-L87】【F:src/config_loader.py†L144-L147】【F:src/vs_core.py†L214-L225】|
+| `vapoursynth_python_paths` | list[str] | `[]` | No | Additional search paths appended to `sys.path` before importing VapourSynth.【F:src/datatypes.py†L79-L87】【F:src/vs_core.py†L34-L82】|
+
+#### `[overrides]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `trim` | dict[str,int] | `{}` | No | Trim leading frames per clip; negative values prepend blanks to preserve indexing.【F:src/datatypes.py†L89-L97】【F:src/vs_core.py†L132-L186】|
+| `trim_end` | dict[str,int] | `{}` | No | Trim trailing frames; accepts negative indexes as Python slicing does.【F:src/datatypes.py†L89-L97】【F:src/vs_core.py†L132-L186】|
+| `change_fps` | dict[str, list[int] or "set"] | `{}` | No | Either `[num, den]` to apply `AssumeFPS`, or `"set"` to mark the clip as the reference FPS for others.【F:src/datatypes.py†L89-L97】【F:frame_compare.py†L199-L275】|
+
+## CLI usage
 ```
-Usage: uv run python frame_compare.py [OPTIONS]
+Usage: frame_compare.py [OPTIONS]
 
 Options:
-  --config PATH  Path to the TOML configuration file. Defaults to config.toml.
-  --input PATH   Override [paths.input_dir] for this run.
+  --config TEXT  Path to config.toml  [default: config.toml]
+  --input TEXT   Override [paths.input_dir] from config.toml
   --help         Show this message and exit.
 ```
 
-Examples:
-- Scan the default sample folder: `uv run python frame_compare.py --config config.toml --input comparison_videos`
-- Point to an absolute path on Windows: `uv run python frame_compare.py --config config.toml --input "D:/captures"`
-- Enable auto-upload in your config, then run: `uv run python frame_compare.py --config profiles/slowpics.toml --input ./captures`
-- Force one encode to drive analysis: set `analysis.analyze_clip = "1"` (or use a label) before running the standard command.
+### Common recipes
+- **Run against another folder**: `uv run python frame_compare.py --config config.toml --input D:/captures` overrides `[paths].input_dir` for a single run.【F:frame_compare.py†L364-L381】
+- **Pin the analysis driver**: set `analysis.analyze_clip` to a filename, label, or index (as a string) so that clip guides scoring while others inherit its FPS when marked with `change_fps = { "name" = "set" }`.【F:frame_compare.py†L178-L275】
+- **Reuse cached metrics**: keep `save_frames_data=true`. Subsequent runs load `frame_data_filename`, skip metric collection, and immediately reuse the stored frame list.【F:frame_compare.py†L408-L478】【F:src/analysis.py†L360-L451】
+- **Render with FFmpeg**: toggle `[screenshots].use_ffmpeg = true` to render directly from source files—useful when VapourSynth is unavailable or trims insert synthetic blanks.【F:src/screenshot.py†L300-L360】【F:frame_compare.py†L587-L706】
+- **Upload to slow.pics**: enable `[slowpics].auto_upload`, optionally set `webhook_url`, and the CLI will stream uploads with progress bars, retry the webhook, and delete screenshots after success when configured.【F:frame_compare.py†L702-L823】【F:src/slowpics.py†L40-L204】
 
-Output files land in `<input>/<screenshots.directory_name>/` (default `screens/`). Filenames are derived from parsed labels plus `_frameNNNNNN.png` (or an index when `add_frame_info = false`). The CLI prints a summary and, when uploads are enabled, the slow.pics URL.
-
-## Configuration
-Configuration lives in `config.toml` and is loaded through `src/config_loader.py`, which coerces booleans, checks ranges, and instantiates the dataclasses in `src/datatypes.py`. Defaults come from those dataclasses; the bundled `config.toml` provides a practical starting point. Key sections:
-
-### [analysis]
-| Key | Type | Default | Description |
-| --- | --- | --- | --- |
-| `frame_count_dark` | int | 20 | Number of darkest frames to keep (quantile or fixed thresholds). |
-| `frame_count_bright` | int | 10 | Number of brightest frames to keep. |
-| `frame_count_motion` | int | 15 | Frames with highest motion scores after smoothing. |
-| `user_frames` | list[int] | `[]` | Explicit frame numbers to force into the selection. |
-| `random_frames` | int | 15 | Additional random frames seeded by `random_seed`. |
-| `save_frames_data` | bool | true | Persist raw metric data alongside selections (enables cache reuse on reruns). |
-| `downscale_height` | int | 480 | Downscale height for metrics to speed up analysis. |
-| `step` | int | 2 | Sampling stride; must stay ≥1. |
-| `analyze_in_sdr` | bool | true | Tonemap HDR clips before analysis using `vs_core`. |
-| `use_quantiles` | bool | true | Switch between quantile thresholds or fixed value bands. |
-| `dark_quantile` | float | 0.20 | Quantile cutoff for dark frame selection. |
-| `bright_quantile` | float | 0.80 | Quantile cutoff for bright frame selection. |
-| `motion_use_absdiff` | bool | false | Use absolute differences instead of edge-emphasised diffs. |
-| `motion_scenecut_quantile` | float | 0.0 | Optional cap to drop extreme motion/scene-cut frames. |
-| `screen_separation_sec` | int | 6 | Minimum separation between chosen frames in seconds (quarter-gap heuristic restored). |
-| `motion_diff_radius` | int | 4 | Radius for motion smoothing window. |
-| `analyze_clip` | str | `""` | Name/index/label hint to pick the driving clip. |
-| `random_seed` | int | 20202020 | Seed controlling deterministic randomness. |
-| `frame_data_filename` | str | `"generated.compframes"` | On-disk cache filename for selection metadata. |
-
-### [screenshots]
-| Key | Type | Default | Description |
-| --- | --- | --- | --- |
-| `directory_name` | str | `"screens"` | Subdirectory inside the input root for output images. |
-| `add_frame_info` | bool | true | Overlay frame numbers in the PNG footer bar. |
-| `use_ffmpeg` | bool | false | Flip to `true` to render via FFmpeg instead of VapourSynth (respects trims/FPS overrides). |
-| `compression_level` | int | 1 | PNG compression preset: 0 (fast) / 1 (balanced) / 2 (small). |
-| `upscale` | bool | true | Allow scaling above source resolution when `single_res` > native. |
-| `single_res` | int | 0 | Force output height (0 keeps native). |
-| `mod_crop` | int | 2 | Crop so width/height stay multiples of this value. |
-| `letterbox_pillarbox_aware` | bool | true | Bias cropping toward bars to preserve active area. |
-
-### [slowpics]
-| Key | Type | Default | Description |
-| --- | --- | --- | --- |
-| `auto_upload` | bool | false | Upload screenshots automatically after rendering. |
-| `collection_name` | str | `""` | Optional slow.pics collection title. |
-| `is_hentai` | bool | false | Flag NSFW content for slow.pics filters. |
-| `is_public` | bool | true | Make the comparison publicly visible. |
-| `tmdb_id` | str | `""` | Attach a TMDB identifier when available. |
-| `remove_after_days` | int | 0 | Schedule collection deletion after N days (0 keeps forever). |
-| `webhook_url` | str | `""` | Notify an external service once the upload finishes. |
-| `open_in_browser` | bool | true | Launch the slow.pics URL in a browser when ready. |
-| `create_url_shortcut` | bool | true | Drop a `.url` shortcut inside the screenshot directory. |
-| `delete_screen_dir_after_upload` | bool | true | Remove rendered screenshots once the upload succeeds. |
-
-### [naming]
-| Key | Type | Default | Description |
-| --- | --- | --- | --- |
-| `always_full_filename` | bool | true | Use the original filename as the screenshot label. |
-| `prefer_guessit` | bool | true | Prefer GuessIt over Anitopy when parsing metadata (falls back automatically). |
-
-### [paths]
-| Key | Type | Default | Description |
-| --- | --- | --- | --- |
-| `input_dir` | str | `"."` | Base directory for input videos (sample config sets this to `comparison_videos`). |
-
-Additional helpers:
-- `[runtime]` exposes `ram_limit_mb` (default 8000) to guard VapourSynth initialisation just like the legacy script.
-- `[overrides]` supplies optional per-file `trim`, `trim_end`, and `change_fps` mappings applied consistently across analysis and screenshot writers.
-
-### Essential configuration checklist (new users)
-1. **Set your input folder** – update `[paths].input_dir` or pass `--input` to the CLI.
-2. **Name your sources** – tweak `[naming]` to balance GuessIt parsing vs original filenames for clearer labels.
-3. **Choose your driver clip** – set `analysis.analyze_clip` to a label, filename, or index when one encode should steer frame selection.
-4. **Plan screenshot sizes** – adjust `[screenshots].single_res`/`upscale` for uniform heights, and toggle `use_ffmpeg` when VapourSynth is unavailable.
-5. **Control uploads** – enable `[slowpics].auto_upload` and fill out webhook/collection fields to automate publishing.
-6. **Apply trims/FPS overrides** – populate `[overrides.trim]`, `[overrides.trim_end]`, or `[overrides.change_fps]` to keep parity with edited project timelines.
-7. **Keep runs reproducible** – leave `analysis.random_seed` as-is and keep `save_frames_data=true` when you want to reuse cached metrics.
-
-## Development
-- Sync tooling: `uv lock` (after dependency edits) and `uv sync --group dev`.
-- Lint: `uv run ruff check . --fix`
-- Format: `uv run black .`
-- Test: `uv run python -m pytest -q`
-
-No `.vscode/tasks.json` is included yet; mirror the commands above if you create VS Code tasks for a one-click dev loop.
-
-## CI
-The `.github/workflows/ci.yml` workflow checks out the code, installs uv, caches the uv directory, runs `uv sync --group dev --frozen --python 3.11`, and executes `uv run python -m pytest -q` on Ubuntu runners for every push and pull request.
-
-## Architecture overview
-- `frame_compare.py` wires together config loading, clip discovery, frame selection, screenshot rendering, and optional uploading.
-- `src/config_loader.py` parses TOML, coerces bool-like values, validates ranges, and produces an `AppConfig` instance.
-- `src/datatypes.py` defines the configuration dataclasses that capture defaults and structure for every section.
-- `src/utils.py` encapsulates filename parsing heuristics using GuessIt/Anitopy to produce consistent labels.
-- `src/analysis.py` samples clips, gathers brightness/motion metrics (VapourSynth or fallback), and returns the frame list.
-- `src/screenshot.py` plans crops/scales, renders frames via VapourSynth, and falls back to placeholder files when rendering fails.
-- `src/slowpics.py` handles slow.pics session bootstrapping, file uploads, webhooks, and `.url` shortcut generation.
-- `src/vs_core.py` initialises VapourSynth clips, applies trims/fps overrides, and tonemaps HDR sources to SDR for downstream modules.
+## Determinism & reproducibility
+- All random sampling uses `random.Random(random_seed)` so identical configs and inputs yield the same frame order.【F:src/analysis.py†L604-L717】
+- Cached metrics store a config fingerprint and clip metadata; the loader validates hashes, file lists, trims, FPS, and release groups before reuse, guaranteeing identical selections when nothing changed.【F:src/analysis.py†L330-L419】
+- Selection windows derive from computed clip metadata and obey deterministic rounding, so applying the same trims, ignores, and FPS overrides reproduces the same frame subset.【F:src/analysis.py†L520-L566】【F:frame_compare.py†L229-L306】
 
 ## Troubleshooting
-- `uv run` complaining about missing project metadata usually means you are outside the repository root—ensure `pyproject.toml` is visible to uv.
-- On Windows PowerShell, prefer absolute paths or quote inputs (`"D:/captures"`) to avoid escaping issues; uv manages virtual environments automatically.
-- Missing VapourSynth/libplacebo/ffmpeg will limit screenshots to placeholder files. Install the native dependencies to unlock full rendering.
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `Config error: analysis.step must be >= 1` (or similar) | TOML value out of range. | Update the value to satisfy the validation listed in the config table.【F:src/config_loader.py†L111-L142】|
+| `VapourSynth is not available in this environment.` | `vapoursynth` module not importable from the current interpreter. | Install a matching VapourSynth build or add its site-packages directory to `runtime.vapoursynth_python_paths`/`VAPOURSYNTH_PYTHONPATH`.【F:src/vs_core.py†L34-L110】|
+| `VapourSynth core is missing the lsmas plugin` | `lsmas.LWLibavSource` unavailable, so clips cannot be opened. | Install the `lsmas` plugin in the active VapourSynth environment.【F:src/vs_core.py†L110-L170】|
+| `FFmpeg executable not found in PATH` | `[screenshots].use_ffmpeg` enabled without FFmpeg installed. | Install FFmpeg and ensure the binary is discoverable, or disable the flag.【F:src/screenshot.py†L300-L360】|
+| `requests-toolbelt is required for slow.pics uploads.` | Dependency missing from the runtime environment. | Install `requests-toolbelt` (bundled via `uv sync`) before enabling auto-upload.【F:src/slowpics.py†L117-L135】|
+| `Screenshot '<name>' does not follow '<frame> - <label>.png' naming` | PNG files renamed or altered before upload. | Keep the generated naming scheme so the uploader can group frames correctly.【F:src/slowpics.py†L135-L172】|
+| `Missing XSRF token` when uploading | slow.pics session cookie not returned. | Retry later; the client requires the token from the landing page before posting images.【F:src/slowpics.py†L177-L204】|
+| `Falling back to placeholder for frame …` warning | VapourSynth/FFmpeg writer raised an exception while rendering. | Inspect the log; install missing plugins or leave placeholders as cues to re-render later.【F:src/screenshot.py†L360-L420】|
 
-## Contributing
-Fork, branch, and submit pull requests with clear descriptions. Keep `uv.lock` in sync after dependency changes, run `uv run python -m pytest -q`, and ensure lint/format checks pass before opening a PR.
+## Development
+- Install dev tools: `uv sync --group dev`
+- Lint: `uv run ruff check .`
+- Format: `uv run black .`
+- Tests: `uv run python -m pytest -q`
+
+The test suite covers analysis heuristics, configuration validation, screenshot planning, slow.pics integration, and the VapourSynth shim.【F:tests/test_analysis.py†L1-L216】【F:tests/test_config.py†L1-L63】【F:tests/test_screenshot.py†L1-L160】【F:tests/test_slowpics.py†L1-L204】【F:tests/test_vs_core.py†L1-L160】
+
+## Repository structure
+```
+frame_compare.py        # Click-based CLI entry point
+config.toml.template    # Sample configuration
+comparison_videos/      # Example input directory
+legacy/                 # Reference legacy scripts
+src/
+  analysis.py           # Frame scoring & selection
+  config_loader.py      # TOML loader & validation
+  datatypes.py          # Configuration schema
+  screenshot.py         # Screenshot planning & writers
+  slowpics.py           # slow.pics client
+  utils.py              # Filename metadata helpers
+  vs_core.py            # VapourSynth helpers
+tests/                  # Pytest suite covering all modules
+```
 
 ## License
-No license file is present yet. **TODO:** add an explicit license (MIT recommended).
+Licensed under the MIT License. See `LICENSE` for details.【F:LICENSE†L1-L9】


### PR DESCRIPTION
## Summary
- rewrite the README with a quickstart, installation requirements, and an authoritative configuration reference
- document CLI usage, reproducibility notes, troubleshooting guidance, and the repository layout

## Testing
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb6ed7c57c8321b438c73f50651f6c