### PR TITLE
Implement TMDB resolver integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ open_in_browser = true
 create_url_shortcut = true
 delete_screen_dir_after_upload = true
 
+[tmdb]
+api_key = ""
+unattended = true
+year_tolerance = 2
+enable_anime_parsing = true
+cache_ttl_seconds = 86400
+category_preference = ""
+
 [naming]
 always_full_filename = true
 prefer_guessit = true
@@ -174,6 +182,16 @@ change_fps = {}
 | `create_url_shortcut` | bool | true | No | Save a `.url` shortcut next to screenshots.|
 | `delete_screen_dir_after_upload` | bool | true | No | Delete rendered screenshots after a successful upload.|
 
+#### `[tmdb]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `api_key` | str | `""` | No | Enable TMDB matching by providing your API key.| 
+| `unattended` | bool | true | No | Automatically select the best TMDB match; disable to allow manual overrides when ambiguous.|
+| `year_tolerance` | int | 2 | No | Acceptable difference between parsed year and TMDB results; must be ≥0.|
+| `enable_anime_parsing` | bool | true | No | Use Anitopy-derived titles when searching for anime releases.|
+| `cache_ttl_seconds` | int | 86400 | No | Cache TMDB responses in-memory for this many seconds; must be ≥0.|
+| `category_preference` | str | `""` | No | Optional default category when external IDs resolve to both movie and TV (set `MOVIE` or `TV`).|
+
 #### `[naming]`
 | Name | Type | Default | Required? | Description |
 | --- | --- | --- | --- | --- |
@@ -197,6 +215,20 @@ change_fps = {}
 | `trim` | dict[str,int] | `{}` | No | Trim leading frames per clip; negative values prepend blanks to preserve indexing.|
 | `trim_end` | dict[str,int] | `{}` | No | Trim trailing frames; accepts negative indexes as Python slicing does.|
 | `change_fps` | dict[str, list[int] or "set"] | `{}` | No | Either `[num, den]` to apply `AssumeFPS`, or `"set"` to mark the clip as the reference FPS for others.|
+
+## TMDB auto-discovery
+Enabling `[tmdb].api_key` activates an asynchronous resolver that translates filenames into TMDB metadata before screenshots are rendered. The CLI analyses the first detected source to gather title/year hints (via GuessIt/Anitopy), then resolves `(category, tmdbId, original language)` once per run. Successful matches populate:
+
+- `cfg.slowpics.tmdb_id` when it is empty so the slow.pics upload automatically links to TMDB, and
+- the templating context for `[slowpics].collection_name`, exposing `${Title}`, `${OriginalTitle}`, `${Year}`, `${TMDBId}`, `${TMDBCategory}`, `${OriginalLanguage}`, `${Filename}`, `${FileName}`, and `${Label}`.
+
+Resolution follows a deterministic pipeline:
+
+1. If the filename or metadata exposes external IDs, `find/{imdb|tvdb}_id` is queried first, honouring `[tmdb].category_preference` when both movie and TV hits are returned.
+2. Otherwise, the resolver issues `search/movie` or `search/tv` calls with progressively broader queries derived from the cleaned title. Heuristics include year windows within `[tmdb].year_tolerance`, roman-numeral conversion, subtitle/colon trimming, reduced word sets, automatic movie↔TV switching, and, when `[tmdb].enable_anime_parsing=true`, romaji titles via Anitopy.
+3. Every response is scored by similarity, release year proximity, and light popularity boosts. Strong matches are selected immediately; otherwise the highest scoring candidate wins with logging that notes the heuristic (e.g. “roman-numeral”). Ambiguity only surfaces when `[tmdb].unattended=false`, in which case the CLI prompts for a manual identifier such as `movie/603`.
+
+All HTTP requests share an in-memory cache governed by `[tmdb].cache_ttl_seconds` and automatically apply exponential backoff on rate limits or transient failures. Setting `[tmdb].api_key` is mandatory; when omitted the resolver is skipped and slow.pics falls back to whatever `tmdb_id` you manually provided in the config.
 
 ## CLI usage
 ```

--- a/config.toml.template
+++ b/config.toml.template
@@ -51,6 +51,15 @@ open_in_browser = true
 create_url_shortcut = true
 delete_screen_dir_after_upload = true
 
+[tmdb]
+# TMDB lookup automation. Provide an API key to enable matching.
+api_key = ""
+unattended = true
+year_tolerance = 2
+enable_anime_parsing = true
+cache_ttl_seconds = 86400
+category_preference = ""
+
 [naming]
 # Controls how GuessIt/Anitopy metadata is turned into labels.
 always_full_filename = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "colorama",
     "requests",
     "requests-toolbelt",
+    "httpx",
     "natsort",
     "anitopy",
     "guessit",

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -10,12 +10,13 @@ import tomllib
 from .datatypes import (
     AppConfig,
     AnalysisConfig,
-    ScreenshotConfig,
-    SlowpicsConfig,
     NamingConfig,
+    OverridesConfig,
     PathsConfig,
     RuntimeConfig,
-    OverridesConfig,
+    ScreenshotConfig,
+    SlowpicsConfig,
+    TMDBConfig,
 )
 
 
@@ -91,6 +92,7 @@ def load_config(path: str) -> AppConfig:
         analysis=_sanitize_section(raw.get("analysis", {}), "analysis", AnalysisConfig),
         screenshots=_sanitize_section(raw.get("screenshots", {}), "screenshots", ScreenshotConfig),
         slowpics=_sanitize_section(raw.get("slowpics", {}), "slowpics", SlowpicsConfig),
+        tmdb=_sanitize_section(raw.get("tmdb", {}), "tmdb", TMDBConfig),
         naming=_sanitize_section(raw.get("naming", {}), "naming", NamingConfig),
         paths=_sanitize_section(raw.get("paths", {}), "paths", PathsConfig),
         runtime=_sanitize_section(raw.get("runtime", {}), "runtime", RuntimeConfig),
@@ -123,6 +125,16 @@ def load_config(path: str) -> AppConfig:
 
     if app.slowpics.remove_after_days < 0:
         raise ConfigError("slowpics.remove_after_days must be >= 0")
+
+    if app.tmdb.year_tolerance < 0:
+        raise ConfigError("tmdb.year_tolerance must be >= 0")
+    if app.tmdb.cache_ttl_seconds < 0:
+        raise ConfigError("tmdb.cache_ttl_seconds must be >= 0")
+    if app.tmdb.category_preference is not None:
+        pref = app.tmdb.category_preference.upper()
+        if pref not in {"", "MOVIE", "TV"}:
+            raise ConfigError("tmdb.category_preference must be MOVIE, TV, or omitted")
+        app.tmdb.category_preference = pref or None
 
     if app.runtime.ram_limit_mb <= 0:
         raise ConfigError("runtime.ram_limit_mb must be > 0")

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -1,6 +1,6 @@
 """Configuration dataclasses for frame comparison tool."""
 from dataclasses import dataclass, field
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 
 @dataclass
@@ -64,6 +64,18 @@ class SlowpicsConfig:
 
 
 @dataclass
+class TMDBConfig:
+    """Configuration controlling TMDB lookup and caching behaviour."""
+
+    api_key: str = ""
+    unattended: bool = True
+    year_tolerance: int = 2
+    enable_anime_parsing: bool = True
+    cache_ttl_seconds: int = 86400
+    category_preference: Optional[str] = None
+
+
+@dataclass
 class NamingConfig:
     """Filename parsing and display preferences."""
 
@@ -102,6 +114,7 @@ class AppConfig:
     analysis: AnalysisConfig
     screenshots: ScreenshotConfig
     slowpics: SlowpicsConfig
+    tmdb: TMDBConfig
     naming: NamingConfig
     paths: PathsConfig
     runtime: RuntimeConfig

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -1,0 +1,798 @@
+from __future__ import annotations
+
+"""Helpers for resolving TMDB metadata from filenames or external IDs."""
+
+import asyncio
+import logging
+import re
+import time
+import unicodedata
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import httpx
+
+from .datatypes import TMDBConfig
+
+logger = logging.getLogger(__name__)
+
+MOVIE = "MOVIE"
+TV = "TV"
+_BASE_URL = "https://api.themoviedb.org/3"
+_SIMILARITY_THRESHOLD = 0.45
+_STRONG_MATCH_THRESHOLD = 0.92
+_AMBIGUITY_MARGIN = 0.08
+
+_NON_WORD_RE = re.compile(r"[^0-9a-zA-Z\s]+", re.UNICODE)
+_WHITESPACE_RE = re.compile(r"\s+")
+_ROMAN_RE = re.compile(r"\b([IVXLCDM]+)\b", re.IGNORECASE)
+_YEAR_RE = re.compile(r"(19|20)\d{2}")
+_IMDB_RE = re.compile(r"tt\d{7,9}", re.IGNORECASE)
+
+
+class TMDBResolutionError(RuntimeError):
+    """Raised when TMDB matching cannot complete."""
+
+
+class TMDBAmbiguityError(TMDBResolutionError):
+    """Raised when multiple TMDB results look equally plausible."""
+
+    def __init__(self, candidates: Sequence["TMDBCandidate"]) -> None:
+        self.candidates = list(candidates)
+        pretty = ", ".join(
+            f"{cand.category.lower()}/{cand.tmdb_id} ({cand.title} – {cand.year or '????'} score={cand.score:0.3f})"
+            for cand in self.candidates
+        )
+        super().__init__(f"Ambiguous TMDB match candidates: {pretty}")
+
+
+@dataclass
+class TMDBCandidate:
+    """Represents a TMDB search or lookup hit."""
+
+    category: str
+    tmdb_id: str
+    title: str
+    original_title: Optional[str]
+    year: Optional[int]
+    score: float
+    original_language: Optional[str]
+    reason: str
+    used_filename_search: bool
+    payload: Dict[str, Any]
+
+
+@dataclass
+class TMDBResolution:
+    """Final TMDB resolution result."""
+
+    candidate: TMDBCandidate
+    margin: float
+    source_query: str
+
+    def __iter__(self):  # pragma: no cover - convenience for tuple unpacking
+        yield self.candidate.category
+        yield self.candidate.tmdb_id
+        yield self.candidate.original_language
+        yield self.candidate.used_filename_search
+
+    @property
+    def category(self) -> str:
+        return self.candidate.category
+
+    @property
+    def tmdb_id(self) -> str:
+        return self.candidate.tmdb_id
+
+    @property
+    def title(self) -> str:
+        return self.candidate.title
+
+    @property
+    def original_title(self) -> Optional[str]:
+        return self.candidate.original_title
+
+    @property
+    def year(self) -> Optional[int]:
+        return self.candidate.year
+
+    @property
+    def original_language(self) -> Optional[str]:
+        return self.candidate.original_language
+
+
+class _TTLCache:
+    """Simple TTL cache shared across TMDB requests."""
+
+    def __init__(self) -> None:
+        self._data: Dict[Tuple[Any, ...], Tuple[float, Any]] = {}
+
+    def get(self, key: Tuple[Any, ...], ttl_seconds: int) -> Any | None:
+        entry = self._data.get(key)
+        if not entry:
+            return None
+        timestamp, value = entry
+        if ttl_seconds <= 0:
+            return None
+        if time.monotonic() - timestamp > ttl_seconds:
+            self._data.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: Tuple[Any, ...], value: Any) -> None:
+        self._data[key] = (time.monotonic(), value)
+
+
+_CACHE = _TTLCache()
+
+
+def parse_manual_id(value: str) -> Tuple[str, str]:
+    """Validate a manual TMDB identifier (movie/12345 or tv/67890)."""
+
+    text = value.strip().lower()
+    if not text:
+        raise TMDBResolutionError("Manual TMDB identifier cannot be empty")
+    if text.isdigit():
+        raise TMDBResolutionError(
+            "Manual TMDB identifier must include a category prefix (movie/ or tv/)."
+        )
+    match = re.match(r"^(movie|tv)[/:-]?(\d+)$", text)
+    if not match:
+        raise TMDBResolutionError(
+            "Manual TMDB identifier must look like movie/12345 or tv/67890"
+        )
+    category = MOVIE if match.group(1) == "movie" else TV
+    tmdb_id = match.group(2)
+    return category, tmdb_id
+
+
+def _normalize_title(title: str) -> str:
+    text = unicodedata.normalize("NFKC", title or "")
+    text = text.replace("&", " and ")
+    text = _NON_WORD_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text)
+    return text.strip().lower()
+
+
+def _normalized_variants(title: str) -> List[str]:
+    base = _normalize_title(title)
+    variants = {base}
+    if base.startswith("the "):
+        variants.add(base[4:])
+    return [variant for variant in variants if variant]
+
+
+def _similarity(left: str, right: str) -> float:
+    if not left or not right:
+        return 0.0
+    if left == right:
+        return 1.0
+    shorter, longer = (left, right) if len(left) <= len(right) else (right, left)
+    if not shorter:
+        return 0.0
+    matches = 0
+    j = 0
+    for ch in shorter:
+        idx = longer.find(ch, j)
+        if idx == -1:
+            continue
+        matches += 1
+        j = idx + 1
+    return matches / max(1, len(longer))
+
+
+def _roman_to_int(text: str) -> Optional[int]:
+    values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+    result = 0
+    prev = 0
+    for char in text.upper():
+        value = values.get(char)
+        if value is None:
+            return None
+        if value > prev:
+            result += value - 2 * prev
+        else:
+            result += value
+        prev = value
+    return result if result > 0 else None
+
+
+def _convert_roman_suffix(title: str) -> Optional[str]:
+    match = _ROMAN_RE.search(title)
+    if not match:
+        return None
+    numeral = match.group(1)
+    converted = _roman_to_int(numeral)
+    if not converted or converted <= 1:
+        return None
+    return f"{title[:match.start(1)]}{converted}{title[match.end(1):]}"
+
+
+def _primary_title(title: str) -> Optional[str]:
+    for delimiter in (":", " - ", " (", " – "):
+        if delimiter in title:
+            candidate = title.split(delimiter, 1)[0].strip()
+            if candidate and candidate != title:
+                return candidate
+    return None
+
+
+def _reduced_words(title: str) -> Optional[str]:
+    words = re.findall(r"[A-Za-z0-9']+", title)
+    filtered = [word for word in words if len(word) > 2]
+    if filtered and filtered != words:
+        return " ".join(filtered)
+    return None
+
+
+def _strip_filename_noise(filename: str) -> str:
+    stem = filename.rsplit(".", 1)[0]
+    stem = re.sub(r"^\[[^]]+\]", "", stem)
+    stem = re.sub(r"[\[\]{}()]", " ", stem)
+    stem = stem.replace("_", " ")
+    stem = re.sub(
+        r"\b(480p|576p|720p|1080p|2160p|4320p|x264|h264|hevc|x265|av1|hdr|sdr|remux|webrip|web-dl|bluray|blu-ray|dvdrip|multi|10bit|proper|repack|extended|uhd|nf|amzn)\b",
+        "",
+        stem,
+        flags=re.IGNORECASE,
+    )
+    stem = _WHITESPACE_RE.sub(" ", stem)
+    return stem.strip()
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_year_from_date(date_text: str) -> Optional[int]:
+    if not date_text:
+        return None
+    match = _YEAR_RE.search(date_text)
+    if match:
+        return int(match.group(0))
+    return None
+
+
+def _extract_year_from_result(payload: Dict[str, Any], category: str) -> Optional[int]:
+    if category == MOVIE:
+        return _extract_year_from_date(payload.get("release_date", ""))
+    return _extract_year_from_date(payload.get("first_air_date", ""))
+
+
+def _call_guessit(filename: str) -> Dict[str, Any]:
+    try:
+        module = import_module("guessit")
+    except Exception:
+        return {}
+    parser = getattr(module, "guessit", None)
+    if not callable(parser):
+        return {}
+    try:
+        result = parser(filename)
+    except Exception:
+        return {}
+    if isinstance(result, dict):
+        return dict(result)
+    return {}
+
+
+def _call_anitopy(filename: str) -> Dict[str, Any]:
+    try:
+        module = import_module("anitopy")
+    except Exception:
+        return {}
+    parser = getattr(module, "parse", None)
+    if not callable(parser):
+        return {}
+    try:
+        result = parser(filename)
+    except Exception:
+        return {}
+    if isinstance(result, dict):
+        return dict(result)
+    return {}
+
+
+@dataclass(frozen=True)
+class _QueryPlan:
+    query: str
+    year: Optional[int]
+    category: str
+    reason: str
+
+
+def _build_query_plans(
+    base_title: str,
+    *,
+    year: Optional[int],
+    category_hint: Optional[str],
+    category_preference: Optional[str],
+    anime_titles: Sequence[str],
+    year_tolerance: int,
+) -> List[_QueryPlan]:
+    queries: List[_QueryPlan] = []
+    seen: set[Tuple[str, Optional[int], str]] = set()
+
+    def add(query: str, year_val: Optional[int], category: str, reason: str) -> None:
+        key = (query.lower(), year_val, category)
+        if not query.strip():
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        queries.append(_QueryPlan(query=query.strip(), year=year_val, category=category, reason=reason))
+
+    categories: List[str] = []
+    for preferred in (category_preference, category_hint, MOVIE, TV):
+        if preferred and preferred not in categories:
+            categories.append(preferred)
+
+    all_titles = [base_title]
+    for alt in anime_titles:
+        if alt and alt not in all_titles:
+            all_titles.append(alt)
+
+    for category in categories:
+        for title in all_titles:
+            add(title, year, category, "primary-title")
+            roman = _convert_roman_suffix(title)
+            if roman and roman != title:
+                add(roman, year, category, "roman-numeral")
+            primary = _primary_title(title)
+            if primary and primary != title:
+                add(primary, year, category, "secondary-title")
+            reduced = _reduced_words(title)
+            if reduced and reduced != title:
+                add(reduced, year, category, "reduced-words")
+
+    if year is not None and year_tolerance > 0:
+        deltas = {delta for delta in range(-year_tolerance, year_tolerance + 1) if delta}
+        for plan in list(queries):
+            for delta in sorted(deltas):
+                add(plan.query, year + delta, plan.category, f"year-adjust {delta:+d}")
+
+    return queries
+
+
+async def _http_request(
+    client: httpx.AsyncClient,
+    *,
+    cache_ttl: int,
+    path: str,
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    key = (path, tuple(sorted(params.items())))
+    cached = _CACHE.get(key, cache_ttl)
+    if cached is not None:
+        return cached
+
+    backoff = 0.5
+    last_error: Exception | None = None
+    for attempt in range(4):
+        try:
+            response = await client.get(path, params=params)
+        except httpx.RequestError as exc:  # pragma: no cover - rare network error
+            last_error = exc
+        else:
+            status = response.status_code
+            if status >= 500 or status == 429:
+                retry_after = response.headers.get("Retry-After")
+                try:
+                    delay = float(retry_after) if retry_after else backoff
+                except ValueError:
+                    delay = backoff
+                await asyncio.sleep(max(0.1, min(delay, 4.0)))
+                backoff = min(backoff * 2, 4.0)
+                continue
+            if status >= 400:
+                raise TMDBResolutionError(
+                    f"TMDB request failed for {path} (status={status}): {response.text[:200]}"
+                )
+            try:
+                payload = response.json()
+            except ValueError as exc:  # pragma: no cover - unexpected
+                raise TMDBResolutionError("TMDB returned invalid JSON") from exc
+            _CACHE.set(key, payload)
+            return payload
+        await asyncio.sleep(backoff)
+        backoff = min(backoff * 2, 4.0)
+    if last_error:
+        raise TMDBResolutionError(f"TMDB request failed after retries: {last_error}")
+    raise TMDBResolutionError("TMDB request failed after retries")
+
+
+def _title_candidates(payload: Dict[str, Any]) -> List[str]:
+    keys = ["title", "name", "original_title", "original_name"]
+    values: List[str] = []
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            values.append(value)
+    seen: set[str] = set()
+    unique: List[str] = []
+    for title in values:
+        normalized = title.lower()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(title)
+    return unique
+
+
+def _score_payload(
+    payload: Dict[str, Any],
+    *,
+    category: str,
+    query_norms: Sequence[str],
+    year: Optional[int],
+    tolerance: int,
+    index: int,
+) -> float:
+    titles = _title_candidates(payload)
+    title_norms = [_normalize_title(title) for title in titles]
+    best = 0.0
+    for query_norm in query_norms:
+        for title_norm in title_norms:
+            sim = _similarity(query_norm, title_norm)
+            if title_norm == query_norm and sim < 1.0:
+                sim = max(sim, 0.99)
+            best = max(best, sim)
+    if not titles:
+        best *= 0.8
+
+    if category == TV and index == 0:
+        best += 0.01
+
+    candidate_year = _extract_year_from_result(payload, category)
+    if year is not None:
+        if candidate_year is None:
+            best -= 0.05
+        else:
+            diff = abs(candidate_year - year)
+            if diff <= tolerance:
+                best += 0.05 * (tolerance - diff + 1)
+            else:
+                best -= min(0.4 + (0.05 * (diff - tolerance)), 0.7)
+    popularity = payload.get("popularity")
+    try:
+        popularity_value = float(popularity)
+    except (TypeError, ValueError):
+        popularity_value = 0.0
+    if popularity_value > 0:
+        best += min(popularity_value / 200.0, 0.05)
+
+    return best
+
+
+def _best_external_candidate(
+    payload: Dict[str, Any],
+    *,
+    category_preference: Optional[str],
+    category_hint: Optional[str],
+    query_norms: Sequence[str],
+    year: Optional[int],
+    tolerance: int,
+) -> Optional[TMDBCandidate]:
+    candidates: List[TMDBCandidate] = []
+    for category, key in ((MOVIE, "movie_results"), (TV, "tv_results")):
+        for item in payload.get(key, []) or []:
+            score = _score_payload(
+                item,
+                category=category,
+                query_norms=query_norms,
+                year=year,
+                tolerance=tolerance,
+                index=0,
+            )
+            candidate = TMDBCandidate(
+                category=category,
+                tmdb_id=str(item.get("id")),
+                title=item.get("title") or item.get("name") or "",
+                original_title=item.get("original_title") or item.get("original_name"),
+                year=_extract_year_from_result(item, category),
+                score=score,
+                original_language=item.get("original_language"),
+                reason="external-id",
+                used_filename_search=False,
+                payload=item,
+            )
+            candidates.append(candidate)
+
+    if not candidates:
+        return None
+
+    def _preferred(category: str) -> int:
+        if category_preference == category:
+            return 0
+        if category_hint == category:
+            return 1
+        return 2
+
+    candidates.sort(key=lambda cand: (_preferred(cand.category), -cand.score))
+    return candidates[0]
+
+
+async def _perform_search(
+    client: httpx.AsyncClient,
+    *,
+    plan: _QueryPlan,
+    cache_ttl: int,
+) -> List[Dict[str, Any]]:
+    params: Dict[str, Any] = {
+        "query": plan.query,
+        "include_adult": "false",
+    }
+    if plan.year is not None:
+        if plan.category == MOVIE:
+            params["year"] = plan.year
+        else:
+            params["first_air_date_year"] = plan.year
+    payload = await _http_request(
+        client,
+        cache_ttl=cache_ttl,
+        path="search/movie" if plan.category == MOVIE else "search/tv",
+        params=params,
+    )
+    results = payload.get("results", [])
+    return list(results) if isinstance(results, list) else []
+
+
+def _extract_best_candidate(
+    *,
+    results: List[Dict[str, Any]],
+    plan: _QueryPlan,
+    query_norms: Sequence[str],
+    tolerance: int,
+    year: Optional[int],
+) -> List[TMDBCandidate]:
+    candidates: List[TMDBCandidate] = []
+    for index, item in enumerate(results):
+        score = _score_payload(
+            item,
+            category=plan.category,
+            query_norms=query_norms,
+            year=plan.year if plan.reason.startswith("year-adjust") else year,
+            tolerance=tolerance,
+            index=index,
+        )
+        candidate = TMDBCandidate(
+            category=plan.category,
+            tmdb_id=str(item.get("id")),
+            title=item.get("title") or item.get("name") or "",
+            original_title=item.get("original_title") or item.get("original_name"),
+            year=_extract_year_from_result(item, plan.category),
+            score=score,
+            original_language=item.get("original_language"),
+            reason=plan.reason,
+            used_filename_search=True,
+            payload=item,
+        )
+        candidates.append(candidate)
+    return candidates
+
+
+def _extract_title_year(filename: str, *, enable_anime: bool) -> Tuple[str, Optional[int], Optional[str], List[str]]:
+    guess = _call_guessit(filename)
+    title = guess.get("title") if isinstance(guess, dict) else ""
+    title_str = str(title or "").strip()
+    year = guess.get("year") if isinstance(guess, dict) else None
+    year_int = _safe_int(year)
+
+    type_hint_raw = str(guess.get("type") or "") if isinstance(guess, dict) else ""
+    category_hint: Optional[str] = None
+    if type_hint_raw.lower() in {"episode", "season", "tv", "series"}:
+        category_hint = TV
+    elif type_hint_raw.lower() == "movie":
+        category_hint = MOVIE
+
+    anime_titles: List[str] = []
+    if enable_anime:
+        ani = _call_anitopy(filename)
+        ani_title = ani.get("anime_title") or ani.get("title") if isinstance(ani, dict) else None
+        if ani_title:
+            ani_title_str = str(ani_title).strip()
+            if ani_title_str and ani_title_str.lower() != title_str.lower():
+                anime_titles.append(ani_title_str)
+        romaji = ani.get("anime_title_romaji") if isinstance(ani, dict) else None
+        if romaji:
+            romaji_str = str(romaji).strip()
+            if romaji_str and romaji_str.lower() not in {t.lower() for t in anime_titles}:
+                anime_titles.append(romaji_str)
+
+    cleaned = title_str or _strip_filename_noise(filename)
+    if not cleaned:
+        cleaned = filename
+    return cleaned, year_int, category_hint, anime_titles
+
+
+def _detect_external_ids(filename: str) -> Tuple[Optional[str], Optional[str]]:
+    imdb = None
+    match = _IMDB_RE.search(filename)
+    if match:
+        imdb = match.group(0)
+    return imdb, None
+
+
+async def resolve_tmdb(
+    filename: str,
+    *,
+    config: TMDBConfig,
+    year: Optional[int] = None,
+    imdb_id: Optional[str] = None,
+    tvdb_id: Optional[str] = None,
+    unattended: Optional[bool] = None,
+    category_preference: Optional[str] = None,
+    http_transport: httpx.BaseTransport | None = None,
+) -> Optional[TMDBResolution]:
+    """Resolve TMDB metadata for *filename* using the provided *config*."""
+
+    if not config.api_key:
+        raise TMDBResolutionError("tmdb.api_key must be set to resolve TMDB metadata")
+
+    unattended_mode = config.unattended if unattended is None else unattended
+    category_pref = (category_preference or config.category_preference or "").upper() or None
+    year_tolerance = max(0, int(config.year_tolerance))
+
+    cleaned_title, parsed_year, category_hint, anime_titles = _extract_title_year(
+        filename,
+        enable_anime=config.enable_anime_parsing,
+    )
+    if year is None and parsed_year is not None:
+        year = parsed_year
+
+    imdb_auto, tvdb_auto = _detect_external_ids(filename)
+    imdb_lookup = imdb_id or imdb_auto
+    tvdb_lookup = tvdb_id or tvdb_auto
+
+    query_norms = _normalized_variants(cleaned_title)
+
+    timeout = httpx.Timeout(10.0, connect=10.0, read=10.0, write=10.0)
+    params = {"api_key": config.api_key}
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=timeout, params=params, transport=http_transport) as client:
+        if imdb_lookup:
+            payload = await _http_request(
+                client,
+                cache_ttl=config.cache_ttl_seconds,
+                path=f"find/{imdb_lookup}",
+                params={"external_source": "imdb_id"},
+            )
+            candidate = _best_external_candidate(
+                payload,
+                category_preference=category_pref,
+                category_hint=category_hint,
+                query_norms=query_norms,
+                year=year,
+                tolerance=year_tolerance,
+            )
+            if candidate:
+                logger.info(
+                    "TMDB external match via IMDb %s -> %s/%s (%s)",
+                    imdb_lookup,
+                    candidate.category,
+                    candidate.tmdb_id,
+                    candidate.title,
+                )
+                return TMDBResolution(candidate=candidate, margin=1.0, source_query=cleaned_title)
+
+        if tvdb_lookup:
+            payload = await _http_request(
+                client,
+                cache_ttl=config.cache_ttl_seconds,
+                path=f"find/{tvdb_lookup}",
+                params={"external_source": "tvdb_id"},
+            )
+            candidate = _best_external_candidate(
+                payload,
+                category_preference=category_pref,
+                category_hint=category_hint,
+                query_norms=query_norms,
+                year=year,
+                tolerance=year_tolerance,
+            )
+            if candidate:
+                logger.info(
+                    "TMDB external match via TVDB %s -> %s/%s (%s)",
+                    tvdb_lookup,
+                    candidate.category,
+                    candidate.tmdb_id,
+                    candidate.title,
+                )
+                return TMDBResolution(candidate=candidate, margin=1.0, source_query=cleaned_title)
+
+        plans = _build_query_plans(
+            cleaned_title,
+            year=year,
+            category_hint=category_hint,
+            category_preference=category_pref,
+            anime_titles=anime_titles,
+            year_tolerance=year_tolerance,
+        )
+
+        all_candidates: List[TMDBCandidate] = []
+        best_candidate: Optional[TMDBCandidate] = None
+        runner_up: Optional[TMDBCandidate] = None
+
+        for plan in plans:
+            results = await _perform_search(
+                client,
+                plan=plan,
+                cache_ttl=config.cache_ttl_seconds,
+            )
+            candidates = _extract_best_candidate(
+                results=results,
+                plan=plan,
+                query_norms=query_norms,
+                tolerance=year_tolerance,
+                year=year,
+            )
+            if not candidates:
+                continue
+            all_candidates.extend(candidates)
+            candidates.sort(key=lambda cand: cand.score, reverse=True)
+            candidate = candidates[0]
+            if candidate.score >= _SIMILARITY_THRESHOLD:
+                if best_candidate is None or candidate.score > best_candidate.score:
+                    runner_up = best_candidate
+                    candidate.reason = plan.reason
+                    best_candidate = candidate
+                elif runner_up is None or candidate.score > runner_up.score:
+                    runner_up = candidate
+            if best_candidate and best_candidate.score >= _STRONG_MATCH_THRESHOLD:
+                break
+
+        if not best_candidate:
+            if all_candidates:
+                top = sorted(all_candidates, key=lambda cand: cand.score, reverse=True)[:3]
+                summary = ", ".join(
+                    f"{cand.category.lower()}/{cand.tmdb_id} {cand.title} ({cand.year or '????'}) score={cand.score:0.3f}"
+                    for cand in top
+                )
+                logger.warning("TMDB search failed for %s. Top candidates: %s", filename, summary)
+            else:
+                logger.warning("TMDB search returned no viable candidates for %s", filename)
+            return None
+
+        margin = best_candidate.score - (runner_up.score if runner_up else 0.0)
+        resolution = TMDBResolution(candidate=best_candidate, margin=margin, source_query=cleaned_title)
+
+        if not unattended_mode and runner_up and margin < _AMBIGUITY_MARGIN:
+            ranked = sorted(all_candidates, key=lambda cand: cand.score, reverse=True)[:5]
+            raise TMDBAmbiguityError(ranked)
+
+        if runner_up and margin < _AMBIGUITY_MARGIN:
+            logger.warning(
+                "TMDB match for %s selected %s/%s (%s) with low margin %.3f",
+                filename,
+                best_candidate.category,
+                best_candidate.tmdb_id,
+                best_candidate.title,
+                margin,
+            )
+        else:
+            logger.info(
+                "TMDB match via %s -> %s/%s (%s, %s) score=%.3f",
+                best_candidate.reason,
+                best_candidate.category,
+                best_candidate.tmdb_id,
+                best_candidate.title,
+                best_candidate.year or "????",
+                best_candidate.score,
+            )
+
+        return resolution
+
+
+__all__ = [
+    "MOVIE",
+    "TV",
+    "TMDBResolution",
+    "TMDBResolutionError",
+    "TMDBAmbiguityError",
+    "TMDBCandidate",
+    "resolve_tmdb",
+    "parse_manual_id",
+]

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,10 @@ import re
 from importlib import import_module
 from typing import Any, Dict, Mapping, Optional
 
+_IMDB_ID_RE = re.compile(r"(tt\d{7,9})", re.IGNORECASE)
+_TVDB_ID_RE = re.compile(r"tvdb\s*(\d+)", re.IGNORECASE)
+_YEAR_RE = re.compile(r"(19|20)\d{2}")
+
 
 def _extract_release_group_brackets(file_name: str) -> Optional[str]:
     """Return the leading release-group tag (e.g. "[Group]") without brackets."""
@@ -125,12 +129,14 @@ def parse_filename_metadata(
     episode_title = ""
     release_group = ""
     label_episode_marker = ""
+    year_value: Any = None
 
     if guessit_data:
         title = str(guessit_data.get("title") or "")
         episode_val = guessit_data.get("episode")
         episode_title = str(guessit_data.get("episode_title") or "")
         release_group = str(guessit_data.get("release_group") or "")
+        year_value = guessit_data.get("year")
         normalized_episode = _normalize_episode_number(episode_val)
         label_episode_marker = _episode_designator_for_label(
             episode_val, guessit_data.get("season"), normalized_episode
@@ -143,9 +149,24 @@ def parse_filename_metadata(
         release_group = str(ani_data.get("release_group") or "")
         normalized_episode = _normalize_episode_number(episode_val)
         label_episode_marker = normalized_episode
+        year_value = ani_data.get("anime_season") or ani_data.get("year")
 
     normalized_episode = _normalize_episode_number(episode_val)
     resolved_release_group = release_group or _extract_release_group_brackets(file_name) or ""
+
+    if isinstance(year_value, (list, tuple)):
+        year_value = year_value[0] if year_value else None
+    year_str = ""
+    if isinstance(year_value, (int, float)):
+        year_int = int(year_value)
+        if 1900 <= year_int <= 2100:
+            year_str = str(year_int)
+    elif isinstance(year_value, str) and year_value.isdigit():
+        year_str = year_value
+    if not year_str:
+        match = _YEAR_RE.search(file_name)
+        if match:
+            year_str = match.group(0)
 
     metadata = {
         "anime_title": title,
@@ -153,6 +174,8 @@ def parse_filename_metadata(
         "episode_title": episode_title,
         "release_group": resolved_release_group,
         "file_name": file_name,
+        "title": title,
+        "year": year_str,
     }
 
     use_full_name = True if always_full_filename is None else bool(always_full_filename)
@@ -164,4 +187,9 @@ def parse_filename_metadata(
         episode_title,
     )
     metadata["label"] = label
+
+    imdb_match = _IMDB_ID_RE.search(file_name)
+    metadata["imdb_id"] = imdb_match.group(1).lower() if imdb_match else ""
+    tvdb_match = _TVDB_ID_RE.search(file_name)
+    metadata["tvdb_id"] = tvdb_match.group(1) if tvdb_match else ""
     return metadata

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,9 @@ from pathlib import Path
 
 import pytest
 
+import pytest
+from pathlib import Path
+
 from src.config_loader import ConfigError, load_config
 
 
@@ -24,6 +27,12 @@ def test_load_defaults(tmp_path: Path) -> None:
     assert app.analysis.ignore_lead_seconds == 0.0
     assert app.analysis.ignore_trail_seconds == 0.0
     assert app.analysis.min_window_seconds == 5.0
+    assert app.tmdb.api_key == ""
+    assert app.tmdb.unattended is True
+    assert app.tmdb.year_tolerance == 2
+    assert app.tmdb.enable_anime_parsing is True
+    assert app.tmdb.cache_ttl_seconds == 86400
+    assert app.tmdb.category_preference is None
 
 
 @pytest.mark.parametrize(
@@ -34,6 +43,9 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[analysis]\nignore_lead_seconds = -1\n", "analysis.ignore_lead_seconds"),
         ("[analysis]\nignore_trail_seconds = -2\n", "analysis.ignore_trail_seconds"),
         ("[analysis]\nmin_window_seconds = -0.5\n", "analysis.min_window_seconds"),
+        ("[tmdb]\nyear_tolerance = -1\n", "tmdb.year_tolerance"),
+        ("[tmdb]\ncache_ttl_seconds = -5\n", "tmdb.cache_ttl_seconds"),
+        ("[tmdb]\ncategory_preference = \"documentary\"\n", "tmdb.category_preference"),
     ],
 )
 def test_validation_errors(tmp_path: Path, toml_snippet: str, message: str) -> None:
@@ -65,6 +77,12 @@ remove_after_days = 14
 [naming]
 always_full_filename = false
 
+[tmdb]
+unattended = false
+year_tolerance = 1
+cache_ttl_seconds = 120
+category_preference = "tv"
+
 [paths]
 input_dir = "D:/comparisons"
         """.strip(),
@@ -81,3 +99,7 @@ input_dir = "D:/comparisons"
     assert app.slowpics.remove_after_days == 14
     assert app.naming.always_full_filename is False
     assert app.paths.input_dir == "D:/comparisons"
+    assert app.tmdb.unattended is False
+    assert app.tmdb.year_tolerance == 1
+    assert app.tmdb.cache_ttl_seconds == 120
+    assert app.tmdb.category_preference == "TV"

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import types
+from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
@@ -14,7 +14,9 @@ from src.datatypes import (
     RuntimeConfig,
     ScreenshotConfig,
     SlowpicsConfig,
+    TMDBConfig,
 )
+from src.tmdb import TMDBAmbiguityError, TMDBCandidate, TMDBResolution
 
 
 @pytest.fixture
@@ -33,6 +35,7 @@ def _make_config(input_dir: Path) -> AppConfig:
         ),
         screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
         slowpics=SlowpicsConfig(auto_upload=False),
+        tmdb=TMDBConfig(),
         naming=NamingConfig(always_full_filename=False, prefer_guessit=False),
         paths=PathsConfig(input_dir=str(input_dir)),
         runtime=RuntimeConfig(ram_limit_mb=4096),
@@ -145,6 +148,7 @@ def test_label_dedupe_preserves_short_labels(tmp_path, monkeypatch, runner):
         analysis=AnalysisConfig(frame_count_dark=0, frame_count_bright=0, frame_count_motion=0, random_frames=0),
         screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
         slowpics=SlowpicsConfig(auto_upload=False),
+        tmdb=TMDBConfig(),
         naming=NamingConfig(always_full_filename=False, prefer_guessit=False),
         paths=PathsConfig(input_dir=str(tmp_path)),
         runtime=RuntimeConfig(ram_limit_mb=1024),
@@ -255,6 +259,7 @@ def test_cli_input_override_and_cleanup(tmp_path, monkeypatch, runner):
         analysis=AnalysisConfig(frame_count_dark=0, frame_count_bright=0, frame_count_motion=0, random_frames=0),
         screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
         slowpics=SlowpicsConfig(auto_upload=True, delete_screen_dir_after_upload=True, open_in_browser=False, create_url_shortcut=False),
+        tmdb=TMDBConfig(),
         naming=NamingConfig(always_full_filename=True, prefer_guessit=False),
         paths=PathsConfig(input_dir=str(default_dir)),
         runtime=RuntimeConfig(ram_limit_mb=1024),
@@ -301,3 +306,197 @@ def test_cli_input_override_and_cleanup(tmp_path, monkeypatch, runner):
     screen_dir = Path(override_dir / cfg.screenshots.directory_name).resolve()
     assert not screen_dir.exists()
     assert str(override_dir) in result.output
+
+
+def test_cli_tmdb_resolution_populates_slowpics(tmp_path, monkeypatch):
+    first = tmp_path / "SourceA.mkv"
+    second = tmp_path / "SourceB.mkv"
+    for file in (first, second):
+        file.write_bytes(b"data")
+
+    cfg = _make_config(tmp_path)
+    cfg.tmdb.api_key = "token"
+    cfg.slowpics.auto_upload = True
+    cfg.slowpics.collection_name = "${Title} (${Year}) [${TMDBCategory}]"
+    cfg.slowpics.delete_screen_dir_after_upload = False
+
+    monkeypatch.setattr(frame_compare, "load_config", lambda _: cfg)
+
+    def fake_parse(name: str, **_: object) -> dict[str, str]:
+        return {
+            "label": name,
+            "release_group": "",
+            "file_name": name,
+            "title": "Metadata Title",
+            "year": "2020",
+            "anime_title": "",
+            "imdb_id": "",
+            "tvdb_id": "",
+        }
+
+    monkeypatch.setattr(frame_compare, "parse_filename_metadata", fake_parse)
+
+    candidate = TMDBCandidate(
+        category="MOVIE",
+        tmdb_id="12345",
+        title="Resolved Title",
+        original_title="Original Title",
+        year=2023,
+        score=0.95,
+        original_language="en",
+        reason="primary-title",
+        used_filename_search=True,
+        payload={"id": 12345},
+    )
+    resolution = TMDBResolution(candidate=candidate, margin=0.4, source_query="Resolved")
+
+    async def fake_resolve(*args, **kwargs):  # pragma: no cover - simple stub
+        return resolution
+
+    monkeypatch.setattr(frame_compare, "resolve_tmdb", fake_resolve)
+    monkeypatch.setattr(frame_compare.vs_core, "set_ram_limit", lambda limit: None)
+
+    def fake_init(path, *, trim_start=0, trim_end=None, fps_map=None, cache_dir=None):
+        return types.SimpleNamespace(
+            width=1280,
+            height=720,
+            fps_num=24000,
+            fps_den=1001,
+            num_frames=1800,
+        )
+
+    monkeypatch.setattr(frame_compare.vs_core, "init_clip", fake_init)
+
+    def fake_select(
+        clip,
+        analysis_cfg,
+        files,
+        file_under_analysis,
+        cache_info=None,
+        progress=None,
+        *,
+        frame_window=None,
+        return_metadata=False,
+    ):
+        assert frame_window is not None
+        return [12, 24]
+
+    monkeypatch.setattr(frame_compare, "select_frames", fake_select)
+
+    def fake_generate(clips, frames, files, metadata, out_dir, cfg_screens, **kwargs):
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return [str(out_dir / f"shot_{idx}.png") for idx in range(len(frames) * len(files))]
+
+    monkeypatch.setattr(frame_compare, "generate_screenshots", fake_generate)
+
+    uploads = []
+
+    def fake_upload(image_paths, screen_dir, cfg_slow, **kwargs):
+        uploads.append((list(image_paths), screen_dir, cfg_slow.tmdb_id, cfg_slow.collection_name))
+        return "https://slow.pics/c/example"
+
+    monkeypatch.setattr(frame_compare, "upload_comparison", fake_upload)
+
+    class DummyProgress:
+        def __init__(self, *_, **__):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def add_task(self, *_, **__):
+            return 1
+
+        def update(self, *_, **__):
+            return None
+
+    monkeypatch.setattr(frame_compare, "Progress", DummyProgress)
+
+    result = frame_compare.run_cli("dummy", None)
+
+    assert uploads
+    _, _, upload_tmdb_id, upload_collection = uploads[0]
+    assert upload_tmdb_id == "12345"
+    assert "Resolved Title (2023)" in upload_collection
+    assert result.config.slowpics.tmdb_id == "12345"
+    assert result.config.slowpics.collection_name == "Resolved Title (2023) [MOVIE]"
+    assert result.slowpics_url == "https://slow.pics/c/example"
+
+
+def test_cli_tmdb_manual_override(tmp_path, monkeypatch):
+    first = tmp_path / "Alpha.mkv"
+    second = tmp_path / "Beta.mkv"
+    for file in (first, second):
+        file.write_bytes(b"data")
+
+    cfg = _make_config(tmp_path)
+    cfg.tmdb.api_key = "token"
+    cfg.tmdb.unattended = False
+    cfg.slowpics.collection_name = "${Label}"
+
+    monkeypatch.setattr(frame_compare, "load_config", lambda _: cfg)
+
+    def fake_parse(name: str, **_: object) -> dict[str, str]:
+        return {
+            "label": f"Label for {name}",
+            "release_group": "",
+            "file_name": name,
+            "title": "",
+            "year": "",
+            "anime_title": "",
+            "imdb_id": "",
+            "tvdb_id": "",
+        }
+
+    monkeypatch.setattr(frame_compare, "parse_filename_metadata", fake_parse)
+
+    candidate = TMDBCandidate(
+        category="TV",
+        tmdb_id="777",
+        title="Option A",
+        original_title=None,
+        year=2001,
+        score=0.5,
+        original_language="ja",
+        reason="primary",
+        used_filename_search=True,
+        payload={"id": 777},
+    )
+
+    def fake_resolve(*args, **kwargs):
+        raise TMDBAmbiguityError([candidate])
+
+    monkeypatch.setattr(frame_compare, "resolve_tmdb", fake_resolve)
+    monkeypatch.setattr(frame_compare, "_prompt_manual_tmdb", lambda candidates: ("TV", "9999"))
+    monkeypatch.setattr(frame_compare.vs_core, "set_ram_limit", lambda limit: None)
+
+    def fake_init(path, *, trim_start=0, trim_end=None, fps_map=None, cache_dir=None):
+        return types.SimpleNamespace(
+            width=1920,
+            height=1080,
+            fps_num=24000,
+            fps_den=1001,
+            num_frames=2400,
+        )
+
+    monkeypatch.setattr(frame_compare.vs_core, "init_clip", fake_init)
+
+    monkeypatch.setattr(
+        frame_compare,
+        "select_frames",
+        lambda clip, cfg, files, file_under_analysis, cache_info=None, progress=None, *, frame_window=None, return_metadata=False: [3, 6],
+    )
+
+    def fake_generate(clips, frames, files, metadata, out_dir, cfg_screens, **kwargs):
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return [str(out_dir / "img.png")]
+
+    monkeypatch.setattr(frame_compare, "generate_screenshots", fake_generate)
+
+    result = frame_compare.run_cli("dummy", None)
+
+    assert result.config.slowpics.tmdb_id == "9999"
+    assert result.config.slowpics.collection_name == "Label for Alpha.mkv"

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -1,0 +1,246 @@
+import asyncio
+from typing import Dict, List
+
+import httpx
+import pytest
+
+from src import tmdb as tmdb_module
+from src.tmdb import (
+    MOVIE,
+    TV,
+    TMDBCandidate,
+    TMDBConfig,
+    TMDBResolutionError,
+    resolve_tmdb,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_tmdb_cache() -> None:
+    tmdb_module._CACHE._data.clear()
+    yield
+    tmdb_module._CACHE._data.clear()
+
+
+def test_resolve_requires_api_key() -> None:
+    cfg = TMDBConfig(api_key="")
+    with pytest.raises(TMDBResolutionError):
+        asyncio.run(resolve_tmdb("Example.mkv", config=cfg))
+
+
+def test_external_id_respects_preference() -> None:
+    calls: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        return httpx.Response(
+            200,
+            json={
+                "movie_results": [
+                    {
+                        "id": 1,
+                        "title": "Example Movie",
+                        "release_date": "2000-01-01",
+                        "popularity": 10.0,
+                    }
+                ],
+                "tv_results": [
+                    {
+                        "id": 2,
+                        "name": "Example Show",
+                        "first_air_date": "2000-01-01",
+                        "popularity": 12.0,
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token", category_preference="TV")
+    result = asyncio.run(
+        resolve_tmdb(
+            "Example.mkv",
+            config=cfg,
+            imdb_id="tt1234567",
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.category == TV
+    assert result.tmdb_id == "2"
+    assert calls == ["/3/find/tt1234567"]
+
+
+def test_filename_search_year_similarity() -> None:
+    calls: List[Dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        calls.append({"path": request.url.path, "query": params.get("query", "")})
+        if request.url.path.endswith("/search/movie"):
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 603,
+                            "title": "The Matrix",
+                            "release_date": "1999-03-31",
+                            "popularity": 15.0,
+                        },
+                        {
+                            "id": 604,
+                            "title": "The Matrix Reloaded",
+                            "release_date": "2003-05-15",
+                            "popularity": 12.0,
+                        },
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token", year_tolerance=2)
+    result = asyncio.run(
+        resolve_tmdb(
+            "The.Matrix.1999.mkv",
+            config=cfg,
+            year=1999,
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.category == MOVIE
+    assert result.tmdb_id == "603"
+    assert any(call["query"] for call in calls)
+
+
+def test_roman_numeral_fallback() -> None:
+    queries: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.params.get("query", "")
+        queries.append(query)
+        if query.strip().lower() == "rocky 2":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 42,
+                            "title": "Rocky II",
+                            "release_date": "1979-06-15",
+                            "popularity": 8.0,
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token")
+    result = asyncio.run(
+        resolve_tmdb(
+            "Rocky.II.1979.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.tmdb_id == "42"
+    assert any(query.strip().lower() == "rocky 2" for query in queries if query)
+
+
+def test_anime_parsing_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tmdb_module, "_call_guessit", lambda filename: {})
+    monkeypatch.setattr(
+        tmdb_module,
+        "_call_anitopy",
+        lambda filename: {"anime_title": "Chainsaw Man"},
+    )
+
+    queries: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.params.get("query", "")
+        queries.append(query)
+        if query == "Chainsaw Man":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 321,
+                            "name": "Chainsaw Man",
+                            "first_air_date": "2022-10-12",
+                            "popularity": 20.0,
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token")
+    result = asyncio.run(
+        resolve_tmdb(
+            "[SubsPlease] Chainsaw Man - 01.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.tmdb_id == "321"
+    assert "Chainsaw Man" in queries
+
+
+def test_tmdb_backoff_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_calls: List[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(tmdb_module.asyncio, "sleep", fake_sleep)
+
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if attempts["count"] == 0:
+            attempts["count"] += 1
+            return httpx.Response(429, json={"status_code": 429})
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": 55,
+                        "title": "Cache Test",
+                        "release_date": "2020-01-01",
+                        "popularity": 6.0,
+                    }
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token")
+    first = asyncio.run(
+        resolve_tmdb(
+            "Cache.Test.2020.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    second = asyncio.run(
+        resolve_tmdb(
+            "Cache.Test.2020.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    assert first is not None and second is not None
+    assert first.tmdb_id == "55"
+    assert second.tmdb_id == "55"
+    assert sleep_calls  # backoff triggered at least once
+    # Only two HTTP calls should have been made (429 + success); cache served the second resolve
+    assert attempts["count"] == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,12 +1,26 @@
 version = 1
-revision = 3
-requires-python = ">=3.11"
+revision = 2
+requires-python = "==3.11.*"
 
 [[package]]
 name = "anitopy"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/8b/3da3f8ba73b8e4e5325a9ecbd6780f4dc9f41c98cc1c6a897800c4f85979/anitopy-2.1.1.tar.gz", hash = "sha256:515b97cd78917ee406313f4eb53bdc75e8a573e6ad5252ffd355c96a06988e26", size = 20890, upload-time = "2022-07-24T10:24:27.23Z" }
+
+[[package]]
+name = "anyio"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+]
 
 [[package]]
 name = "babelfish"
@@ -34,14 +48,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/d0/2c34c36190b741c59c901e56ab7f6e54dad8df05a6272a9747ecef7c6036/black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299", size = 1442865, upload-time = "2025-01-29T05:37:14.309Z" },
     { url = "https://files.pythonhosted.org/packages/21/d4/7518c72262468430ead45cf22bd86c883a6448b9eb43672765d69a8f1248/black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096", size = 1749699, upload-time = "2025-01-29T04:18:17.688Z" },
     { url = "https://files.pythonhosted.org/packages/58/db/4f5beb989b547f79096e035c4981ceb36ac2b552d0ac5f2620e941501c99/black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2", size = 1428028, upload-time = "2025-01-29T04:18:51.711Z" },
-    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988, upload-time = "2025-01-29T05:37:16.707Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985, upload-time = "2025-01-29T05:37:18.273Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816, upload-time = "2025-01-29T04:18:33.823Z" },
-    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860, upload-time = "2025-01-29T04:19:12.944Z" },
-    { url = "https://files.pythonhosted.org/packages/98/87/0edf98916640efa5d0696e1abb0a8357b52e69e82322628f25bf14d263d1/black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f", size = 1650673, upload-time = "2025-01-29T05:37:20.574Z" },
-    { url = "https://files.pythonhosted.org/packages/52/e5/f7bf17207cf87fa6e9b676576749c6b6ed0d70f179a3d812c997870291c3/black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3", size = 1453190, upload-time = "2025-01-29T05:37:22.106Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload-time = "2025-01-29T04:18:58.564Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload-time = "2025-01-29T04:19:27.63Z" },
     { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
 ]
 
@@ -71,39 +77,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/36/77da9c6a328c54d17b960c89eccacfab8271fdaaa228305330915b88afa9/charset_normalizer-3.4.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e8ac75d72fa3775e0b7cb7e4629cec13b7514d928d15ef8ea06bca03ef01cae", size = 151600, upload-time = "2025-08-09T07:56:04.089Z" },
     { url = "https://files.pythonhosted.org/packages/64/d4/9eb4ff2c167edbbf08cdd28e19078bf195762e9bd63371689cab5ecd3d0d/charset_normalizer-3.4.3-cp311-cp311-win32.whl", hash = "sha256:6cf8fd4c04756b6b60146d98cd8a77d0cdae0e1ca20329da2ac85eed779b6849", size = 99616, upload-time = "2025-08-09T07:56:05.658Z" },
     { url = "https://files.pythonhosted.org/packages/f4/9c/996a4a028222e7761a96634d1820de8a744ff4327a00ada9c8942033089b/charset_normalizer-3.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:31a9a6f775f9bcd865d88ee350f0ffb0e25936a7f930ca98995c05abf1faf21c", size = 107108, upload-time = "2025-08-09T07:56:07.176Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/5e/14c94999e418d9b87682734589404a25854d5f5d0408df68bc15b6ff54bb/charset_normalizer-3.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e28e334d3ff134e88989d90ba04b47d84382a828c061d0d1027b1b12a62b39b1", size = 205655, upload-time = "2025-08-09T07:56:08.475Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a8/c6ec5d389672521f644505a257f50544c074cf5fc292d5390331cd6fc9c3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cacf8f7297b0c4fcb74227692ca46b4a5852f8f4f24b3c766dd94a1075c4884", size = 146223, upload-time = "2025-08-09T07:56:09.708Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/eb/a2ffb08547f4e1e5415fb69eb7db25932c52a52bed371429648db4d84fb1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c6fd51128a41297f5409deab284fecbe5305ebd7e5a1f959bee1c054622b7018", size = 159366, upload-time = "2025-08-09T07:56:11.326Z" },
-    { url = "https://files.pythonhosted.org/packages/82/10/0fd19f20c624b278dddaf83b8464dcddc2456cb4b02bb902a6da126b87a1/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cfb2aad70f2c6debfbcb717f23b7eb55febc0bb23dcffc0f076009da10c6392", size = 157104, upload-time = "2025-08-09T07:56:13.014Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ab/0233c3231af734f5dfcf0844aa9582d5a1466c985bbed6cedab85af9bfe3/charset_normalizer-3.4.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1606f4a55c0fd363d754049cdf400175ee96c992b1f8018b993941f221221c5f", size = 151830, upload-time = "2025-08-09T07:56:14.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/02/e29e22b4e02839a0e4a06557b1999d0a47db3567e82989b5bb21f3fbbd9f/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:027b776c26d38b7f15b26a5da1044f376455fb3766df8fc38563b4efbc515154", size = 148854, upload-time = "2025-08-09T07:56:16.051Z" },
-    { url = "https://files.pythonhosted.org/packages/05/6b/e2539a0a4be302b481e8cafb5af8792da8093b486885a1ae4d15d452bcec/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:42e5088973e56e31e4fa58eb6bd709e42fc03799c11c42929592889a2e54c491", size = 160670, upload-time = "2025-08-09T07:56:17.314Z" },
-    { url = "https://files.pythonhosted.org/packages/31/e7/883ee5676a2ef217a40ce0bffcc3d0dfbf9e64cbcfbdf822c52981c3304b/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cc34f233c9e71701040d772aa7490318673aa7164a0efe3172b2981218c26d93", size = 158501, upload-time = "2025-08-09T07:56:18.641Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/35/6525b21aa0db614cf8b5792d232021dca3df7f90a1944db934efa5d20bb1/charset_normalizer-3.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:320e8e66157cc4e247d9ddca8e21f427efc7a04bbd0ac8a9faf56583fa543f9f", size = 153173, upload-time = "2025-08-09T07:56:20.289Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ee/f4704bad8201de513fdc8aac1cabc87e38c5818c93857140e06e772b5892/charset_normalizer-3.4.3-cp312-cp312-win32.whl", hash = "sha256:fb6fecfd65564f208cbf0fba07f107fb661bcd1a7c389edbced3f7a493f70e37", size = 99822, upload-time = "2025-08-09T07:56:21.551Z" },
-    { url = "https://files.pythonhosted.org/packages/39/f5/3b3836ca6064d0992c58c7561c6b6eee1b3892e9665d650c803bd5614522/charset_normalizer-3.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:86df271bf921c2ee3818f0522e9a5b8092ca2ad8b065ece5d7d9d0e9f4849bcc", size = 107543, upload-time = "2025-08-09T07:56:23.115Z" },
-    { url = "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe", size = 205326, upload-time = "2025-08-09T07:56:24.721Z" },
-    { url = "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8", size = 146008, upload-time = "2025-08-09T07:56:26.004Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9", size = 159196, upload-time = "2025-08-09T07:56:27.25Z" },
-    { url = "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31", size = 156819, upload-time = "2025-08-09T07:56:28.515Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f", size = 151350, upload-time = "2025-08-09T07:56:29.716Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927", size = 148644, upload-time = "2025-08-09T07:56:30.984Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9", size = 160468, upload-time = "2025-08-09T07:56:32.252Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5", size = 158187, upload-time = "2025-08-09T07:56:33.481Z" },
-    { url = "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc", size = 152699, upload-time = "2025-08-09T07:56:34.739Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce", size = 99580, upload-time = "2025-08-09T07:56:35.981Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef", size = 107366, upload-time = "2025-08-09T07:56:37.339Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15", size = 204342, upload-time = "2025-08-09T07:56:38.687Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db", size = 145995, upload-time = "2025-08-09T07:56:40.048Z" },
-    { url = "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d", size = 158640, upload-time = "2025-08-09T07:56:41.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096", size = 156636, upload-time = "2025-08-09T07:56:43.195Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa", size = 150939, upload-time = "2025-08-09T07:56:44.819Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049", size = 148580, upload-time = "2025-08-09T07:56:46.684Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0", size = 159870, upload-time = "2025-08-09T07:56:47.941Z" },
-    { url = "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92", size = 157797, upload-time = "2025-08-09T07:56:49.756Z" },
-    { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
     { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
 
@@ -137,6 +110,7 @@ dependencies = [
     { name = "click" },
     { name = "colorama" },
     { name = "guessit" },
+    { name = "httpx" },
     { name = "natsort" },
     { name = "requests" },
     { name = "requests-toolbelt" },
@@ -158,6 +132,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "colorama" },
     { name = "guessit" },
+    { name = "httpx" },
     { name = "natsort" },
     { name = "requests" },
     { name = "requests-toolbelt" },
@@ -185,6 +160,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d0/07/5a88020bfe2591af2ffc75841200b2c17ff52510779510346af5477e64cd/guessit-3.8.0.tar.gz", hash = "sha256:6619fcbbf9a0510ec8c2c33744c4251cad0507b1d573d05c875de17edc5edbed", size = 271285, upload-time = "2023-12-14T10:24:20.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/9b/924a8f9709c3143d4c9a301a88042cbce37e09789378217284b19d4f8132/guessit-3.8.0-py3-none-any.whl", hash = "sha256:eb5747b1d0fbca926562c1e5894dbc3f6507c35e8c0bd9e38148401cd9579d83", size = 206049, upload-time = "2023-12-14T10:24:17.753Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -423,6 +435,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add an asynchronous TMDB resolver with caching, heuristics, and manual ID support
- thread TMDB metadata through CLI templating, configuration, and documentation
- expand unit coverage for TMDB resolution, CLI wiring, and update dependencies/lock file

## Testing
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb789a8ca88321b4b784a2094b204a