### PR TITLE
Log applied trims during clip initialization

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -376,6 +376,25 @@ def _extract_clip_fps(clip: object) -> Tuple[int, int]:
     return (24000, 1001)
 
 
+def _log_plan_trim(plan: _ClipPlan) -> None:
+    raw_label = plan.metadata.get("label") or plan.path.name
+    label = escape((raw_label or plan.path.name).strip())
+
+    if plan.trim_start:
+        if plan.trim_start > 0:
+            print(f"[cyan]{label}[/]: Trimmed to start at frame {plan.trim_start}")
+        else:
+            count = abs(int(plan.trim_start))
+            print(f"[cyan]{label}[/]: {count} frame(s) appended at start")
+
+    if plan.trim_end:
+        if plan.trim_end > 0:
+            print(f"[cyan]{label}[/]: Trimmed to end at frame {plan.trim_end}")
+        else:
+            count = abs(int(plan.trim_end))
+            print(f"[cyan]{label}[/]: Trimmed to end {count} frame(s) early")
+
+
 def _init_clips(plans: Sequence[_ClipPlan], runtime_cfg, cache_dir: Path | None) -> None:
     vs_core.set_ram_limit(runtime_cfg.ram_limit_mb)
 
@@ -386,6 +405,7 @@ def _init_clips(plans: Sequence[_ClipPlan], runtime_cfg, cache_dir: Path | None)
 
     if reference_index is not None:
         plan = plans[reference_index]
+        _log_plan_trim(plan)
         clip = vs_core.init_clip(
             str(plan.path),
             trim_start=plan.trim_start,
@@ -403,6 +423,7 @@ def _init_clips(plans: Sequence[_ClipPlan], runtime_cfg, cache_dir: Path | None)
         if fps_override is None and reference_fps is not None and idx != reference_index:
             fps_override = reference_fps
 
+        _log_plan_trim(plan)
         clip = vs_core.init_clip(
             str(plan.path),
             trim_start=plan.trim_start,

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -120,6 +120,8 @@ def test_cli_applies_overrides_and_naming(tmp_path, monkeypatch, runner):
     assert result.exit_code == 0
     assert "AAA Short" in result.output
     assert "BBB Short" in result.output
+    assert "Trimmed to start at frame 5" in result.output
+    assert "Trimmed to end 12 frame(s) early" in result.output
 
     assert ram_limits == [cfg.runtime.ram_limit_mb]
 


### PR DESCRIPTION
## Summary
- log trim start and end adjustments for each clip during initialization to mirror the legacy terminal output
- extend the CLI integration test to assert the new trim logging


------
https://chatgpt.com/codex/tasks/task_e_68cb9833c0508321b168c35436887cf0