### PR TITLE
Align crop planning with legacy heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ change_fps = {}
 | `compression_level` | int | 1 | No | Compression preset: 0 (fast), 1 (balanced), 2 (small). Other values raise `ConfigError`.|
 | `upscale` | bool | true | No | Allow scaling above source height (global tallest clip by default).|
 | `single_res` | int | 0 | No | Force a specific output height (`0` keeps clip-relative planning).|
-| `mod_crop` | int | 2 | No | Crop to maintain dimensions divisible by this modulus; must be ≥0.|
-| `letterbox_pillarbox_aware` | bool | true | No | Bias cropping toward letterbox/pillarbox bars when trimming.|
+| `mod_crop` | int | 2 | No | Align every clip to the smallest width/height while keeping dimensions divisible by this modulus; must be ≥0.|
+| `letterbox_pillarbox_aware` | bool | true | No | When widths or heights already match, only crop the mismatched axis (preserves letterbox/pillarbox bars).|
 
 #### `[tonemap]`
 

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -172,41 +172,94 @@ class ScreenshotWriterError(ScreenshotError):
     """Raised when the underlying writer fails."""
 
 
-def plan_mod_crop(width: int, height: int, mod: int, letterbox_pillarbox_aware: bool) -> Tuple[int, int, int, int]:
-    """Plan left/top/right/bottom croppings so dimensions align to *mod*."""
+def _snap_pair_to_mod(first: int, second: int, total: int, mod: int) -> tuple[int, int]:
+    """Snap a crop pair to *mod* multiples without exceeding *total*."""
 
-    if width <= 0 or height <= 0:
-        raise ScreenshotGeometryError("Clip dimensions must be positive")
+    if total <= 0:
+        return (0, 0)
+
+    first = max(0, min(first, total))
     if mod <= 1:
-        return (0, 0, 0, 0)
+        return (first, max(0, total - first))
 
-    def _axis_crop(size: int) -> Tuple[int, int]:
-        remainder = size % mod
-        if remainder == 0:
-            return (0, 0)
-        before = remainder // 2
-        after = remainder - before
-        return (before, after)
+    if first % mod != 0:
+        first += mod - (first % mod)
+    first = min(first, total)
+    second = total - first
 
-    left, right = _axis_crop(width)
-    top, bottom = _axis_crop(height)
+    remainder = second % mod
+    if remainder != 0:
+        shift = remainder
+        if first - shift >= 0:
+            first -= shift
+            second += shift
+        else:
+            second += mod - remainder
 
-    if letterbox_pillarbox_aware:
-        if width > height and (top + bottom) == 0 and (left + right) > 0:
-            total = left + right
-            left = total // 2
-            right = total - left
-        elif height >= width and (left + right) == 0 and (top + bottom) > 0:
-            total = top + bottom
-            top = total // 2
-            bottom = total - top
+    first = max(0, first - (first % mod))
+    second = max(0, second - (second % mod))
 
-    cropped_w = width - left - right
-    cropped_h = height - top - bottom
-    if cropped_w <= 0 or cropped_h <= 0:
-        raise ScreenshotGeometryError("Cropping removed all pixels")
+    while first + second > total:
+        if first >= mod:
+            first -= mod
+        elif second >= mod:
+            second -= mod
+        else:
+            break
 
-    return (left, top, right, bottom)
+    first = max(0, min(first, total))
+    second = max(0, min(second, total - first))
+    return (first, second)
+
+
+def plan_mod_crop(
+    dimensions: Sequence[tuple[int, int]],
+    mod: int,
+    letterbox_pillarbox_aware: bool,
+) -> list[tuple[int, int, int, int]]:
+    """Plan per-clip crops mirroring the legacy heuristics."""
+
+    if not dimensions:
+        return []
+
+    valid = [(w, h) for w, h in dimensions if w > 0 and h > 0]
+    if not valid:
+        raise ScreenshotGeometryError("Clip dimensions must be positive")
+
+    target_w = min(w for w, _ in valid)
+    target_h = min(h for _, h in valid)
+    same_w = all(w == valid[0][0] for w, _ in valid)
+    same_h = all(h == valid[0][1] for _, h in valid)
+
+    plans: list[tuple[int, int, int, int]] = []
+    for width, height in dimensions:
+        if width <= 0 or height <= 0:
+            raise ScreenshotGeometryError("Clip dimensions must be positive")
+
+        wdiff = max(0, width - target_w)
+        hdiff = max(0, height - target_h)
+
+        if letterbox_pillarbox_aware and same_w and not same_h:
+            left = right = 0
+            top = hdiff // 2
+            bottom = hdiff - top
+            top, bottom = _snap_pair_to_mod(top, bottom, hdiff, mod)
+        elif letterbox_pillarbox_aware and same_h and not same_w:
+            top = bottom = 0
+            left = wdiff // 2
+            right = wdiff - left
+            left, right = _snap_pair_to_mod(left, right, wdiff, mod)
+        else:
+            left = wdiff // 2
+            right = wdiff - left
+            top = hdiff // 2
+            bottom = hdiff - top
+            left, right = _snap_pair_to_mod(left, right, wdiff, mod)
+            top, bottom = _snap_pair_to_mod(top, bottom, hdiff, mod)
+
+        plans.append((left, top, right, bottom))
+
+    return plans
 
 
 def _compute_scaled_dimensions(
@@ -228,14 +281,21 @@ def _compute_scaled_dimensions(
 
 
 def _plan_geometry(clips: Sequence[object], cfg: ScreenshotConfig) -> List[dict[str, object]]:
-    plans: List[dict[str, object]] = []
+    dimensions: list[tuple[int, int]] = []
     for clip in clips:
         width = getattr(clip, "width", None)
         height = getattr(clip, "height", None)
         if not isinstance(width, int) or not isinstance(height, int):
             raise ScreenshotGeometryError("Clip missing width/height metadata")
+        if width <= 0 or height <= 0:
+            raise ScreenshotGeometryError("Clip dimensions must be positive")
 
-        crop = plan_mod_crop(width, height, cfg.mod_crop, cfg.letterbox_pillarbox_aware)
+        dimensions.append((width, height))
+
+    crops = plan_mod_crop(dimensions, cfg.mod_crop, cfg.letterbox_pillarbox_aware)
+
+    plans: List[dict[str, object]] = []
+    for (width, height), crop in zip(dimensions, crops):
         cropped_w = width - crop[0] - crop[2]
         cropped_h = height - crop[1] - crop[3]
         if cropped_w <= 0 or cropped_h <= 0:

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -28,12 +28,46 @@ def test_sanitise_label_falls_back_when_blank():
 
 
 def test_plan_mod_crop_modulus():
-    left, top, right, bottom = screenshot.plan_mod_crop(1919, 1079, mod=4, letterbox_pillarbox_aware=True)
-    new_w = 1919 - left - right
-    new_h = 1079 - top - bottom
+    crops = screenshot.plan_mod_crop(
+        [(1924, 1080), (1920, 1080)],
+        mod=4,
+        letterbox_pillarbox_aware=True,
+    )
+    left, top, right, bottom = crops[0]
+    new_w = 1924 - left - right
+    new_h = 1080 - top - bottom
     assert new_w % 4 == 0
     assert new_h % 4 == 0
-    assert new_w > 0 and new_h > 0
+    assert new_w == 1920
+    assert crops[1] == (0, 0, 0, 0)
+
+
+def test_plan_mod_crop_letterbox_bias():
+    crops = screenshot.plan_mod_crop(
+        [(1920, 1080), (1920, 800)],
+        mod=2,
+        letterbox_pillarbox_aware=True,
+    )
+    assert crops[0] == (0, 140, 0, 140)
+    assert crops[1] == (0, 0, 0, 0)
+
+
+def test_plan_mod_crop_pillarbox_bias():
+    crops = screenshot.plan_mod_crop(
+        [(1280, 720), (1920, 720)],
+        mod=2,
+        letterbox_pillarbox_aware=True,
+    )
+    assert crops[0] == (0, 0, 0, 0)
+    assert crops[1] == (320, 0, 320, 0)
+
+
+def test_plan_mod_crop_aligns_to_smallest_dimensions():
+    dims = [(1920, 1080), (1280, 720)]
+    crops = screenshot.plan_mod_crop(dims, mod=2, letterbox_pillarbox_aware=False)
+    left, top, right, bottom = crops[0]
+    assert (1920 - left - right, 1080 - top - bottom) == (1280, 720)
+    assert crops[1] == (0, 0, 0, 0)
 
 
 def test_generate_screenshots_filenames(tmp_path, monkeypatch):
@@ -144,7 +178,7 @@ def test_global_upscale_coordination(tmp_path, monkeypatch):
         trim_offsets=[0, 0, 0],
     )
 
-    assert scaled == [(1920, 1080), (1920, 1080), (1440, 1080)]
+    assert scaled == [(640, 480), (640, 480), (640, 480)]
 
 
 def test_placeholder_logging(tmp_path, caplog, monkeypatch):


### PR DESCRIPTION
## Summary
- port the crop planner to use legacy heuristics that consider all clips and snap crops to the configured modulus
- update geometry planning to use the shared crop plan and refresh README guidance on the screenshot options
- expand unit coverage for the new crop behaviors and adjust scaling expectations accordingly

## Testing
- uv run python -m pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68cc367273dc832194b31b1dfcd3951c