### PR TITLE
Fix screenshot overlay debug helpers and tonemap range props

### DIFF
--- a/src/tonemap/core.py
+++ b/src/tonemap/core.py
@@ -394,5 +394,5 @@ def apply_tonemap(clip: Any, cfg: TMConfig, *, force: bool = False) -> TonemapRe
     output = _stamp_tonemap_metadata(output, resolved_cfg, backend=backend)
     if resolved_cfg.overlay:
         output = apply_overlay(output, resolved_cfg)
-    output = _set_sdr_props(output, color_range=target_range)
+    output = _set_sdr_props(output, color_range=target_range_value)
     return TonemapResult(output, fallback_clip, used_libplacebo, hdr_detected)


### PR DESCRIPTION
## Summary
- add a `_debug_dump_range` helper so frame debug logging no longer raises at runtime
- resolve the missing VapourSynth `Point` resizer lookup before drawing frame overlays
- set SDR frame props using the resolved target range value so tonemapping no longer raises a `NameError`

## Testing
- uv sync --frozen
- uv run python -c "import sys; print(sys.version); print(sys.executable)"
- uv run python - <<'PY'
import importlib.util as u
spec = u.find_spec('vapoursynth')
print('vapoursynth spec:', spec)
try:
    import vapoursynth as vs
    print('vapoursynth OK:', vs.__version__)
except Exception as e:
    print('vapoursynth import error:', e)
PY *(fails: `No module named 'vapoursynth'` in this environment)*
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cda3f8912c8321bf75bec34ab59c88