### PR TITLE
Clean TMDB test imports

### DIFF
--- a/config.toml.template
+++ b/config.toml.template
@@ -71,6 +71,15 @@ open_in_browser = true
 create_url_shortcut = true
 delete_screen_dir_after_upload = true
 
+[tmdb]
+# TMDB lookup automation. Provide an API key to enable matching.
+api_key = ""
+unattended = true
+year_tolerance = 2
+enable_anime_parsing = true
+cache_ttl_seconds = 86400
+category_preference = ""
+
 [naming]
 # Controls how GuessIt/Anitopy metadata is turned into labels.
 always_full_filename = true

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import builtins
+import logging
 import re
 import sys
 import shutil
@@ -9,6 +11,7 @@ import traceback
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+from string import Template
 import time
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
@@ -30,6 +33,16 @@ from src.analysis import (
 )
 from src.screenshot import generate_screenshots, ScreenshotError
 from src.slowpics import SlowpicsAPIError, upload_comparison
+from src.tmdb import (
+    TMDBAmbiguityError,
+    TMDBCandidate,
+    TMDBResolution,
+    TMDBResolutionError,
+    parse_manual_id,
+    resolve_tmdb,
+)
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_EXTS = (
     ".mkv",
@@ -162,6 +175,56 @@ def _dedupe_labels(
     for idx, meta in enumerate(metadata):
         if not (meta.get("label") or "").strip():
             meta["label"] = files[idx].name
+
+
+def _first_non_empty(metadata: Sequence[Dict[str, str]], key: str) -> str:
+    for meta in metadata:
+        value = meta.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _parse_year_hint(value: str) -> Optional[int]:
+    try:
+        year = int(value)
+    except (TypeError, ValueError):
+        return None
+    if 1900 <= year <= 2100:
+        return year
+    return None
+
+
+def _prompt_manual_tmdb(candidates: Sequence[TMDBCandidate]) -> tuple[str, str] | None:
+    print("[yellow]TMDB search returned multiple plausible matches:[/yellow]")
+    for cand in candidates:
+        year = cand.year or "????"
+        print(
+            f"  • [cyan]{cand.category.lower()}/{cand.tmdb_id}[/cyan] "
+            f"{cand.title or '(unknown title)'} ({year}) score={cand.score:0.3f}"
+        )
+    while True:
+        response = click.prompt(
+            "Enter TMDB id (movie/##### or tv/#####) or leave blank to skip",
+            default="",
+            show_default=False,
+        ).strip()
+        if not response:
+            return None
+        try:
+            return parse_manual_id(response)
+        except TMDBResolutionError as exc:
+            print(f"[red]Invalid TMDB identifier:[/red] {exc}")
+
+
+def _render_collection_name(template_text: str, context: Mapping[str, str]) -> str:
+    if "${" not in template_text:
+        return template_text
+    try:
+        template = Template(template_text)
+        return template.safe_substitute(context)
+    except Exception:
+        return template_text
 
 
 def _estimate_analysis_time(file: Path, cache_dir: Path | None) -> float:
@@ -514,6 +577,127 @@ def run_cli(config_path: str, input_dir: str | None = None) -> RunResult:
         )
 
     metadata = _parse_metadata(files, cfg.naming)
+    year_hint_raw = _first_non_empty(metadata, "year")
+    metadata_title = _first_non_empty(metadata, "title") or _first_non_empty(metadata, "anime_title")
+    tmdb_resolution: TMDBResolution | None = None
+    manual_tmdb: tuple[str, str] | None = None
+    tmdb_category: Optional[str] = None
+    tmdb_id_value: Optional[str] = None
+    tmdb_language: Optional[str] = None
+    tmdb_error_message: Optional[str] = None
+    tmdb_ambiguous = False
+    tmdb_api_key_present = bool(cfg.tmdb.api_key.strip())
+
+    if tmdb_api_key_present:
+        base_file = files[0]
+        imdb_hint = _first_non_empty(metadata, "imdb_id").lower()
+        tvdb_hint = _first_non_empty(metadata, "tvdb_id")
+        year_hint = _parse_year_hint(year_hint_raw)
+        try:
+            tmdb_resolution = asyncio.run(
+                resolve_tmdb(
+                    base_file.name,
+                    config=cfg.tmdb,
+                    year=year_hint,
+                    imdb_id=imdb_hint or None,
+                    tvdb_id=tvdb_hint or None,
+                    unattended=cfg.tmdb.unattended,
+                    category_preference=cfg.tmdb.category_preference,
+                )
+            )
+        except TMDBAmbiguityError as exc:
+            tmdb_ambiguous = True
+            manual_tmdb = _prompt_manual_tmdb(exc.candidates)
+        except TMDBResolutionError as exc:
+            logger.warning("TMDB lookup failed for %s: %s", base_file.name, exc)
+            tmdb_error_message = str(exc)
+        else:
+            if tmdb_resolution is not None:
+                tmdb_category = tmdb_resolution.category
+                tmdb_id_value = tmdb_resolution.tmdb_id
+                tmdb_language = tmdb_resolution.original_language
+
+    if manual_tmdb:
+        tmdb_category, tmdb_id_value = manual_tmdb
+        tmdb_language = None
+        tmdb_resolution = None
+        logger.info("TMDB manual override selected: %s/%s", tmdb_category, tmdb_id_value)
+
+    tmdb_context: Dict[str, str] = {
+        "Title": metadata_title or (metadata[0].get("label") if metadata else ""),
+        "OriginalTitle": "",
+        "Year": year_hint_raw or "",
+        "TMDBId": tmdb_id_value or "",
+        "TMDBCategory": tmdb_category or "",
+        "OriginalLanguage": tmdb_language or "",
+        "Filename": files[0].stem,
+        "FileName": files[0].name,
+        "Label": metadata[0].get("label") if metadata else files[0].name,
+    }
+
+    if tmdb_resolution is not None:
+        if tmdb_resolution.title:
+            tmdb_context["Title"] = tmdb_resolution.title
+        if tmdb_resolution.original_title:
+            tmdb_context["OriginalTitle"] = tmdb_resolution.original_title
+        if tmdb_resolution.year is not None:
+            tmdb_context["Year"] = str(tmdb_resolution.year)
+        if tmdb_resolution.original_language:
+            tmdb_context["OriginalLanguage"] = tmdb_resolution.original_language
+        tmdb_category = tmdb_category or tmdb_resolution.category
+        tmdb_id_value = tmdb_id_value or tmdb_resolution.tmdb_id
+
+    if tmdb_id_value and not (cfg.slowpics.tmdb_id or "").strip():
+        cfg.slowpics.tmdb_id = str(tmdb_id_value)
+
+    collection_template = (cfg.slowpics.collection_name or "").strip()
+    if collection_template:
+        rendered_collection = _render_collection_name(collection_template, tmdb_context).strip()
+        cfg.slowpics.collection_name = rendered_collection or "Frame Comparison"
+    else:
+        derived_title = (tmdb_context.get("Title") or "").strip() or files[0].stem
+        derived_year = (tmdb_context.get("Year") or "").strip()
+        collection_name = derived_title
+        if derived_title and derived_year:
+            collection_name = f"{derived_title} ({derived_year})"
+        cfg.slowpics.collection_name = collection_name or "Frame Comparison"
+
+    if tmdb_resolution is not None:
+        match_title = tmdb_resolution.title or tmdb_context.get("Title") or files[0].stem
+        year_text = f" ({tmdb_resolution.year})" if tmdb_resolution.year else ""
+        lang_text = tmdb_resolution.original_language or "unknown"
+        heuristic = (tmdb_resolution.candidate.reason or "match").replace("_", " ").replace("-", " ")
+        source = "filename" if tmdb_resolution.candidate.used_filename_search else "external id"
+        print(
+            "[cyan]TMDB match:[/cyan] "
+            f"{match_title}{year_text} "
+            f"[{tmdb_resolution.category}] -> {tmdb_resolution.tmdb_id} "
+            f"({source}, {heuristic.strip()}) lang={lang_text}"
+        )
+    elif manual_tmdb:
+        display_title = tmdb_context.get("Title") or files[0].stem
+        print(
+            "[cyan]TMDB manual override:[/cyan] "
+            f"{tmdb_category}/{tmdb_id_value} for {display_title}"
+        )
+    elif tmdb_api_key_present:
+        if tmdb_error_message:
+            print(f"[yellow]TMDB lookup failed:[/yellow] {tmdb_error_message}")
+        elif tmdb_ambiguous:
+            print(
+                "[yellow]TMDB: ambiguous results for[/yellow] "
+                f"{files[0].name}; continuing without metadata."
+            )
+        else:
+            print(
+                "[yellow]TMDB: no confident match for[/yellow] "
+                f"{files[0].name}; continuing without metadata."
+            )
+    elif not (cfg.slowpics.tmdb_id or "").strip():
+        print(
+            "[yellow]TMDB disabled:[/yellow] set [tmdb].api_key in config.toml to enable automatic matching."
+        )
+
     labels = [meta.get("label") or file.name for meta, file in zip(metadata, files)]
     print("[green]Files detected:[/green]")
     for label, file in zip(labels, files):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "colorama",
     "requests",
     "requests-toolbelt",
+    "httpx",
     "natsort",
     "anitopy",
     "guessit",

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -12,12 +12,13 @@ from .datatypes import (
     AnalysisConfig,
     ColorConfig,
     NamingConfig,
-    ScreenshotConfig,
-    SlowpicsConfig,
+    OverridesConfig,
     PathsConfig,
     RuntimeConfig,
-    OverridesConfig,
+    ScreenshotConfig,
+    SlowpicsConfig,
     SourceConfig,
+    TMDBConfig,
 )
 
 
@@ -93,6 +94,7 @@ def load_config(path: str) -> AppConfig:
         analysis=_sanitize_section(raw.get("analysis", {}), "analysis", AnalysisConfig),
         screenshots=_sanitize_section(raw.get("screenshots", {}), "screenshots", ScreenshotConfig),
         slowpics=_sanitize_section(raw.get("slowpics", {}), "slowpics", SlowpicsConfig),
+        tmdb=_sanitize_section(raw.get("tmdb", {}), "tmdb", TMDBConfig),
         naming=_sanitize_section(raw.get("naming", {}), "naming", NamingConfig),
         paths=_sanitize_section(raw.get("paths", {}), "paths", PathsConfig),
         runtime=_sanitize_section(raw.get("runtime", {}), "runtime", RuntimeConfig),
@@ -127,6 +129,16 @@ def load_config(path: str) -> AppConfig:
 
     if app.slowpics.remove_after_days < 0:
         raise ConfigError("slowpics.remove_after_days must be >= 0")
+
+    if app.tmdb.year_tolerance < 0:
+        raise ConfigError("tmdb.year_tolerance must be >= 0")
+    if app.tmdb.cache_ttl_seconds < 0:
+        raise ConfigError("tmdb.cache_ttl_seconds must be >= 0")
+    if app.tmdb.category_preference is not None:
+        preference = app.tmdb.category_preference.strip().upper()
+        if preference not in {"", "MOVIE", "TV"}:
+            raise ConfigError("tmdb.category_preference must be MOVIE, TV, or omitted")
+        app.tmdb.category_preference = preference or None
 
     if app.runtime.ram_limit_mb <= 0:
         raise ConfigError("runtime.ram_limit_mb must be > 0")

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -86,6 +86,18 @@ class SlowpicsConfig:
 
 
 @dataclass
+class TMDBConfig:
+    """Configuration controlling TMDB lookup and caching behaviour."""
+
+    api_key: str = ""
+    unattended: bool = True
+    year_tolerance: int = 2
+    enable_anime_parsing: bool = True
+    cache_ttl_seconds: int = 86400
+    category_preference: Optional[str] = None
+
+
+@dataclass
 class NamingConfig:
     """Filename parsing and display preferences."""
 
@@ -131,6 +143,7 @@ class AppConfig:
     analysis: AnalysisConfig
     screenshots: ScreenshotConfig
     slowpics: SlowpicsConfig
+    tmdb: TMDBConfig
     naming: NamingConfig
     paths: PathsConfig
     runtime: RuntimeConfig

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -1,0 +1,798 @@
+from __future__ import annotations
+
+"""Helpers for resolving TMDB metadata from filenames or external IDs."""
+
+import asyncio
+import logging
+import re
+import time
+import unicodedata
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import httpx
+
+from .datatypes import TMDBConfig
+
+logger = logging.getLogger(__name__)
+
+MOVIE = "MOVIE"
+TV = "TV"
+_BASE_URL = "https://api.themoviedb.org/3"
+_SIMILARITY_THRESHOLD = 0.45
+_STRONG_MATCH_THRESHOLD = 0.92
+_AMBIGUITY_MARGIN = 0.08
+
+_NON_WORD_RE = re.compile(r"[^0-9a-zA-Z\s]+", re.UNICODE)
+_WHITESPACE_RE = re.compile(r"\s+")
+_ROMAN_RE = re.compile(r"\b([IVXLCDM]+)\b", re.IGNORECASE)
+_YEAR_RE = re.compile(r"(19|20)\d{2}")
+_IMDB_RE = re.compile(r"tt\d{7,9}", re.IGNORECASE)
+
+
+class TMDBResolutionError(RuntimeError):
+    """Raised when TMDB matching cannot complete."""
+
+
+class TMDBAmbiguityError(TMDBResolutionError):
+    """Raised when multiple TMDB results look equally plausible."""
+
+    def __init__(self, candidates: Sequence["TMDBCandidate"]) -> None:
+        self.candidates = list(candidates)
+        pretty = ", ".join(
+            f"{cand.category.lower()}/{cand.tmdb_id} ({cand.title} – {cand.year or '????'} score={cand.score:0.3f})"
+            for cand in self.candidates
+        )
+        super().__init__(f"Ambiguous TMDB match candidates: {pretty}")
+
+
+@dataclass
+class TMDBCandidate:
+    """Represents a TMDB search or lookup hit."""
+
+    category: str
+    tmdb_id: str
+    title: str
+    original_title: Optional[str]
+    year: Optional[int]
+    score: float
+    original_language: Optional[str]
+    reason: str
+    used_filename_search: bool
+    payload: Dict[str, Any]
+
+
+@dataclass
+class TMDBResolution:
+    """Final TMDB resolution result."""
+
+    candidate: TMDBCandidate
+    margin: float
+    source_query: str
+
+    def __iter__(self):  # pragma: no cover - convenience for tuple unpacking
+        yield self.candidate.category
+        yield self.candidate.tmdb_id
+        yield self.candidate.original_language
+        yield self.candidate.used_filename_search
+
+    @property
+    def category(self) -> str:
+        return self.candidate.category
+
+    @property
+    def tmdb_id(self) -> str:
+        return self.candidate.tmdb_id
+
+    @property
+    def title(self) -> str:
+        return self.candidate.title
+
+    @property
+    def original_title(self) -> Optional[str]:
+        return self.candidate.original_title
+
+    @property
+    def year(self) -> Optional[int]:
+        return self.candidate.year
+
+    @property
+    def original_language(self) -> Optional[str]:
+        return self.candidate.original_language
+
+
+class _TTLCache:
+    """Simple TTL cache shared across TMDB requests."""
+
+    def __init__(self) -> None:
+        self._data: Dict[Tuple[Any, ...], Tuple[float, Any]] = {}
+
+    def get(self, key: Tuple[Any, ...], ttl_seconds: int) -> Any | None:
+        entry = self._data.get(key)
+        if not entry:
+            return None
+        timestamp, value = entry
+        if ttl_seconds <= 0:
+            return None
+        if time.monotonic() - timestamp > ttl_seconds:
+            self._data.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: Tuple[Any, ...], value: Any) -> None:
+        self._data[key] = (time.monotonic(), value)
+
+
+_CACHE = _TTLCache()
+
+
+def parse_manual_id(value: str) -> Tuple[str, str]:
+    """Validate a manual TMDB identifier (movie/12345 or tv/67890)."""
+
+    text = value.strip().lower()
+    if not text:
+        raise TMDBResolutionError("Manual TMDB identifier cannot be empty")
+    if text.isdigit():
+        raise TMDBResolutionError(
+            "Manual TMDB identifier must include a category prefix (movie/ or tv/)."
+        )
+    match = re.match(r"^(movie|tv)[/:-]?(\d+)$", text)
+    if not match:
+        raise TMDBResolutionError(
+            "Manual TMDB identifier must look like movie/12345 or tv/67890"
+        )
+    category = MOVIE if match.group(1) == "movie" else TV
+    tmdb_id = match.group(2)
+    return category, tmdb_id
+
+
+def _normalize_title(title: str) -> str:
+    text = unicodedata.normalize("NFKC", title or "")
+    text = text.replace("&", " and ")
+    text = _NON_WORD_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text)
+    return text.strip().lower()
+
+
+def _normalized_variants(title: str) -> List[str]:
+    base = _normalize_title(title)
+    variants = {base}
+    if base.startswith("the "):
+        variants.add(base[4:])
+    return [variant for variant in variants if variant]
+
+
+def _similarity(left: str, right: str) -> float:
+    if not left or not right:
+        return 0.0
+    if left == right:
+        return 1.0
+    shorter, longer = (left, right) if len(left) <= len(right) else (right, left)
+    if not shorter:
+        return 0.0
+    matches = 0
+    j = 0
+    for ch in shorter:
+        idx = longer.find(ch, j)
+        if idx == -1:
+            continue
+        matches += 1
+        j = idx + 1
+    return matches / max(1, len(longer))
+
+
+def _roman_to_int(text: str) -> Optional[int]:
+    values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+    result = 0
+    prev = 0
+    for char in text.upper():
+        value = values.get(char)
+        if value is None:
+            return None
+        if value > prev:
+            result += value - 2 * prev
+        else:
+            result += value
+        prev = value
+    return result if result > 0 else None
+
+
+def _convert_roman_suffix(title: str) -> Optional[str]:
+    match = _ROMAN_RE.search(title)
+    if not match:
+        return None
+    numeral = match.group(1)
+    converted = _roman_to_int(numeral)
+    if not converted or converted <= 1:
+        return None
+    return f"{title[:match.start(1)]}{converted}{title[match.end(1):]}"
+
+
+def _primary_title(title: str) -> Optional[str]:
+    for delimiter in (":", " - ", " (", " – "):
+        if delimiter in title:
+            candidate = title.split(delimiter, 1)[0].strip()
+            if candidate and candidate != title:
+                return candidate
+    return None
+
+
+def _reduced_words(title: str) -> Optional[str]:
+    words = re.findall(r"[A-Za-z0-9']+", title)
+    filtered = [word for word in words if len(word) > 2]
+    if filtered and filtered != words:
+        return " ".join(filtered)
+    return None
+
+
+def _strip_filename_noise(filename: str) -> str:
+    stem = filename.rsplit(".", 1)[0]
+    stem = re.sub(r"^\[[^]]+\]", "", stem)
+    stem = re.sub(r"[\[\]{}()]", " ", stem)
+    stem = stem.replace("_", " ")
+    stem = re.sub(
+        r"\b(480p|576p|720p|1080p|2160p|4320p|x264|h264|hevc|x265|av1|hdr|sdr|remux|webrip|web-dl|bluray|blu-ray|dvdrip|multi|10bit|proper|repack|extended|uhd|nf|amzn)\b",
+        "",
+        stem,
+        flags=re.IGNORECASE,
+    )
+    stem = _WHITESPACE_RE.sub(" ", stem)
+    return stem.strip()
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_year_from_date(date_text: str) -> Optional[int]:
+    if not date_text:
+        return None
+    match = _YEAR_RE.search(date_text)
+    if match:
+        return int(match.group(0))
+    return None
+
+
+def _extract_year_from_result(payload: Dict[str, Any], category: str) -> Optional[int]:
+    if category == MOVIE:
+        return _extract_year_from_date(payload.get("release_date", ""))
+    return _extract_year_from_date(payload.get("first_air_date", ""))
+
+
+def _call_guessit(filename: str) -> Dict[str, Any]:
+    try:
+        module = import_module("guessit")
+    except Exception:
+        return {}
+    parser = getattr(module, "guessit", None)
+    if not callable(parser):
+        return {}
+    try:
+        result = parser(filename)
+    except Exception:
+        return {}
+    if isinstance(result, dict):
+        return dict(result)
+    return {}
+
+
+def _call_anitopy(filename: str) -> Dict[str, Any]:
+    try:
+        module = import_module("anitopy")
+    except Exception:
+        return {}
+    parser = getattr(module, "parse", None)
+    if not callable(parser):
+        return {}
+    try:
+        result = parser(filename)
+    except Exception:
+        return {}
+    if isinstance(result, dict):
+        return dict(result)
+    return {}
+
+
+@dataclass(frozen=True)
+class _QueryPlan:
+    query: str
+    year: Optional[int]
+    category: str
+    reason: str
+
+
+def _build_query_plans(
+    base_title: str,
+    *,
+    year: Optional[int],
+    category_hint: Optional[str],
+    category_preference: Optional[str],
+    anime_titles: Sequence[str],
+    year_tolerance: int,
+) -> List[_QueryPlan]:
+    queries: List[_QueryPlan] = []
+    seen: set[Tuple[str, Optional[int], str]] = set()
+
+    def add(query: str, year_val: Optional[int], category: str, reason: str) -> None:
+        key = (query.lower(), year_val, category)
+        if not query.strip():
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        queries.append(_QueryPlan(query=query.strip(), year=year_val, category=category, reason=reason))
+
+    categories: List[str] = []
+    for preferred in (category_preference, category_hint, MOVIE, TV):
+        if preferred and preferred not in categories:
+            categories.append(preferred)
+
+    all_titles = [base_title]
+    for alt in anime_titles:
+        if alt and alt not in all_titles:
+            all_titles.append(alt)
+
+    for category in categories:
+        for title in all_titles:
+            add(title, year, category, "primary-title")
+            roman = _convert_roman_suffix(title)
+            if roman and roman != title:
+                add(roman, year, category, "roman-numeral")
+            primary = _primary_title(title)
+            if primary and primary != title:
+                add(primary, year, category, "secondary-title")
+            reduced = _reduced_words(title)
+            if reduced and reduced != title:
+                add(reduced, year, category, "reduced-words")
+
+    if year is not None and year_tolerance > 0:
+        deltas = {delta for delta in range(-year_tolerance, year_tolerance + 1) if delta}
+        for plan in list(queries):
+            for delta in sorted(deltas):
+                add(plan.query, year + delta, plan.category, f"year-adjust {delta:+d}")
+
+    return queries
+
+
+async def _http_request(
+    client: httpx.AsyncClient,
+    *,
+    cache_ttl: int,
+    path: str,
+    params: Dict[str, Any],
+) -> Dict[str, Any]:
+    key = (path, tuple(sorted(params.items())))
+    cached = _CACHE.get(key, cache_ttl)
+    if cached is not None:
+        return cached
+
+    backoff = 0.5
+    last_error: Exception | None = None
+    for attempt in range(4):
+        try:
+            response = await client.get(path, params=params)
+        except httpx.RequestError as exc:  # pragma: no cover - rare network error
+            last_error = exc
+        else:
+            status = response.status_code
+            if status >= 500 or status == 429:
+                retry_after = response.headers.get("Retry-After")
+                try:
+                    delay = float(retry_after) if retry_after else backoff
+                except ValueError:
+                    delay = backoff
+                await asyncio.sleep(max(0.1, min(delay, 4.0)))
+                backoff = min(backoff * 2, 4.0)
+                continue
+            if status >= 400:
+                raise TMDBResolutionError(
+                    f"TMDB request failed for {path} (status={status}): {response.text[:200]}"
+                )
+            try:
+                payload = response.json()
+            except ValueError as exc:  # pragma: no cover - unexpected
+                raise TMDBResolutionError("TMDB returned invalid JSON") from exc
+            _CACHE.set(key, payload)
+            return payload
+        await asyncio.sleep(backoff)
+        backoff = min(backoff * 2, 4.0)
+    if last_error:
+        raise TMDBResolutionError(f"TMDB request failed after retries: {last_error}")
+    raise TMDBResolutionError("TMDB request failed after retries")
+
+
+def _title_candidates(payload: Dict[str, Any]) -> List[str]:
+    keys = ["title", "name", "original_title", "original_name"]
+    values: List[str] = []
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            values.append(value)
+    seen: set[str] = set()
+    unique: List[str] = []
+    for title in values:
+        normalized = title.lower()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(title)
+    return unique
+
+
+def _score_payload(
+    payload: Dict[str, Any],
+    *,
+    category: str,
+    query_norms: Sequence[str],
+    year: Optional[int],
+    tolerance: int,
+    index: int,
+) -> float:
+    titles = _title_candidates(payload)
+    title_norms = [_normalize_title(title) for title in titles]
+    best = 0.0
+    for query_norm in query_norms:
+        for title_norm in title_norms:
+            sim = _similarity(query_norm, title_norm)
+            if title_norm == query_norm and sim < 1.0:
+                sim = max(sim, 0.99)
+            best = max(best, sim)
+    if not titles:
+        best *= 0.8
+
+    if category == TV and index == 0:
+        best += 0.01
+
+    candidate_year = _extract_year_from_result(payload, category)
+    if year is not None:
+        if candidate_year is None:
+            best -= 0.05
+        else:
+            diff = abs(candidate_year - year)
+            if diff <= tolerance:
+                best += 0.05 * (tolerance - diff + 1)
+            else:
+                best -= min(0.4 + (0.05 * (diff - tolerance)), 0.7)
+    popularity = payload.get("popularity")
+    try:
+        popularity_value = float(popularity)
+    except (TypeError, ValueError):
+        popularity_value = 0.0
+    if popularity_value > 0:
+        best += min(popularity_value / 200.0, 0.05)
+
+    return best
+
+
+def _best_external_candidate(
+    payload: Dict[str, Any],
+    *,
+    category_preference: Optional[str],
+    category_hint: Optional[str],
+    query_norms: Sequence[str],
+    year: Optional[int],
+    tolerance: int,
+) -> Optional[TMDBCandidate]:
+    candidates: List[TMDBCandidate] = []
+    for category, key in ((MOVIE, "movie_results"), (TV, "tv_results")):
+        for item in payload.get(key, []) or []:
+            score = _score_payload(
+                item,
+                category=category,
+                query_norms=query_norms,
+                year=year,
+                tolerance=tolerance,
+                index=0,
+            )
+            candidate = TMDBCandidate(
+                category=category,
+                tmdb_id=str(item.get("id")),
+                title=item.get("title") or item.get("name") or "",
+                original_title=item.get("original_title") or item.get("original_name"),
+                year=_extract_year_from_result(item, category),
+                score=score,
+                original_language=item.get("original_language"),
+                reason="external-id",
+                used_filename_search=False,
+                payload=item,
+            )
+            candidates.append(candidate)
+
+    if not candidates:
+        return None
+
+    def _preferred(category: str) -> int:
+        if category_preference == category:
+            return 0
+        if category_hint == category:
+            return 1
+        return 2
+
+    candidates.sort(key=lambda cand: (_preferred(cand.category), -cand.score))
+    return candidates[0]
+
+
+async def _perform_search(
+    client: httpx.AsyncClient,
+    *,
+    plan: _QueryPlan,
+    cache_ttl: int,
+) -> List[Dict[str, Any]]:
+    params: Dict[str, Any] = {
+        "query": plan.query,
+        "include_adult": "false",
+    }
+    if plan.year is not None:
+        if plan.category == MOVIE:
+            params["year"] = plan.year
+        else:
+            params["first_air_date_year"] = plan.year
+    payload = await _http_request(
+        client,
+        cache_ttl=cache_ttl,
+        path="search/movie" if plan.category == MOVIE else "search/tv",
+        params=params,
+    )
+    results = payload.get("results", [])
+    return list(results) if isinstance(results, list) else []
+
+
+def _extract_best_candidate(
+    *,
+    results: List[Dict[str, Any]],
+    plan: _QueryPlan,
+    query_norms: Sequence[str],
+    tolerance: int,
+    year: Optional[int],
+) -> List[TMDBCandidate]:
+    candidates: List[TMDBCandidate] = []
+    for index, item in enumerate(results):
+        score = _score_payload(
+            item,
+            category=plan.category,
+            query_norms=query_norms,
+            year=plan.year if plan.reason.startswith("year-adjust") else year,
+            tolerance=tolerance,
+            index=index,
+        )
+        candidate = TMDBCandidate(
+            category=plan.category,
+            tmdb_id=str(item.get("id")),
+            title=item.get("title") or item.get("name") or "",
+            original_title=item.get("original_title") or item.get("original_name"),
+            year=_extract_year_from_result(item, plan.category),
+            score=score,
+            original_language=item.get("original_language"),
+            reason=plan.reason,
+            used_filename_search=True,
+            payload=item,
+        )
+        candidates.append(candidate)
+    return candidates
+
+
+def _extract_title_year(filename: str, *, enable_anime: bool) -> Tuple[str, Optional[int], Optional[str], List[str]]:
+    guess = _call_guessit(filename)
+    title = guess.get("title") if isinstance(guess, dict) else ""
+    title_str = str(title or "").strip()
+    year = guess.get("year") if isinstance(guess, dict) else None
+    year_int = _safe_int(year)
+
+    type_hint_raw = str(guess.get("type") or "") if isinstance(guess, dict) else ""
+    category_hint: Optional[str] = None
+    if type_hint_raw.lower() in {"episode", "season", "tv", "series"}:
+        category_hint = TV
+    elif type_hint_raw.lower() == "movie":
+        category_hint = MOVIE
+
+    anime_titles: List[str] = []
+    if enable_anime:
+        ani = _call_anitopy(filename)
+        ani_title = ani.get("anime_title") or ani.get("title") if isinstance(ani, dict) else None
+        if ani_title:
+            ani_title_str = str(ani_title).strip()
+            if ani_title_str and ani_title_str.lower() != title_str.lower():
+                anime_titles.append(ani_title_str)
+        romaji = ani.get("anime_title_romaji") if isinstance(ani, dict) else None
+        if romaji:
+            romaji_str = str(romaji).strip()
+            if romaji_str and romaji_str.lower() not in {t.lower() for t in anime_titles}:
+                anime_titles.append(romaji_str)
+
+    cleaned = title_str or _strip_filename_noise(filename)
+    if not cleaned:
+        cleaned = filename
+    return cleaned, year_int, category_hint, anime_titles
+
+
+def _detect_external_ids(filename: str) -> Tuple[Optional[str], Optional[str]]:
+    imdb = None
+    match = _IMDB_RE.search(filename)
+    if match:
+        imdb = match.group(0)
+    return imdb, None
+
+
+async def resolve_tmdb(
+    filename: str,
+    *,
+    config: TMDBConfig,
+    year: Optional[int] = None,
+    imdb_id: Optional[str] = None,
+    tvdb_id: Optional[str] = None,
+    unattended: Optional[bool] = None,
+    category_preference: Optional[str] = None,
+    http_transport: httpx.BaseTransport | None = None,
+) -> Optional[TMDBResolution]:
+    """Resolve TMDB metadata for *filename* using the provided *config*."""
+
+    if not config.api_key:
+        raise TMDBResolutionError("tmdb.api_key must be set to resolve TMDB metadata")
+
+    unattended_mode = config.unattended if unattended is None else unattended
+    category_pref = (category_preference or config.category_preference or "").upper() or None
+    year_tolerance = max(0, int(config.year_tolerance))
+
+    cleaned_title, parsed_year, category_hint, anime_titles = _extract_title_year(
+        filename,
+        enable_anime=config.enable_anime_parsing,
+    )
+    if year is None and parsed_year is not None:
+        year = parsed_year
+
+    imdb_auto, tvdb_auto = _detect_external_ids(filename)
+    imdb_lookup = imdb_id or imdb_auto
+    tvdb_lookup = tvdb_id or tvdb_auto
+
+    query_norms = _normalized_variants(cleaned_title)
+
+    timeout = httpx.Timeout(10.0, connect=10.0, read=10.0, write=10.0)
+    params = {"api_key": config.api_key}
+    async with httpx.AsyncClient(base_url=_BASE_URL, timeout=timeout, params=params, transport=http_transport) as client:
+        if imdb_lookup:
+            payload = await _http_request(
+                client,
+                cache_ttl=config.cache_ttl_seconds,
+                path=f"find/{imdb_lookup}",
+                params={"external_source": "imdb_id"},
+            )
+            candidate = _best_external_candidate(
+                payload,
+                category_preference=category_pref,
+                category_hint=category_hint,
+                query_norms=query_norms,
+                year=year,
+                tolerance=year_tolerance,
+            )
+            if candidate:
+                logger.info(
+                    "TMDB external match via IMDb %s -> %s/%s (%s)",
+                    imdb_lookup,
+                    candidate.category,
+                    candidate.tmdb_id,
+                    candidate.title,
+                )
+                return TMDBResolution(candidate=candidate, margin=1.0, source_query=cleaned_title)
+
+        if tvdb_lookup:
+            payload = await _http_request(
+                client,
+                cache_ttl=config.cache_ttl_seconds,
+                path=f"find/{tvdb_lookup}",
+                params={"external_source": "tvdb_id"},
+            )
+            candidate = _best_external_candidate(
+                payload,
+                category_preference=category_pref,
+                category_hint=category_hint,
+                query_norms=query_norms,
+                year=year,
+                tolerance=year_tolerance,
+            )
+            if candidate:
+                logger.info(
+                    "TMDB external match via TVDB %s -> %s/%s (%s)",
+                    tvdb_lookup,
+                    candidate.category,
+                    candidate.tmdb_id,
+                    candidate.title,
+                )
+                return TMDBResolution(candidate=candidate, margin=1.0, source_query=cleaned_title)
+
+        plans = _build_query_plans(
+            cleaned_title,
+            year=year,
+            category_hint=category_hint,
+            category_preference=category_pref,
+            anime_titles=anime_titles,
+            year_tolerance=year_tolerance,
+        )
+
+        all_candidates: List[TMDBCandidate] = []
+        best_candidate: Optional[TMDBCandidate] = None
+        runner_up: Optional[TMDBCandidate] = None
+
+        for plan in plans:
+            results = await _perform_search(
+                client,
+                plan=plan,
+                cache_ttl=config.cache_ttl_seconds,
+            )
+            candidates = _extract_best_candidate(
+                results=results,
+                plan=plan,
+                query_norms=query_norms,
+                tolerance=year_tolerance,
+                year=year,
+            )
+            if not candidates:
+                continue
+            all_candidates.extend(candidates)
+            candidates.sort(key=lambda cand: cand.score, reverse=True)
+            candidate = candidates[0]
+            if candidate.score >= _SIMILARITY_THRESHOLD:
+                if best_candidate is None or candidate.score > best_candidate.score:
+                    runner_up = best_candidate
+                    candidate.reason = plan.reason
+                    best_candidate = candidate
+                elif runner_up is None or candidate.score > runner_up.score:
+                    runner_up = candidate
+            if best_candidate and best_candidate.score >= _STRONG_MATCH_THRESHOLD:
+                break
+
+        if not best_candidate:
+            if all_candidates:
+                top = sorted(all_candidates, key=lambda cand: cand.score, reverse=True)[:3]
+                summary = ", ".join(
+                    f"{cand.category.lower()}/{cand.tmdb_id} {cand.title} ({cand.year or '????'}) score={cand.score:0.3f}"
+                    for cand in top
+                )
+                logger.warning("TMDB search failed for %s. Top candidates: %s", filename, summary)
+            else:
+                logger.warning("TMDB search returned no viable candidates for %s", filename)
+            return None
+
+        margin = best_candidate.score - (runner_up.score if runner_up else 0.0)
+        resolution = TMDBResolution(candidate=best_candidate, margin=margin, source_query=cleaned_title)
+
+        if not unattended_mode and runner_up and margin < _AMBIGUITY_MARGIN:
+            ranked = sorted(all_candidates, key=lambda cand: cand.score, reverse=True)[:5]
+            raise TMDBAmbiguityError(ranked)
+
+        if runner_up and margin < _AMBIGUITY_MARGIN:
+            logger.warning(
+                "TMDB match for %s selected %s/%s (%s) with low margin %.3f",
+                filename,
+                best_candidate.category,
+                best_candidate.tmdb_id,
+                best_candidate.title,
+                margin,
+            )
+        else:
+            logger.info(
+                "TMDB match via %s -> %s/%s (%s, %s) score=%.3f",
+                best_candidate.reason,
+                best_candidate.category,
+                best_candidate.tmdb_id,
+                best_candidate.title,
+                best_candidate.year or "????",
+                best_candidate.score,
+            )
+
+        return resolution
+
+
+__all__ = [
+    "MOVIE",
+    "TV",
+    "TMDBResolution",
+    "TMDBResolutionError",
+    "TMDBAmbiguityError",
+    "TMDBCandidate",
+    "resolve_tmdb",
+    "parse_manual_id",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,12 @@ def test_load_defaults(tmp_path: Path) -> None:
     assert app.color.overlay_enabled is True
     assert app.color.verify_enabled is True
     assert app.source.preferred == "lsmas"
+    assert app.tmdb.api_key == ""
+    assert app.tmdb.unattended is True
+    assert app.tmdb.year_tolerance == 2
+    assert app.tmdb.enable_anime_parsing is True
+    assert app.tmdb.cache_ttl_seconds == 86400
+    assert app.tmdb.category_preference is None
 
 
 @pytest.mark.parametrize(
@@ -44,6 +50,9 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[color]\nverify_step_seconds = 0\n", "color.verify_step_seconds"),
         ("[color]\ntarget_nits = -10\n", "color.target_nits"),
         ("[source]\npreferred = \"bogus\"\n", "source.preferred"),
+        ("[tmdb]\nyear_tolerance = -1\n", "tmdb.year_tolerance"),
+        ("[tmdb]\ncache_ttl_seconds = -5\n", "tmdb.cache_ttl_seconds"),
+        ("[tmdb]\ncategory_preference = \"documentary\"\n", "tmdb.category_preference"),
     ],
 )
 def test_validation_errors(tmp_path: Path, toml_snippet: str, message: str) -> None:
@@ -75,6 +84,12 @@ remove_after_days = 14
 [naming]
 always_full_filename = false
 
+[tmdb]
+unattended = false
+year_tolerance = 1
+cache_ttl_seconds = 120
+category_preference = "tv"
+
 [paths]
 input_dir = "D:/comparisons"
 
@@ -105,3 +120,7 @@ preferred = "ffms2"
     assert app.color.verify_enabled is False
     assert app.color.overlay_enabled is False
     assert app.source.preferred == "ffms2"
+    assert app.tmdb.unattended is False
+    assert app.tmdb.year_tolerance == 1
+    assert app.tmdb.cache_ttl_seconds == 120
+    assert app.tmdb.category_preference == "TV"

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -16,12 +16,31 @@ from src.datatypes import (
     ScreenshotConfig,
     SlowpicsConfig,
     SourceConfig,
+    TMDBConfig,
 )
+from src.tmdb import TMDBAmbiguityError, TMDBCandidate, TMDBResolution
 
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+class DummyProgress:
+    def __init__(self, *_, **__):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def add_task(self, *_, **__):
+        return 1
+
+    def update(self, *_, **__):
+        return None
 
 
 def _make_config(input_dir: Path) -> AppConfig:
@@ -36,6 +55,7 @@ def _make_config(input_dir: Path) -> AppConfig:
         screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
         color=ColorConfig(),
         slowpics=SlowpicsConfig(auto_upload=False),
+        tmdb=TMDBConfig(),
         naming=NamingConfig(always_full_filename=False, prefer_guessit=False),
         paths=PathsConfig(input_dir=str(input_dir)),
         runtime=RuntimeConfig(ram_limit_mb=4096),
@@ -151,6 +171,7 @@ def test_label_dedupe_preserves_short_labels(tmp_path, monkeypatch, runner):
         screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
         color=ColorConfig(),
         slowpics=SlowpicsConfig(auto_upload=False),
+        tmdb=TMDBConfig(),
         naming=NamingConfig(always_full_filename=False, prefer_guessit=False),
         paths=PathsConfig(input_dir=str(tmp_path)),
         runtime=RuntimeConfig(ram_limit_mb=1024),
@@ -264,6 +285,7 @@ def test_cli_input_override_and_cleanup(tmp_path, monkeypatch, runner):
         screenshots=ScreenshotConfig(directory_name="screens", add_frame_info=False),
         color=ColorConfig(),
         slowpics=SlowpicsConfig(auto_upload=True, delete_screen_dir_after_upload=True, open_in_browser=False, create_url_shortcut=False),
+        tmdb=TMDBConfig(),
         naming=NamingConfig(always_full_filename=True, prefer_guessit=False),
         paths=PathsConfig(input_dir=str(default_dir)),
         runtime=RuntimeConfig(ram_limit_mb=1024),
@@ -311,3 +333,221 @@ def test_cli_input_override_and_cleanup(tmp_path, monkeypatch, runner):
     screen_dir = Path(override_dir / cfg.screenshots.directory_name).resolve()
     assert not screen_dir.exists()
     assert str(override_dir) in result.output
+
+
+def test_cli_tmdb_resolution_populates_slowpics(tmp_path, monkeypatch):
+    first = tmp_path / "SourceA.mkv"
+    second = tmp_path / "SourceB.mkv"
+    for file in (first, second):
+        file.write_bytes(b"data")
+
+    cfg = _make_config(tmp_path)
+    cfg.tmdb.api_key = "token"
+    cfg.slowpics.auto_upload = True
+    cfg.slowpics.collection_name = "${Title} (${Year}) [${TMDBCategory}]"
+    cfg.slowpics.delete_screen_dir_after_upload = False
+
+    monkeypatch.setattr(frame_compare, "load_config", lambda _: cfg)
+
+    def fake_parse(name: str, **_: object) -> dict[str, str]:
+        return {
+            "label": name,
+            "release_group": "",
+            "file_name": name,
+            "title": "Metadata Title",
+            "year": "2020",
+            "anime_title": "",
+            "imdb_id": "",
+            "tvdb_id": "",
+        }
+
+    monkeypatch.setattr(frame_compare, "parse_filename_metadata", fake_parse)
+
+    candidate = TMDBCandidate(
+        category="MOVIE",
+        tmdb_id="12345",
+        title="Resolved Title",
+        original_title="Original Title",
+        year=2023,
+        score=0.95,
+        original_language="en",
+        reason="primary-title",
+        used_filename_search=True,
+        payload={"id": 12345},
+    )
+    resolution = TMDBResolution(candidate=candidate, margin=0.4, source_query="Resolved")
+
+    async def fake_resolve(*_, **__):  # pragma: no cover - simple stub
+        return resolution
+
+    monkeypatch.setattr(frame_compare, "resolve_tmdb", fake_resolve)
+    monkeypatch.setattr(frame_compare.vs_core, "set_ram_limit", lambda limit: None)
+
+    def fake_init(path, *, trim_start=0, trim_end=None, fps_map=None, cache_dir=None):
+        return types.SimpleNamespace(
+            width=1280,
+            height=720,
+            fps_num=24000,
+            fps_den=1001,
+            num_frames=1800,
+        )
+
+    monkeypatch.setattr(frame_compare.vs_core, "init_clip", fake_init)
+
+    def fake_select(
+        clip,
+        analysis_cfg,
+        files,
+        file_under_analysis,
+        cache_info=None,
+        progress=None,
+        *,
+        frame_window=None,
+        return_metadata=False,
+        color_cfg=None,
+    ):
+        assert frame_window is not None
+        return [12, 24]
+
+    monkeypatch.setattr(frame_compare, "select_frames", fake_select)
+
+    def fake_generate(clips, frames, files, metadata, out_dir, cfg_screens, color_cfg, **kwargs):
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return [str(out_dir / f"shot_{idx}.png") for idx in range(len(frames) * len(files))]
+
+    monkeypatch.setattr(frame_compare, "generate_screenshots", fake_generate)
+
+    uploads: list[tuple[list[str], Path, str, str]] = []
+
+    def fake_upload(image_paths, screen_dir, cfg_slow, **kwargs):
+        uploads.append((list(image_paths), screen_dir, cfg_slow.tmdb_id, cfg_slow.collection_name))
+        return "https://slow.pics/c/example"
+
+    monkeypatch.setattr(frame_compare, "upload_comparison", fake_upload)
+
+    monkeypatch.setattr(frame_compare, "Progress", DummyProgress)
+
+    result = frame_compare.run_cli("dummy", None)
+
+    assert uploads
+    _, _, upload_tmdb_id, upload_collection = uploads[0]
+    assert upload_tmdb_id == "12345"
+    assert "Resolved Title (2023)" in upload_collection
+    assert result.config.slowpics.tmdb_id == "12345"
+    assert result.config.slowpics.collection_name == "Resolved Title (2023) [MOVIE]"
+
+
+def test_cli_tmdb_resolution_sets_default_collection_name(tmp_path, monkeypatch):
+    first = tmp_path / "SourceA.mkv"
+    second = tmp_path / "SourceB.mkv"
+    for file in (first, second):
+        file.write_bytes(b"data")
+
+    cfg = _make_config(tmp_path)
+    cfg.tmdb.api_key = "token"
+    cfg.slowpics.auto_upload = True
+    cfg.slowpics.collection_name = ""
+    cfg.slowpics.delete_screen_dir_after_upload = False
+
+    monkeypatch.setattr(frame_compare, "load_config", lambda _: cfg)
+
+    def fake_parse(name: str, **_: object) -> dict[str, str]:
+        return {
+            "label": name,
+            "release_group": "",
+            "file_name": name,
+            "title": "Metadata Title",
+            "year": "2020",
+            "anime_title": "",
+            "imdb_id": "",
+            "tvdb_id": "",
+        }
+
+    monkeypatch.setattr(frame_compare, "parse_filename_metadata", fake_parse)
+
+    candidate = TMDBCandidate(
+        category="MOVIE",
+        tmdb_id="12345",
+        title="Resolved Title",
+        original_title="Original Title",
+        year=2023,
+        score=0.95,
+        original_language="en",
+        reason="primary-title",
+        used_filename_search=True,
+        payload={"id": 12345},
+    )
+    resolution = TMDBResolution(candidate=candidate, margin=0.4, source_query="Resolved")
+
+    async def fake_resolve(*_, **__):
+        return resolution
+
+    monkeypatch.setattr(frame_compare, "resolve_tmdb", fake_resolve)
+    monkeypatch.setattr(frame_compare.vs_core, "set_ram_limit", lambda limit: None)
+    monkeypatch.setattr(frame_compare.vs_core, "init_clip", lambda *_, **__: types.SimpleNamespace(width=1280, height=720, fps_num=24000, fps_den=1001, num_frames=1800))
+    monkeypatch.setattr(frame_compare, "select_frames", lambda *_, **__: [10, 20])
+    monkeypatch.setattr(frame_compare, "generate_screenshots", lambda *args, **kwargs: [str(tmp_path / "shot.png")])
+    monkeypatch.setattr(frame_compare, "upload_comparison", lambda *args, **kwargs: "https://slow.pics/c/example")
+    monkeypatch.setattr(frame_compare, "Progress", DummyProgress)
+
+    result = frame_compare.run_cli("dummy", None)
+
+    assert result.config.slowpics.collection_name.startswith("Resolved Title (2023)")
+    assert result.config.slowpics.tmdb_id == "12345"
+
+
+def test_cli_tmdb_manual_override(tmp_path, monkeypatch):
+    first = tmp_path / "Alpha.mkv"
+    second = tmp_path / "Beta.mkv"
+    for file in (first, second):
+        file.write_bytes(b"data")
+
+    cfg = _make_config(tmp_path)
+    cfg.tmdb.api_key = "token"
+    cfg.tmdb.unattended = False
+    cfg.slowpics.collection_name = "${Label}"
+
+    monkeypatch.setattr(frame_compare, "load_config", lambda _: cfg)
+
+    def fake_parse(name: str, **_: object) -> dict[str, str]:
+        return {
+            "label": f"Label for {name}",
+            "release_group": "",
+            "file_name": name,
+            "title": "",
+            "year": "",
+            "anime_title": "",
+            "imdb_id": "",
+            "tvdb_id": "",
+        }
+
+    monkeypatch.setattr(frame_compare, "parse_filename_metadata", fake_parse)
+
+    candidate = TMDBCandidate(
+        category="TV",
+        tmdb_id="777",
+        title="Option A",
+        original_title=None,
+        year=2001,
+        score=0.5,
+        original_language="ja",
+        reason="primary",
+        used_filename_search=True,
+        payload={"id": 777},
+    )
+
+    def fake_resolve(*_, **__):
+        raise TMDBAmbiguityError([candidate])
+
+    monkeypatch.setattr(frame_compare, "resolve_tmdb", fake_resolve)
+    monkeypatch.setattr(frame_compare, "_prompt_manual_tmdb", lambda candidates: ("TV", "9999"))
+    monkeypatch.setattr(frame_compare.vs_core, "set_ram_limit", lambda limit: None)
+    monkeypatch.setattr(frame_compare.vs_core, "init_clip", lambda *_, **__: types.SimpleNamespace(width=1920, height=1080, fps_num=24000, fps_den=1001, num_frames=2400))
+    monkeypatch.setattr(frame_compare, "select_frames", lambda *_, **__: [3, 6])
+    monkeypatch.setattr(frame_compare, "generate_screenshots", lambda *args, **kwargs: [str(tmp_path / "img.png")])
+    monkeypatch.setattr(frame_compare, "Progress", DummyProgress)
+
+    result = frame_compare.run_cli("dummy", None)
+
+    assert result.config.slowpics.tmdb_id == "9999"
+    assert result.config.slowpics.collection_name == "Label for Alpha.mkv"

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -1,0 +1,246 @@
+import asyncio
+from typing import Dict, List
+
+import httpx
+import pytest
+
+from src import tmdb as tmdb_module
+from src.tmdb import (
+    MOVIE,
+    TV,
+    TMDBCandidate,
+    TMDBConfig,
+    TMDBResolutionError,
+    resolve_tmdb,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_tmdb_cache() -> None:
+    tmdb_module._CACHE._data.clear()
+    yield
+    tmdb_module._CACHE._data.clear()
+
+
+def test_resolve_requires_api_key() -> None:
+    cfg = TMDBConfig(api_key="")
+    with pytest.raises(TMDBResolutionError):
+        asyncio.run(resolve_tmdb("Example.mkv", config=cfg))
+
+
+def test_external_id_respects_preference() -> None:
+    calls: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        return httpx.Response(
+            200,
+            json={
+                "movie_results": [
+                    {
+                        "id": 1,
+                        "title": "Example Movie",
+                        "release_date": "2000-01-01",
+                        "popularity": 10.0,
+                    }
+                ],
+                "tv_results": [
+                    {
+                        "id": 2,
+                        "name": "Example Show",
+                        "first_air_date": "2000-01-01",
+                        "popularity": 12.0,
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token", category_preference="TV")
+    result = asyncio.run(
+        resolve_tmdb(
+            "Example.mkv",
+            config=cfg,
+            imdb_id="tt1234567",
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.category == TV
+    assert result.tmdb_id == "2"
+    assert calls == ["/3/find/tt1234567"]
+
+
+def test_filename_search_year_similarity() -> None:
+    calls: List[Dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params)
+        calls.append({"path": request.url.path, "query": params.get("query", "")})
+        if request.url.path.endswith("/search/movie"):
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 603,
+                            "title": "The Matrix",
+                            "release_date": "1999-03-31",
+                            "popularity": 15.0,
+                        },
+                        {
+                            "id": 604,
+                            "title": "The Matrix Reloaded",
+                            "release_date": "2003-05-15",
+                            "popularity": 12.0,
+                        },
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token", year_tolerance=2)
+    result = asyncio.run(
+        resolve_tmdb(
+            "The.Matrix.1999.mkv",
+            config=cfg,
+            year=1999,
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.category == MOVIE
+    assert result.tmdb_id == "603"
+    assert any(call["query"] for call in calls)
+
+
+def test_roman_numeral_fallback() -> None:
+    queries: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.params.get("query", "")
+        queries.append(query)
+        if query.strip().lower() == "rocky 2":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 42,
+                            "title": "Rocky II",
+                            "release_date": "1979-06-15",
+                            "popularity": 8.0,
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token")
+    result = asyncio.run(
+        resolve_tmdb(
+            "Rocky.II.1979.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.tmdb_id == "42"
+    assert any(query.strip().lower() == "rocky 2" for query in queries if query)
+
+
+def test_anime_parsing_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tmdb_module, "_call_guessit", lambda filename: {})
+    monkeypatch.setattr(
+        tmdb_module,
+        "_call_anitopy",
+        lambda filename: {"anime_title": "Chainsaw Man"},
+    )
+
+    queries: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = request.url.params.get("query", "")
+        queries.append(query)
+        if query == "Chainsaw Man":
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "id": 321,
+                            "name": "Chainsaw Man",
+                            "first_air_date": "2022-10-12",
+                            "popularity": 20.0,
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"results": []})
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token")
+    result = asyncio.run(
+        resolve_tmdb(
+            "[SubsPlease] Chainsaw Man - 01.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    assert result is not None
+    assert result.tmdb_id == "321"
+    assert "Chainsaw Man" in queries
+
+
+def test_tmdb_backoff_and_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_calls: List[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(tmdb_module.asyncio, "sleep", fake_sleep)
+
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if attempts["count"] == 0:
+            attempts["count"] += 1
+            return httpx.Response(429, json={"status_code": 429})
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "id": 55,
+                        "title": "Cache Test",
+                        "release_date": "2020-01-01",
+                        "popularity": 6.0,
+                    }
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    cfg = TMDBConfig(api_key="token")
+    first = asyncio.run(
+        resolve_tmdb(
+            "Cache.Test.2020.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    second = asyncio.run(
+        resolve_tmdb(
+            "Cache.Test.2020.mkv",
+            config=cfg,
+            http_transport=transport,
+        )
+    )
+    assert first is not None and second is not None
+    assert first.tmdb_id == "55"
+    assert second.tmdb_id == "55"
+    assert sleep_calls  # backoff triggered at least once
+    # Only two HTTP calls should have been made (429 + success); cache served the second resolve
+    assert attempts["count"] == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,3 +105,26 @@ def test_guessit_error_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     assert meta["release_group"] == "FB"
     assert meta["label"] != "[FB] Title - 04.mkv"
     assert meta["label"].startswith("[FB] Fallback Show")
+
+
+def test_metadata_includes_year_and_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = utils.import_module
+
+    def fake_import(name: str):
+        if name == "anitopy":
+            return types.SimpleNamespace(
+                parse=lambda _: {"anime_title": "Sample", "anime_season": 2020}
+            )
+        return original_import(name)
+
+    monkeypatch.setattr(utils, "import_module", fake_import)
+
+    meta = utils.parse_filename_metadata(
+        "Sample.2020.tt7654321.mkv",
+        prefer_guessit=False,
+        always_full_filename=True,
+    )
+    assert meta["year"] == "2020"
+    assert meta["imdb_id"] == "tt7654321"
+    assert meta["tvdb_id"] == ""
+    assert meta["title"] == "Sample"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -7,6 +7,20 @@ name = "anitopy"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/8b/3da3f8ba73b8e4e5325a9ecbd6780f4dc9f41c98cc1c6a897800c4f85979/anitopy-2.1.1.tar.gz", hash = "sha256:515b97cd78917ee406313f4eb53bdc75e8a573e6ad5252ffd355c96a06988e26", size = 20890, upload-time = "2022-07-24T10:24:27.23Z" }
+
+[[package]]
+name = "anyio"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+]
 
 [[package]]
 name = "babelfish"
@@ -137,6 +151,7 @@ dependencies = [
     { name = "click" },
     { name = "colorama" },
     { name = "guessit" },
+    { name = "httpx" },
     { name = "natsort" },
     { name = "requests" },
     { name = "requests-toolbelt" },
@@ -158,6 +173,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "colorama" },
     { name = "guessit" },
+    { name = "httpx" },
     { name = "natsort" },
     { name = "requests" },
     { name = "requests-toolbelt" },
@@ -185,6 +201,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d0/07/5a88020bfe2591af2ffc75841200b2c17ff52510779510346af5477e64cd/guessit-3.8.0.tar.gz", hash = "sha256:6619fcbbf9a0510ec8c2c33744c4251cad0507b1d573d05c875de17edc5edbed", size = 271285, upload-time = "2023-12-14T10:24:20.582Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/9b/924a8f9709c3143d4c9a301a88042cbce37e09789378217284b19d4f8132/guessit-3.8.0-py3-none-any.whl", hash = "sha256:eb5747b1d0fbca926562c1e5894dbc3f6507c35e8c0bd9e38148401cd9579d83", size = 206049, upload-time = "2023-12-14T10:24:17.753Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -423,6 +476,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- deduplicate the import section in `tests/test_tmdb.py` so the TMDB suite matches the intended patch layout

## Testing
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4c185f6f08321934f45213592e040