### PR TITLE
Normalize TMDB identifiers for slow.pics uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ collection_name = ""
 is_hentai = false
 is_public = true
 tmdb_id = ""
+tmdb_category = ""
 remove_after_days = 0
 webhook_url = ""
 open_in_browser = true
@@ -197,7 +198,8 @@ See `docs/hdr_tonemap_overview.md` for a walkthrough of the log messages, preset
 | `collection_name` | str | `""` | No | Custom collection title sent to slow.pics.|
 | `is_hentai` | bool | false | No | Marks the collection as hentai for filtering.|
 | `is_public` | bool | true | No | Controls slow.pics visibility.|
-| `tmdb_id` | str | `""` | No | Optional TMDB identifier.|
+| `tmdb_id` | str | `""` | No | Optional TMDB identifier (digits or preformatted `movie/#####`).|
+| `tmdb_category` | str | `""` | No | Optional TMDB category hint (`MOVIE` or `TV`).|
 | `remove_after_days` | int | 0 | No | Schedule deletion after N days; must be ≥0.|
 | `webhook_url` | str | `""` | No | Webhook notified after upload; retries with backoff.|
 | `open_in_browser` | bool | true | No | Launch slow.pics URL with `webbrowser.open` on success.|
@@ -241,7 +243,7 @@ See `docs/hdr_tonemap_overview.md` for a walkthrough of the log messages, preset
 ## TMDB auto-discovery
 Enabling `[tmdb].api_key` activates an asynchronous resolver that translates filenames into TMDB metadata before screenshots are rendered. The CLI analyses the first detected source to gather title/year hints (via GuessIt/Anitopy), then resolves `(category, tmdbId, original language)` once per run. Successful matches populate:
 
-- `cfg.slowpics.tmdb_id` when it is empty so the slow.pics upload automatically links to TMDB, and
+- `cfg.slowpics.tmdb_id` and `cfg.slowpics.tmdb_category` when empty so the slow.pics upload automatically links to TMDB, and
 - the templating context for `[slowpics].collection_name`, exposing `${Title}`, `${OriginalTitle}`, `${Year}`, `${TMDBId}`, `${TMDBCategory}`, `${OriginalLanguage}`, `${Filename}`, `${FileName}`, and `${Label}`.
 
 Resolution follows a deterministic pipeline:

--- a/config.toml.template
+++ b/config.toml.template
@@ -65,6 +65,7 @@ collection_name = ""
 is_hentai = false
 is_public = true
 tmdb_id = ""
+tmdb_category = ""
 remove_after_days = 0
 webhook_url = ""
 open_in_browser = true

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -679,6 +679,8 @@ def run_cli(config_path: str, input_dir: str | None = None) -> RunResult:
 
     if tmdb_id_value and not (cfg.slowpics.tmdb_id or "").strip():
         cfg.slowpics.tmdb_id = str(tmdb_id_value)
+    if tmdb_category and not (getattr(cfg.slowpics, "tmdb_category", "") or "").strip():
+        cfg.slowpics.tmdb_category = tmdb_category
 
     collection_template = (cfg.slowpics.collection_name or "").strip()
     if collection_template:

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -78,6 +78,7 @@ class SlowpicsConfig:
     is_hentai: bool = False
     is_public: bool = True
     tmdb_id: str = ""
+    tmdb_category: str = ""
     remove_after_days: int = 0
     webhook_url: str = ""
     open_in_browser: bool = True

--- a/src/slowpics.py
+++ b/src/slowpics.py
@@ -94,6 +94,24 @@ def _build_legacy_headers(session: requests.Session, encoder: "MultipartEncoder"
     }
 
 
+def _format_tmdb_identifier(tmdb_id: str, category: str | None) -> str:
+    """Normalize TMDB identifiers for slow.pics legacy form fields."""
+
+    text = (tmdb_id or "").strip()
+    if not text:
+        return ""
+
+    lowered = text.lower()
+    if lowered.startswith(("movie/", "tv/", "movie_", "tv_")):
+        return text
+
+    normalized_category = (category or "").strip().lower()
+    if normalized_category in {"movie", "tv"}:
+        return f"{normalized_category}/{text}"
+
+    return text
+
+
 def _prepare_legacy_plan(image_files: List[str]) -> tuple[List[int], List[List[tuple[str, Path]]]]:
     groups: dict[int, List[tuple[str, Path]]] = defaultdict(list)
     for file_path in image_files:
@@ -151,7 +169,7 @@ def _upload_comparison_legacy(
         "public": str(bool(cfg.is_public)).lower(),
     }
     if cfg.tmdb_id:
-        fields["tmdbId"] = str(cfg.tmdb_id)
+        fields["tmdbId"] = _format_tmdb_identifier(cfg.tmdb_id, getattr(cfg, "tmdb_category", ""))
     if cfg.remove_after_days:
         fields["removeAfter"] = str(int(cfg.remove_after_days))
 

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -438,6 +438,7 @@ def test_cli_tmdb_resolution_populates_slowpics(tmp_path, monkeypatch):
     assert upload_tmdb_id == "12345"
     assert "Resolved Title (2023)" in upload_collection
     assert result.config.slowpics.tmdb_id == "12345"
+    assert result.config.slowpics.tmdb_category == "MOVIE"
     assert result.config.slowpics.collection_name == "Resolved Title (2023) [MOVIE]"
 
 
@@ -498,6 +499,7 @@ def test_cli_tmdb_resolution_sets_default_collection_name(tmp_path, monkeypatch)
 
     assert result.config.slowpics.collection_name.startswith("Resolved Title (2023)")
     assert result.config.slowpics.tmdb_id == "12345"
+    assert result.config.slowpics.tmdb_category == "MOVIE"
 
 
 def test_cli_tmdb_manual_override(tmp_path, monkeypatch):
@@ -554,4 +556,5 @@ def test_cli_tmdb_manual_override(tmp_path, monkeypatch):
     result = frame_compare.run_cli("dummy", None)
 
     assert result.config.slowpics.tmdb_id == "9999"
+    assert result.config.slowpics.tmdb_category == "TV"
     assert result.config.slowpics.collection_name == "Label for Alpha.mkv"


### PR DESCRIPTION
## Summary
- capture the TMDB category when resolving metadata and store it in the slow.pics config
- normalize tmdbId values sent to slow.pics so the media type prefix is preserved
- document the new tmdb_category option and extend the test suite for the new behavior

## Testing
- `uv run pytest` *(fails: system is missing libvapoursynth during wheel build)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e7a8fcd083219c7c821c0ada8eb0