### PR TITLE
Update README defaults and configuration reference

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -570,8 +570,31 @@ def _print_summary(files: Sequence[Path], frames: Sequence[int], out_dir: Path, 
 
 
 def run_cli(config_path: str, input_dir: str | None = None) -> RunResult:
+    config_location = Path(config_path).expanduser()
+
     try:
-        cfg: AppConfig = load_config(config_path)
+        cfg: AppConfig = load_config(str(config_location))
+    except FileNotFoundError as exc:
+        message = f"Config file not found: {config_location}"
+        raise CLIAppError(
+            message,
+            code=2,
+            rich_message=f"[red]Config file not found:[/red] {config_location}",
+        ) from exc
+    except PermissionError as exc:
+        message = f"Config file is not readable: {config_location}"
+        raise CLIAppError(
+            message,
+            code=2,
+            rich_message=f"[red]Config file is not readable:[/red] {config_location}",
+        ) from exc
+    except OSError as exc:
+        message = f"Failed to read config file: {exc}"
+        raise CLIAppError(
+            message,
+            code=2,
+            rich_message=f"[red]Failed to read config file:[/red] {exc}",
+        ) from exc
     except ConfigError as exc:
         raise CLIAppError(
             f"Config error: {exc}", code=2, rich_message=f"[red]Config error:[/red] {exc}"

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -111,8 +111,10 @@ def load_config(path: str) -> AppConfig:
 
     if app.analysis.step < 1:
         raise ConfigError("analysis.step must be >= 1")
-    if app.analysis.downscale_height < 64:
-        raise ConfigError("analysis.downscale_height must be >= 64")
+    if app.analysis.downscale_height < 0:
+        raise ConfigError("analysis.downscale_height must be >= 0")
+    if 0 < app.analysis.downscale_height < 64:
+        raise ConfigError("analysis.downscale_height must be 0 or >= 64")
     if app.analysis.random_seed < 0:
         raise ConfigError("analysis.random_seed must be >= 0")
     if not app.analysis.frame_data_filename:

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -16,8 +16,6 @@ from . import vs_core
 
 _INVALID_LABEL_PATTERN = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
 
-_INVALID_LABEL_PATTERN = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- align the README's full configuration example with the current template, including color and source sections
- refresh default values in the configuration reference tables and add guidance for source preference errors
- document the tmdb helper module in the repository structure overview
- allow disabling analysis downscaling by permitting a zero height sentinel while keeping validation for invalid values
- improve CLI error messaging for missing or unreadable config files and remove a redundant screenshot label regex

## Testing
- `uv run python -m pytest -q` *(fails: libvapoursynth is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f8c6d1c88321af1816d92fb06947