### PR TITLE
Make VapourSynth support optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ uv run python frame_compare.py --config config.toml --input comparison_videos
 ```
 You should see `Comparison ready` followed by the selected frames, output directory, and slow.pics URL (when enabled).
 
+> 💡 Planning to use VapourSynth locally? Install the optional extra with `uv sync --extra vapoursynth` before running the CLI.
+
 ## Features
 - Deterministic frame selection that combines quantile-based brightness picks, smoothed motion scoring, user pins, and seeded randomness, while caching metrics for reruns.
 - Configurable selection windows that respect per-clip trims, ignore/skip timing, and collapse to a safe fallback when sources disagree.
@@ -21,8 +23,8 @@ You should see `Comparison ready` followed by the selected frames, output direct
 ### Requirements
 - Python 3.13 (>=3.13,<3.14).
 - Runtime tools depending on your workflow:
-  - VapourSynth with the `lsmas` plugin and (optionally) `libplacebo` for HDR tonemapping.
-  - FFmpeg when `screenshots.use_ffmpeg=true` (the CLI checks for the executable).
+  - VapourSynth with the `lsmas` plugin and (optionally) `libplacebo` for HDR tonemapping. Install it via the optional extra (`uv sync --extra vapoursynth`) or follow the manual instructions below. When VapourSynth is unavailable the tool gracefully reports the missing dependency and you can enable the FFmpeg screenshot path instead.
+  - FFmpeg when `screenshots.use_ffmpeg=true` (the CLI checks for the executable). This is the supported fallback in cloud environments where VapourSynth is impractical.
   - `requests-toolbelt` is installed via `pyproject.toml` for slow.pics uploads; the code warns if it is missing.
   - Optional: `pyperclip` to copy the slow.pics URL to your clipboard.
 
@@ -32,8 +34,14 @@ uv sync
 ```
 This resolves the application dependencies listed in `pyproject.toml`. Add `--group dev` when you also want linting and test tools.
 
+Install VapourSynth support only when you need it:
+
+```bash
+uv sync --extra vapoursynth
+```
+
 ### Provision VapourSynth
-- **Inside the virtual environment**: install a wheel that matches your interpreter, e.g. `uv pip install VapourSynth`.
+- **Inside the virtual environment**: install the optional extra (`uv sync --extra vapoursynth`) or add the wheel manually, e.g. `uv pip install VapourSynth`.
 - **Using a system install**: install VapourSynth through your platform’s packages, then expose its Python modules by either
   - setting the `VAPOURSYNTH_PYTHONPATH` environment variable, or
   - listing search folders in `[runtime.vapoursynth_python_paths]` (they are prepended to `sys.path`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ dependencies = [
     "anitopy",
     "guessit",
     "click>=8.1",
+]
+
+[project.optional-dependencies]
+vapoursynth = [
     "vapoursynth>=72",
 ]
 

--- a/tests/test_vs_core.py
+++ b/tests/test_vs_core.py
@@ -2,6 +2,9 @@ import sys
 import types
 
 import pytest
+
+pytest.importorskip("vapoursynth", reason="VapourSynth-dependent behaviour is optional")
+
 import src.vs_core as vs_core
 
 from src.datatypes import ColorConfig

--- a/uv.lock
+++ b/uv.lock
@@ -125,6 +125,10 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "rich" },
+]
+
+[package.optional-dependencies]
+vapoursynth = [
     { name = "vapoursynth" },
 ]
 
@@ -148,8 +152,9 @@ requires-dist = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "rich" },
-    { name = "vapoursynth", specifier = ">=72" },
+    { name = "vapoursynth", marker = "extra == 'vapoursynth'", specifier = ">=72" },
 ]
+provides-extras = ["vapoursynth"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- move VapourSynth into an optional extra so base installs work without the module
- update the README with optional installation steps and the FFmpeg fallback guidance
- skip the VapourSynth-focused test suite when the module cannot be imported

## Testing
- PYTHONPATH=. uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5984e058c8321b3f5083d45a0a13e