### PR TITLE
Several changes to try and speed up the analysis step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+- add `generated.selection.v1.json` sidecar to short-circuit cached selections
+- stream VapourSynth metrics sequentially to avoid random frame fetches
+- skip SDR tonemapping when `analyze_in_sdr` is enabled and the source reports SDR transfer


### PR DESCRIPTION

- Brightness/motion stats run on that prepared sample and are iterated sequentially, mapping directly back to the original indices. Motion uses neighboring sampled frames, so alignment is maintained (src/analysis.py:652–693).
- Fallback branch for non-uniform indices still exists; only the sequential path gets the new fast pipeline.
Added a new helper _select_frames_list in tests to cast return types, and the faux clip now declares frame_props; this silences Pylance while leaving runtime unchanged (tests/test_analysis.py).
- Added _ProgressCoalescer to batch progress callbacks, avoiding the per-frame overhead during VapourSynth metric collection (src/analysis.py:478).
- _collect_metrics_vapoursynth now drives progress updates through the coalescer for both sequential and fallback branches, with guaranteed flushing on exit (src/analysis.py:663–708).## What
- Added a pre-cache fast path that returns stored frames (with "Cached" metadata) before loading full metrics (src/analysis.py:798).
- Reworked VapourSynth metric collection to trim/select frames and render sequentially, reducing random access in both brightness and motion paths (src/analysis.py:516).
- Introduced _is_hdr_source and now only tonemap when the source reports HDR, logging and skipping the SDR conversion otherwise (src/analysis.py:492, src/analysis.py:798).
- Logged the behavioral changes in a new changelog entry (CHANGELOG.md:4).