### PR TITLE
Fix summary rendering in CLI layout

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2636,6 +2636,31 @@ def run_cli(
         slowpics_url=slowpics_url,
         json_tail=json_tail,
     )
+
+    summary_lines: List[str] = []
+    summary_section = next(
+        (section for section in reporter.layout.sections if section.get("id") == "summary"),
+        None,
+    )
+    if isinstance(summary_section, Mapping):
+        items = summary_section.get("items", [])
+        if isinstance(items, list):
+            for item in items:
+                if not isinstance(item, str):
+                    continue
+                rendered = reporter.renderer.render_template(item, reporter.values, reporter.flags)
+                if rendered:
+                    summary_lines.append(rendered)
+
+    if not summary_lines:
+        summary_lines = [
+            f"Files     : {len(result.files)}",
+            f"Frames    : {len(result.frames)} -> {result.frames}",
+            f"Output dir: {result.out_dir}",
+        ]
+        if result.slowpics_url:
+            summary_lines.append(f"Slow.pics : {result.slowpics_url}")
+
     for warning in collected_warnings:
         reporter.warn(warning)
 


### PR DESCRIPTION
## Summary
- derive summary lines from the JSON-driven layout before rendering the summary section
- add a legacy fallback so the CLI still prints a summary block and avoids NameError crashes

## Testing
- `PYTHONPATH=. pytest tests/test_frame_compare.py` *(fails: output assertions need to be updated for the new layout)*

------
https://chatgpt.com/codex/tasks/task_e_68df422242988321bc0234ae95ea1228