### PR TITLE
Confirm audio alignment before recording results

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2089,6 +2089,19 @@ def run_cli(
         audio_track_override_map,
         reporter=reporter,
     )
+    if (
+        alignment_summary is not None
+        and alignment_display is not None
+        and cfg.audio_alignment.enable
+    ):
+        _confirm_alignment_with_screenshots(
+            plans,
+            alignment_summary,
+            cfg,
+            root,
+            reporter,
+            alignment_display,
+        )
     audio_offsets_applied = alignment_summary is not None
     if alignment_display is not None:
         json_tail["audio_alignment"]["offsets_filename"] = alignment_display.offsets_file_line.split(": ", 1)[-1]


### PR DESCRIPTION
## Summary
- ensure `run_cli` triggers audio-alignment screenshot confirmation before persisting layout/json data
- add a regression test that verifies the confirmation helper runs whenever screenshot confirmation is enabled

## Testing
- PYTHONPATH=. pytest tests/test_frame_compare.py::test_run_cli_calls_alignment_confirmation tests/test_frame_compare.py::test_confirm_alignment_reports_preview_paths *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68df5c8416408321aaaed51432c2a292