### PR TITLE
Document CLI legend and diagnostic overlay metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@ All notable user-visible updates will be documented in this file in reverse chro
 - *2025-09-29:* Initialize changelog to align with repository persistence rules.
 - *2025-09-29:* Revamped CLI presentation: extended palette, added style spans, highlights, section accents, progress bar styling, verification metrics, and refreshed templates per `features/CLI/GUIDE.md`.
 - *2025-09-30:* Enhanced CLI group blocks with accent subhead glyphs, dimmed divider rules, numeric alignment, and verbose legends describing token colouring for RENDER/PREPARE sections.
-- *2025-09-30:* Removed HDR measurement overlays and frame-info content-type rows to keep diagnostic output concise; tonemap details now focus on resolution and mastering metadata only.
+- *2025-09-30:* Diagnostic overlay now replaces the HDR MAX/AVG measurement block with the render resolution summary, mastering display luminance (when available), and a `Frame Selection Type` line sourced from cached selection metadata.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add VapourSynth support later with `uv sync --extra vapoursynth` or `pip install
 - VapourSynth integration with optional HDR→SDR tonemapping, FFmpeg screenshot fallback, modulus-aware cropping, and placeholder creation when writers fail.
 - Audio-guided trim suggestions—the only automated offset step—that write `generated.audio_offsets.toml`, auto-select matching streams, use finer DTW hops, prompt for quick visual confirmation, and accelerate alignment for mismatched transfers.
 - Automatic slow.pics uploads with webhook retries, `.url` shortcut generation, and strict naming validation so every frame lands in the right slot.
-- Rich CLI that discovers clips, deduplicates labels, applies trims/FPS overrides consistently, and cleans up rendered images after upload when requested.
+- Rich CLI that discovers clips, deduplicates labels, applies trims/FPS overrides consistently, and now renders accented section headers with Unicode/ASCII fallbacks, dimmed dividers, and a verbose legend that explains every token used in the progress dashboard.
 
 ## Configuration (start here)
 | Flag/Key | What it controls | When to use it | Type | Default | Example | Impact / Trade-offs | Notes | Source |
@@ -134,8 +134,7 @@ Add VapourSynth support later with `uv sync --extra vapoursynth` or `pip install
 | `[color].enable_tonemap` | HDR→SDR pipeline toggle | Disable when inputs are SDR | bool | `True` | `enable_tonemap = false` | Skipping tonemap speeds renders but loses HDR cues |  | original, readme, new |
 | `[runtime].ram_limit_mb` | VapourSynth RAM guard | Tune on constrained systems | int | `8000` | `ram_limit_mb = 4096` | Lower limits prevent spikes yet may trigger reloads |  | original, readme, new |
 | `VAPOURSYNTH_PYTHONPATH` | Env search path for VapourSynth | Set when using a system install | env var | (verify) | `export VAPOURSYNTH_PYTHONPATH=/opt/vs/site-packages` | Missing path triggers ClipInit errors | Value read at src/vs_core.py:186 (verify) | original, ripgrep |
-| `--threads / --gpu / --device` | Planned performance flags | Use backend settings until CLI exposes them | CLI (n/a) | n/a | N/A | Currently unavailable; rely on VapourSynth/FFmpeg (verify frame_compare.py:1107-1108) | Placeholder only | original, readme |
-| `--output-dir / --csv / --json / --images / --grid / --slowpics` | Planned output flags | Configure outputs via config keys today | CLI (n/a) | n/a | N/A | Not yet wired; use `[screenshots.*]` and `[slowpics.*]` (verify frame_compare.py:1107-1108) | Placeholder only | original, readme |
+| `[cli].emit_json_tail` | Append structured summary to CLI output | Enable downstream tooling that scrapes runs | bool | `True` | `emit_json_tail = false` | Disabling removes the trailing machine-readable block; legend output still renders | config.toml |
 
 ## Features & Metrics
 Brightness and darkness metrics downscale each sampled frame when needed, convert it to GRAY, and inspect the Y (luma) plane. The pipeline records the normalized mean brightness (0.0–1.0). Tonemapping in `[color].enable_tonemap` runs before sampling when HDR sources need SDR previews.
@@ -197,14 +196,6 @@ The CLI reads a UTF-8 TOML file and instantiates the dataclasses in `src/datatyp
 | `runtime.ram_limit_mb` | Upper bound for VapourSynth RAM use | `int` | `8000` | `ram_limit_mb = 4096` | Performance Tips |
 | `runtime.vapoursynth_python_paths` | Extra Python paths for VapourSynth | `List[str]` | `[]` | `vapoursynth_python_paths = ["/opt/vs/python"]` | Installation, Performance |
 | `source.preferred` | Preferred VapourSynth source plugin | `str` | `"lsmas"` | `preferred = "ffms2"` | Detailed Features |
-| `--random-frames` *(Documented here but verify in code)* | CLI flag not implemented; use `[analysis].random_frames` instead | CLI (n/a) | n/a | `--random-frames 10` | Usage Modes |
-| `--user-frames / --frames` *(Documented here but verify in code)* | CLI shortcut not implemented; configure `[analysis].user_frames` | CLI (n/a) | n/a | `--user-frames 10,200,501` | Usage Modes |
-| `--frame-step / --frame-interval` *(Documented here but verify in code)* | Prefer `[analysis].step` for stride control | CLI (n/a) | n/a | `--frame-step 2` | Performance Tips |
-| `--seed / --deterministic` *(Documented here but verify in code)* | Determinism handled via `[analysis].random_seed` | CLI (n/a) | n/a | `--seed 20202020` | Detailed Features |
-| `--metrics / --brightness / --darkness / --motion` *(Documented here but verify in code)* | Use analysis config keys above to tune selections | CLI (n/a) | n/a | `--brightness 10` | Detailed Features |
-| `--tonemap / --hdr-to-sdr / --gamma / --colorspace / --crop / --resize / --grayscale` *(Documented here but verify in code)* | Governed by `[color.*]` and `[screenshots.*]` options listed above | CLI (n/a) | n/a | `--tonemap hable` | Detailed Features |
-| `--threads / --gpu / --device` *(Documented here but verify in code)* | No dedicated flags; consider `[runtime.ram_limit_mb]` and FFmpeg/VapourSynth configs | CLI (n/a) | n/a | `--threads 4` | Performance Tips |
-| `--output-dir / --csv / --json / --images / --grid / --slowpics` *(Documented here but verify in code)* | Output control managed via `[screenshots.*]`, `[analysis.*]`, `[slowpics.*]` | CLI (n/a) | n/a | `--output-dir screenshots` | Outputs |
 
 ### Minimal config
 ```toml
@@ -365,7 +356,7 @@ change_fps = {}
 | `dst_min_nits` | float | 0.1 | No | Minimum nits for libplacebo (`dst_min`). Must be ≥0.|
 | `overlay_enabled` | bool | true | No | Draw an SDR metadata overlay (top-right). If true, failures log `[OVERLAY]` and obey `strict`.|
 | `overlay_text_template` | str | `"Tonemapping Algorithm: {tone_curve} dpd = {dynamic_peak_detection} dst = {target_nits} nits"` | No | Template for the overlay text. Placeholders: `{tone_curve}`, `{dpd}`, `{dynamic_peak_detection}`, `{target_nits}`, `{preset}`, `{reason}`.|
-| `overlay_mode` | str | `"minimal"` | No | Selects overlay detail level: `minimal` shows the template; `diagnostic` appends pipeline and metadata diagnostics.|
+| `overlay_mode` | str | `"minimal"` | No | Selects overlay detail level: `minimal` shows the template; `diagnostic` adds the render resolution summary, HDR mastering luminance (when available), and a `Frame Selection Type` line sourced from cached selection metadata.|
 | `verify_enabled` | bool | true | No | Compute Δ vs naive SDR and log `[VERIFY] frame=… avg=… max=…`.|
 | `verify_frame` | int? | null | No | Force a specific verification frame index.|
 | `verify_auto` | bool | true | No | Enable the auto-search described in `docs/hdr_tonemap_overview.md`.|
@@ -409,6 +400,11 @@ See `docs/hdr_tonemap_overview.md` for a walkthrough of the log messages, preset
 | --- | --- | --- | --- | --- |
 | `always_full_filename` | bool | true | No | Use the original filename as the label instead of parsed metadata.|
 | `prefer_guessit` | bool | true | No | Prefer GuessIt over Anitopy when deriving metadata; falls back automatically.|
+
+#### `[cli]`
+| Name | Type | Default | Required? | Description |
+| --- | --- | --- | --- | --- |
+| `emit_json_tail` | bool | true | No | Append a JSON summary block to the CLI footer so scripts can scrape run metadata alongside the human-readable legend.|
 
 #### `[paths]`
 | Name | Type | Default | Required? | Description |
@@ -458,6 +454,12 @@ Options:
                  Manual audio stream override (label=index). Repeatable.
   --help         Show this message and exit.
 ```
+
+### CLI dashboard & legend
+- Section headers in the live dashboard now inherit accent colours from `cli_layout.v1.json`. When the terminal supports Unicode, subheads use `›` prefixes; ASCII fallbacks swap in `>` automatically.
+- Divider rules dim relative to the active block so verbose runs remain readable even with dozens of groups.
+- Verbose mode prints a dedicated `Legend` block under `[RENDER]` that explains every token (`key`, `value`, `unit`, `path`) and the new prefixes so operators can map colours to meaning quickly.
+- Each run ends with an optional JSON tail (governed by `[cli].emit_json_tail`) that mirrors the human-readable summary for downstream tooling.
 
 ### Two-file comparison
 ```bash

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -2,4 +2,4 @@
 
 - *2025-09-29:* Adopted CLI layout styling DSL with semantic spans and data-driven highlight rules. Renderer now consumes palette roles (`value`, `unit`, `path`, etc.), honors section accent theming, and evaluates JSON-configured thresholds (e.g., tonemap verification, boolean states) to keep formatting declarative.
 - *2025-09-30:* Standardised group subhead styling across CLI sections: accent-subhead prefixes (`›`/`>` fallback), dim divider rules sized to block content, column alignment for numeric values, and verbose legends describing token roles to satisfy `features/CLI/GUIDE.md`.
-- *2025-09-30:* Simplified diagnostics: removed measurement overlays for HDR tonemap output and trimmed frame-info overlays (no content-type line) to keep CLI banners uncluttered.
+- *2025-09-30:* Simplified diagnostic overlays by retiring the HDR MAX/AVG measurement line and instead appending render resolution, mastering display luminance (when HDR tonemap applies), and cached `Frame Selection Type` metadata.

--- a/docs/current_pipeline_trace.md
+++ b/docs/current_pipeline_trace.md
@@ -9,7 +9,7 @@ Scope: `frame_compare.py` + `src/screenshot.py` + `src/vs_core.py`.
 | 1 | `rgb16` | `vs_core.process_clip_for_screenshot` (`resize.Spline36`) | `RGB48` | 0 (forced) | From stage 0 | From stage 0 | 0 (forced full) | — | `_normalize_rgb_props` stamps RGB props so libplacebo can infer linearisation. |
 | 2 | `tonemapped` | `_tonemap_with_retries` | `RGB48`/`RGBS` | 0 | 1 (BT.1886) | 1 (BT.709) | 0 | `placebo:{curve},dpd={dpd},dst_max={nits}` | Retries hinted → inferred → PQ fallback, logging `[TM INPUT]` / `[TM APPLIED]` / failures. |
 | 3 | `tm_rgb24` | Verification path (`resize.Point`) | `RGB24` | 0 | 1 | 1 | 0 | Same as stage 2 | Used only for diff vs naive SDR, never written to disk. |
-| 4a | `render_clip` (VapourSynth writer) | `_save_frame_with_fpng` | `RGB24` | 0 | 1 | 1 | 0 | Preserved | Crop/resize, optional frame-info overlay, `_apply_overlay_text` (alignment=9). `_ensure_rgb24` stamps BT.709/BT.1886 full-range props for downstream sanity. |
+| 4a | `render_clip` (VapourSynth writer) | `_save_frame_with_fpng` | `RGB24` | 0 | 1 | 1 | 0 | Preserved | Crop/resize, optional frame-info overlay, `_apply_overlay_text` (alignment=9). Diagnostic mode layers the base template plus render resolution, HDR mastering luminance when tonemapping ran, and cached `Frame Selection Type` metadata. `_ensure_rgb24` stamps BT.709/BT.1886 full-range props for downstream sanity. |
 | 4b | FFmpeg render | `_save_frame_with_ffmpeg` | File stream | N/A | N/A | N/A | N/A | N/A | FFmpeg redoes crop/scale and injects top-right `drawtext` overlay; tonemapped pixels come from stage 2 clip via `result.clip` when available. |
 
 ## SDR bypass path
@@ -21,7 +21,7 @@ Scope: `frame_compare.py` + `src/screenshot.py` + `src/vs_core.py`.
 ## Overlay & verification guarantees
 - `process_clip_for_screenshot` runs **before** geometry planning; the resulting node is the one fed into `_plan_geometry` and ultimately into the writers.
 - Verification (`verify_enabled`) occurs on the tonemapped node, selecting a non-trivial frame via `_pick_verify_frame` (skip ≥10s, sample every 10s up to 90s, fall back to brightest or midpoint). Logs `[VERIFY]` with frame/Δ before any screenshots emit.
-- Overlay text is applied once per clip: VapourSynth path uses `core.text.Text(..., alignment=9)`, FFmpeg path mirrors via `drawtext` anchored top-right. Failures honour `color.strict` and raise.
+- Overlay text is applied once per clip: VapourSynth path uses `core.text.Text(..., alignment=9)`, FFmpeg path mirrors via `drawtext` anchored top-right. The diagnostic branch now augments the base tonemap string with the render resolution summary, mastering display luminance (only when tonemapping applied), and the cached frame-selection label. Failures honour `color.strict` and raise.
 
 ## Open issues observed
 - Maintain coverage to ensure `_Tonemapped` flag survives future overlay/crop rewrites (current `std.CopyFrameProps` guard keeps it intact).

--- a/docs/hdr_tonemap_overview.md
+++ b/docs/hdr_tonemap_overview.md
@@ -52,6 +52,9 @@ logs and sets `_Tonemapped="placebo:{curve},dpd={0|1},dst_max={nits}"` on the pr
 ## Overlay & writer behaviour
 - Overlay text defaults to `Tonemapping Algorithm: {tone_curve} dpd = {dynamic_peak_detection} dst = {target_nits} nits` and accepts `{preset}` and `{reason}`
   placeholders. You can fully override the template in config.
+- Diagnostic overlay mode now appends the final render resolution (original → target), the mastering display luminance parsed
+  from frame props when HDR tonemapping is applied, and `Frame Selection Type: …` sourced from persisted selection metadata.
+  The previous MAX/AVG measurement line has been retired to keep the overlay concise.
 - VapourSynth renders apply the overlay after all geometry adjustments (`CropRel`/`Spline36`) but before the final
   dither to RGB24. FFmpeg renders append a matching `drawtext` filter positioned at `x=w-tw-10:y=10`.
 - The overlay lives in the top-right corner to avoid frame info overlays (when enabled).


### PR DESCRIPTION
## Summary
- update the README to highlight the diagnostic overlay output, CLI legend behaviour, JSON tail toggle, and drop redundant placeholder CLI flag entries
- update docs/current_pipeline_trace.md so the stage summary and overlay guarantees document the diagnostic overlay’s resolution, luminance, and frame-selection lines

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e72b2a2db48321b501aec809348548