### PR TITLE
Add CLI progress config and update layout presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-10:* Reject invalid `cli.progress.style` values during configuration loading and persist normalized styles for downstream flag handling to keep CLI reporters consistent.
 - *2025-10-09:* Expanded minimal overlays with resolution/upscale and frame-selection type lines while simplifying diagnostic overlays by removing on-screen selection timecode/score/notes that remain available via cached metadata.
 - *2025-10-02:* Scoped audio alignment's NumPy flush-to-zero warning suppression to local contexts, added regression tests to keep diagnostics available, and hardened TMDB caching with TTL-aware eviction to cap memory growth during long CLI sessions.
 - *2025-10-01:* Added selection metadata persistence v1: cached JSON sidecar, compframes annotations, CLI summary metrics, and screenshot overlay reuse without rerunning analysis.

--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -8,6 +8,13 @@
       "accent_analyze": "purple.bright",
       "accent_render": "magenta.bright",
       "accent_publish": "green.bright",
+      "section_discover": "cyan.bold",
+      "section_prepare": "blue.bright",
+      "section_analyze": "purple.bright",
+      "section_render": "magenta.bright",
+      "section_publish": "green.bright",
+      "section_warnings": "yellow.bold",
+      "section_summary": "cyan.bold",
       "accent_subhead": "magenta.bold",
       "value": "white.bright",
       "unit": "grey.dim",
@@ -81,6 +88,7 @@
       "id": "discover",
       "type": "list",
       "title_badge": "[DISCOVER]",
+      "accent_role": "section_discover",
       "items": [
         "• [[key]]ref[[/]]=[[value]]{clips.ref.label}[[/]]  [[value]]{clips.ref.width}[[/]]x[[value]]{clips.ref.height}[[/]] @ [[value]]{clips.ref.fps:.3f}[[/]][[unit]]fps[[/]]  frames=[[value]]{clips.ref.frames}[[/]]  dur=[[value]]{clips.ref.duration_tc}[[/]]",
         "• [[key]]tgt[[/]]=[[value]]{clips.tgt.label}[[/]]  [[value]]{clips.tgt.width}[[/]]x[[value]]{clips.tgt.height}[[/]] @ [[value]]{clips.tgt.fps:.3f}[[/]][[unit]]fps[[/]]  frames=[[value]]{clips.tgt.frames}[[/]]  dur=[[value]]{clips.tgt.duration_tc}[[/]]",
@@ -91,6 +99,7 @@
       "id": "prepare",
       "type": "group",
       "title_badge": "[PREPARE]",
+      "accent_role": "section_prepare",
       "blocks": [
         {
           "subtitle": "Trim",
@@ -122,6 +131,7 @@
       "id": "audio_align",
       "type": "group",
       "title_badge": "[PREPARE · Audio]",
+      "accent_role": "section_prepare",
       "when": "audio_alignment.enabled",
       "blocks": [
         {
@@ -139,6 +149,7 @@
       "id": "analyze",
       "type": "group",
       "title_badge": "[ANALYZE]",
+      "accent_role": "section_analyze",
       "blocks": [
         {
           "subtitle": "Config",
@@ -155,7 +166,7 @@
         {
           "type": "progress",
           "progress_id": "analyze_bar",
-          "right_label": "[[value]]{progress.fps:.1f}[[/]] [[unit]]fps[[/]] | ETA [[value]]{progress.eta_tc}[[/]] | elapsed [[value]]{progress.elapsed_tc}[[/]]"
+          "right_label": "[[value]]{progress.fps:.2f}[[/]] [[unit]]fps[[/]] | ETA [[value]]{progress.eta_tc}[[/]] | elapsed [[value]]{progress.elapsed_tc}[[/]]"
         }
       ]
     },
@@ -163,6 +174,7 @@
       "id": "render",
       "type": "group",
       "title_badge": "[RENDER]",
+      "accent_role": "section_render",
       "blocks": [
         {
           "subtitle": "Legend",
@@ -175,43 +187,45 @@
         {
           "subtitle": "Writer",
           "lines": [
-            "writer=[[key]]writer[[/]]=[[value]]{render.writer}[[/]]  out_dir=[[key]]out_dir[[/]]=[[path]]{render.out_dir.e}[[/]]  add_frame_info=[[key]]add_frame_info[[/]]=[[value]]{render.add_frame_info}[[/]]"
+            "[[key]]writer[[/]]=[[value]]{render.writer}[[/]] [[key]]out_dir[[/]]=[[path]]{render.out_dir.e}[[/]]{render.add_frame_info? [[key]]add_frame_info[[/]]=[[value]]{render.add_frame_info|bool}[[/]]:''}"
           ]
         },
         {
           "subtitle": "Canvas",
           "lines": [
-            "single_res=[[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale=[[value]]{render.upscale}[[/]]  crop=mod[[value]]{render.mod_crop}[[/]]  letterbox_aware=[[value]]{render.letterbox_pillarbox_aware}[[/]]  pad=[[value]]{render.center_pad}[[/]],[[unit]]tol={render.letterbox_px_tolerance}[[/]][[unit]]px[[/]]"
+            "single_res=[[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]] upscale=[[value]]{render.upscale|bool}[[/]] crop=mod[[value]]{render.mod_crop}[[/]] letterbox_aware=[[value]]{render.letterbox_pillarbox_aware|bool}[[/]] pad=[[value]]{render.center_pad|bool}[[/]] tol=[[value]]{render.letterbox_px_tolerance}[[/]][[unit]]px[[/]]"
           ]
         },
         {
           "subtitle": "Tonemap",
           "lines": [
-            "curve=[[value]]{tonemap.tone_curve}[[/]]  dpd=[[value]]{tonemap.dynamic_peak_detection}[[/]]  target=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  verify_luma_thresh=[[value]]{tonemap.verify_luma_threshold}[[/]]  verify_delta=[[value]]{verify.delta.max}[[/]]"
+            "[[key]]curve[[/]]=[[value]]{tonemap.tone_curve}[[/]] dpd=[[value]]{tonemap.dynamic_peak_detection|bool}[[/]] [[key]]target[[/]]=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] [[key]]verify_luma_thresh[[/]]=[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[key]]verify_delta[[/]]=[[value]]{verify.delta.max}[[/]]:''}"
           ]
         },
         {
           "subtitle": "Overlay",
           "lines": [
-            "enabled=[[value]]{overlay.enabled}[[/]]  template=\"[[value]]{overlay.template}[[/]]\"  mode=[[value]]{overlay.mode}[[/]]"
+            "[[key]]enabled[[/]]=[[value]]{overlay.enabled|bool}[[/]]{overlay.mode? [[key]]mode[[/]]=[[value]]{overlay.mode}[[/]]:''}"
           ]
         },
         {
           "type": "progress",
           "progress_id": "render_bar",
-          "right_label": "[[value]]{progress.current}[[/]]/[[value]]{progress.total}[[/]] | [[value]]{progress.fps:.1f}[[/]] [[unit]]fps[[/]] | ETA [[value]]{progress.eta_tc}[[/]] | elapsed [[value]]{progress.elapsed_tc}[[/]]"
+          "right_label": "[[value]]{progress.current}[[/]]/[[value]]{progress.total}[[/]] | [[value]]{progress.fps:.2f}[[/]] [[unit]]fps[[/]] | ETA [[value]]{progress.eta_tc}[[/]] | elapsed [[value]]{progress.elapsed_tc}[[/]]"
         }
       ]
     },
     {
       "id": "publish",
       "type": "passthrough",
-      "title_badge": "[PUBLISH]"
+      "title_badge": "[PUBLISH]",
+      "accent_role": "section_publish"
     },
     {
       "id": "warnings",
       "type": "table",
       "title_badge": "[WARNINGS]",
+      "accent_role": "section_warnings",
       "group_by": "warning.type",
       "row_template": "• [[warn]]{warning.type}[[/]] — [[value]]{warning.count}[[/]] occurrence(s){warning.labels?`: [[dim]]${warning.labels}[[/]]`:''}",
       "fold_labels": { "head": 2, "tail": 1, "when": "!verbose" }
@@ -220,15 +234,16 @@
       "id": "summary",
       "type": "list",
       "title_badge": "[SUMMARY]",
+      "accent_role": "section_summary",
       "items": [
-        "• Clips:[[value]]{clips.count}[[/]]  Window: lead=[[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]] trail=[[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  step=[[value]]{analysis.step}[[/]] downscale=[[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
-        "• Align: audio=[[value]]{audio_alignment.enabled}[[/]]  offsets=[[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  file=[[path]]{audio_alignment.offsets_filename.e}[[/]]",
+        "• Clips:[[value]]{clips.count}[[/]] Window: lead=[[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]] trail=[[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]] step=[[value]]{analysis.step}[[/]] downscale=[[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
+        "• Align: audio=[[value]]{audio_alignment.enabled|bool}[[/]] offsets=[[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]] file=[[path]]{audio_alignment.offsets_filename.e}[[/]]",
         "• Plan: Dark=[[value]]{analysis.counts.dark}[[/]] Bright=[[value]]{analysis.counts.bright}[[/]] Motion=[[value]]{analysis.counts.motion}[[/]] Random=[[value]]{analysis.counts.random}[[/]] User=[[value]]{analysis.counts.user}[[/]]  sep=[[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
-        "• Canvas: single_res=[[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]] upscale=[[value]]{render.upscale}[[/]] crop=mod[[value]]{render.mod_crop}[[/]] pad=[[value]]{render.center_pad}[[/]]",
-        "• Tonemap: [[value]]{tonemap.tone_curve}[[/]]@[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] dpd=[[value]]{tonemap.dynamic_peak_detection}[[/]]  verify≤[[value]]{tonemap.verify_luma_threshold}[[/]]  Δ=[[value]]{verify.delta.max}[[/]]",
+        "• Canvas: single_res=[[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]] upscale=[[value]]{render.upscale|bool}[[/]] crop=mod[[value]]{render.mod_crop}[[/]] pad=[[value]]{render.center_pad|bool}[[/]]",
+        "• Tonemap: [[value]]{tonemap.tone_curve}[[/]]@[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] dpd=[[value]]{tonemap.dynamic_peak_detection|bool}[[/]] verify≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? Δ=[[value]]{verify.delta.max}[[/]]:''}",
         "• Output: [[path]]{render.out_dir.e}[[/]]  compression=[[value]]{render.compression}[[/]]",
         "• Cache: [[path]]{cache.file}[[/]]  status=[[value]]{cache.status}[[/]]",
-        "Output frames: [[value]]{analysis.output_frame_count}[[/]]  [[dim]][{analysis.output_frames_preview}][[/]]  (full list in JSON{verbose?' and above':''})"
+        "• Output frames ([[value]]{analysis.output_frame_count}[[/]]):{emit_json_tail? [[dim]][{analysis.output_frames_preview}][[/]]  (full list in JSON{verbose?' and above':''}) :}{emit_json_tail? : [[value]]{analysis.output_frames_full|wrap_indent2}[[/]]}"
       ]
     }
   ],

--- a/config.toml.template
+++ b/config.toml.template
@@ -118,6 +118,10 @@ prefer_guessit = true
 # Control CLI output behaviours.
 emit_json_tail = true
 
+[cli.progress]
+# Progress bar appearance: "fill" for filled bar, "dot" for single indicator.
+style = "fill"
+
 [paths]
 # Default input folder; override via CLI when needed.
 input_dir = "comparison_videos"

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-10:* Hardened CLI progress configuration by validating styles during config load, normalizing the stored value, and simplifying runtime flag handling to avoid getattr/except patterns flagged by linters.
 - *2025-10-09:* Adjusted overlay text defaults so minimal mode now shows resolution/upscale context and frame-selection type while diagnostic mode drops per-frame selection detail lines that were redundant on-screen but remain available in cached metadata.
 - *2025-10-02:* Restricted audio alignment's NumPy warning suppression to local contexts, paired with regression coverage that preserves global diagnostics while muting noisy dependencies.
 - *2025-10-02:* Bounded the TMDB response cache to a configurable entry limit with TTL-aware eviction to stop unbounded growth flagged in deep-review performance findings.

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2160,21 +2160,18 @@ def run_cli(
         no_color=no_color,
         layout_path=layout_path,
     )
-    cli_cfg = getattr(cfg, "cli", None)
-    emit_json_tail_flag = bool(getattr(cli_cfg, "emit_json_tail", True))
-    progress_cfg = getattr(cli_cfg, "progress", None)
-    if progress_cfg is not None:
-        progress_style = str(getattr(progress_cfg, "style", "fill"))
-    else:
-        progress_style = "fill"
-    progress_style = progress_style.strip().lower()
-    if progress_style not in {"fill", "dot"}:
-        progress_style = "fill"
-    if progress_cfg is not None:
-        try:
-            progress_cfg.style = progress_style
-        except AttributeError:
-            pass
+    cli_cfg = cfg.cli if hasattr(cfg, "cli") else None
+    emit_json_tail_flag = True
+    if cli_cfg is not None and hasattr(cli_cfg, "emit_json_tail"):
+        emit_json_tail_flag = bool(cli_cfg.emit_json_tail)
+
+    progress_cfg = cli_cfg.progress if cli_cfg is not None and hasattr(cli_cfg, "progress") else None
+    progress_style = "fill"
+    if progress_cfg is not None and hasattr(progress_cfg, "style"):
+        candidate_style = str(progress_cfg.style).strip().lower()
+        if candidate_style in {"fill", "dot"}:
+            progress_style = candidate_style
+        progress_cfg.style = progress_style
     reporter.set_flag("progress_style", progress_style)
     reporter.set_flag("emit_json_tail", emit_json_tail_flag)
     collected_warnings: List[str] = []

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2160,18 +2160,13 @@ def run_cli(
         no_color=no_color,
         layout_path=layout_path,
     )
-    cli_cfg = cfg.cli if hasattr(cfg, "cli") else None
     emit_json_tail_flag = True
-    if cli_cfg is not None and hasattr(cli_cfg, "emit_json_tail"):
-        emit_json_tail_flag = bool(cli_cfg.emit_json_tail)
-
-    progress_cfg = cli_cfg.progress if cli_cfg is not None and hasattr(cli_cfg, "progress") else None
     progress_style = "fill"
-    if progress_cfg is not None and hasattr(progress_cfg, "style"):
-        candidate_style = str(progress_cfg.style).strip().lower()
-        if candidate_style in {"fill", "dot"}:
-            progress_style = candidate_style
-        progress_cfg.style = progress_style
+
+    if hasattr(cfg, "cli"):
+        emit_json_tail_flag = bool(getattr(cfg.cli, "emit_json_tail", True))
+        if hasattr(cfg.cli, "progress") and hasattr(cfg.cli.progress, "style"):
+            progress_style = str(cfg.cli.progress.style)
     reporter.set_flag("progress_style", progress_style)
     reporter.set_flag("emit_json_tail", emit_json_tail_flag)
     collected_warnings: List[str] = []
@@ -3566,8 +3561,9 @@ def main(
         slowpics_block.setdefault("shortcut_path", None)
         slowpics_block.setdefault("url", None)
 
-    cli_cfg = getattr(cfg, "cli", None)
-    emit_json_tail_flag = bool(getattr(cli_cfg, "emit_json_tail", True))
+    emit_json_tail_flag = True
+    if hasattr(cfg, "cli"):
+        emit_json_tail_flag = bool(getattr(cfg.cli, "emit_json_tail", True))
 
     if emit_json_tail_flag:
         if json_pretty:

--- a/src/cli_layout.py
+++ b/src/cli_layout.py
@@ -7,12 +7,14 @@ import json
 import os
 import re
 import shutil
+import textwrap
 from itertools import zip_longest
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
 from rich.console import Console
 from rich.progress import BarColumn, Progress, ProgressColumn, Task, TextColumn
+from rich.text import Text
 
 
 class CliLayoutError(RuntimeError):
@@ -579,6 +581,7 @@ class CliLayoutRenderer:
                 if not key.startswith("ascii_")
             }
         self._role_tokens = dict(layout.theme.colors)
+        self._unknown_role_warnings: Set[str] = set()
         self._color_blind_safe = bool(self._theme_options.get("color_blind_safe"))
         if self._color_blind_safe:
             for role, token in _COLOR_BLIND_OVERRIDES.items():
@@ -704,11 +707,11 @@ class CliLayoutRenderer:
     def _colorize(self, role: str, text: str) -> str:
         """
         Apply the theme role's color/style to the given text.
-        
+
         Returns:
-        	The input text wrapped with ANSI escape sequences for the role, or the original text if no style is configured.
+                The input text wrapped with ANSI escape sequences for the role, or the original text if no style is configured.
         """
-        token = self._role_tokens.get(role, "")
+        token = self._lookup_role_token(role)
         return self._color_mapper.apply(token, text)
 
     def _role_style(self, role: Optional[str]) -> Optional[str]:
@@ -723,7 +726,8 @@ class CliLayoutRenderer:
         """
         if self.no_color or not role:
             return None
-        return self._role_tokens.get(role)
+        token = self._lookup_role_token(role)
+        return token or None
 
     def _rich_style_from_token(self, token: Optional[str]) -> Optional[str]:
         """
@@ -780,6 +784,37 @@ class CliLayoutRenderer:
         rich_modifiers.append(base_color)
         return " ".join(rich_modifiers).strip()
 
+    def _lookup_role_token(self, role: Optional[str]) -> str:
+        """Return the style token for ``role`` and warn once when missing."""
+
+        if not role:
+            return ""
+        token = self._role_tokens.get(role)
+        if token is not None:
+            return token
+        if role not in self._unknown_role_warnings:
+            message = f"Unknown color role '{role}' in layout"
+            if self.no_color:
+                self.console.print(f"Warning: {message}")
+            else:
+                self.console.print(f"[yellow]Warning:[/] {message}")
+            self._unknown_role_warnings.add(role)
+        return ""
+
+    def _log_section_role(self, section_id: Optional[str], role: Optional[str]) -> None:
+        """Emit a verbose log line describing the role applied to a section header."""
+
+        if not self.verbose:
+            return
+        label = section_id or "unknown"
+        applied = role or "header"
+        message = f"section[{label}] header role → {applied}"
+        if self.no_color:
+            self.console.log(message, markup=False)
+        else:
+            escaped = message.replace("[", "[[").replace("]", "]]" )
+            self.console.log(f"[dim]{escaped}[/dim]")
+
     def _resolve_section_accent(self, section: Mapping[str, Any], badge: Optional[str] = None) -> Optional[str]:
         """
         Determine the accent role for a section based on an explicit role, badge content, or the section id.
@@ -833,6 +868,7 @@ class CliLayoutRenderer:
         if not badge:
             return
         role = self._resolve_section_accent(section, badge) or "header"
+        self._log_section_role(section.get("id"), role)
         self._write(self._colorize(role, badge))
 
     def _apply_style_spans(self, text: str) -> str:
@@ -1203,6 +1239,8 @@ class CliLayoutRenderer:
                 return format(value, fmt)
             except (TypeError, ValueError):
                 pass
+        if isinstance(value, bool):
+            return "true" if value else "false"
         if isinstance(value, int) and not isinstance(value, bool):
             separator = self.layout.theme.units.get("thousands_sep")
             if separator:
@@ -1232,6 +1270,20 @@ class CliLayoutRenderer:
         Returns:
             Any: The transformed value according to the selected filter.
         """
+        if filter_name == "bool":
+            return "true" if bool(value) else "false"
+        if filter_name == "wrap_indent2":
+            text = "" if value is None else str(value)
+            if not text:
+                return ""
+            width = max(10, self._console_width() - 2)
+            return textwrap.fill(
+                text,
+                width=width,
+                subsequent_indent="  ",
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
         if filter_name == "none":
             return value if value not in (None, "") else "none"
         if filter_name == "unchanged":
@@ -1415,7 +1467,7 @@ class CliLayoutRenderer:
             return None
         true_expr = remainder[:colon_index]
         false_expr = remainder[colon_index + 1 :]
-        return left.strip(), true_expr.strip(), false_expr.strip()
+        return left.strip(), true_expr, false_expr
 
     def _find_unescaped_question(self, text: str) -> Optional[int]:
         """
@@ -1765,7 +1817,7 @@ class CliLayoutRenderer:
             if subtitle:
                 self._write(self._format_subtitle(subtitle))
                 if show_rule:
-                    rule_line = self._build_rule_line(lines)
+                    rule_line = self._build_rule_line(subtitle, lines)
                     if rule_line:
                         self._write(rule_line)
             for line in lines:
@@ -1815,15 +1867,16 @@ class CliLayoutRenderer:
             return text
         return self._colorize("accent_subhead", text)
 
-    def _build_rule_line(self, lines: Sequence[str]) -> str:
+    def _build_rule_line(self, subtitle: str, lines: Sequence[str]) -> str:
         """
-        Constructs a horizontal rule aligned to the smallest indentation and visible content width of the provided lines.
-        
+        Construct a horizontal rule sized to the subtitle label and block content width.
+
         Parameters:
-            lines (Sequence[str]): Lines used to determine the minimal indentation and maximum visible content width.
-        
+            subtitle (str): Subtitle text used to size the decorative rule.
+            lines (Sequence[str]): Lines used to determine indentation and available content width.
+
         Returns:
-            str: A single-line string containing a horizontal rule indented to the minimal indentation found and truncated to fit the console width and content width. Returns an empty string if there is no visible content. Uses '-' when ASCII symbols are required; otherwise uses '─' and applies the `rule_dim` role color.
+            str: A single-line string containing a horizontal rule indented to the minimal indentation found and truncated to fit the console width, block content width, and subtitle width. Returns an empty string if there is no visible content. Uses '-' when ASCII symbols are required; otherwise uses '─' and applies the `rule_dim` role color.
         """
         if not lines:
             return ""
@@ -1841,6 +1894,11 @@ class CliLayoutRenderer:
         indent = indent or 0
         width_limit = max(1, self._console_width() - indent)
         rule_width = min(max_content_width, width_limit)
+        subtitle_width = self._visible_length(self._format_subtitle(subtitle))
+        max_rule_width = max(1, min(32, subtitle_width + 2))
+        rule_width = min(rule_width, max_rule_width)
+        if rule_width <= 0:
+            return ""
         char = "-" if self._using_ascii_symbols() else "─"
         rule_body = char * rule_width
         if not self._using_ascii_symbols():
@@ -1975,16 +2033,22 @@ class CliLayoutRenderer:
         accent_role = info.get("accent")
 
         bar_style_token = self._role_style(accent_role or "accent")
-        rich_bar_style = self._rich_style_from_token(bar_style_token)
-        if rich_bar_style:
-            bar_column = BarColumn(
-                style=rich_bar_style,
-                complete_style=rich_bar_style,
-                finished_style=rich_bar_style,
-                pulse_style=rich_bar_style,
-            )
+        progress_style = str(self._active_flags.get("progress_style", "fill")).strip().lower()
+        if progress_style not in {"fill", "dot"}:
+            progress_style = "fill"
+        if progress_style == "dot":
+            bar_column = _DotProgressColumn(self, bar_style_token)
         else:
-            bar_column = BarColumn()
+            rich_bar_style = self._rich_style_from_token(bar_style_token)
+            if rich_bar_style:
+                bar_column = BarColumn(
+                    style=rich_bar_style,
+                    complete_style=rich_bar_style,
+                    finished_style=rich_bar_style,
+                    pulse_style=rich_bar_style,
+                )
+            else:
+                bar_column = BarColumn()
 
         columns: List[ProgressColumn] = [
             TextColumn("{task.description}", justify="left"),
@@ -1998,6 +2062,42 @@ class CliLayoutRenderer:
 
         transient_flag = bool(block.get("transient", transient))
         return Progress(*columns, console=self.console, transient=transient_flag)
+
+
+class _DotProgressColumn(ProgressColumn):
+    """Progress column that renders a single moving marker along a track."""
+
+    def __init__(self, renderer: "CliLayoutRenderer", style_token: Optional[str]) -> None:
+        super().__init__()
+        self.renderer = renderer
+        self._style_token = style_token
+
+    def render(self, task: Task) -> Text:
+        total = task.total or 0
+        completed = task.completed or 0
+        ratio = 0.0
+        if total:
+            try:
+                ratio = max(0.0, min(1.0, float(completed) / float(total)))
+            except ZeroDivisionError:
+                ratio = 0.0
+        width = max(10, min(28, self.renderer._console_width() // 3))
+        if self.renderer._using_ascii_symbols():
+            track_char = "-"
+            marker = "*"
+        else:
+            track_char = "─"
+            marker = "●"
+        bar_chars = [track_char] * width
+        index = 0
+        if width > 1:
+            index = min(width - 1, int(round(ratio * (width - 1))))
+        bar_chars[index] = marker
+        bar_text = "".join(bar_chars)
+        rich_style = self.renderer._rich_style_from_token(self._style_token)
+        if rich_style:
+            return Text(bar_text, style=rich_style)
+        return Text(bar_text)
 
 
 class _TemplateProgressColumn(ProgressColumn):

--- a/src/cli_layout.py
+++ b/src/cli_layout.py
@@ -2091,7 +2091,7 @@ class _DotProgressColumn(ProgressColumn):
         bar_chars = [track_char] * width
         index = 0
         if width > 1:
-            index = min(width - 1, int(round(ratio * (width - 1))))
+            index = min(width - 1, round(ratio * (width - 1)))
         bar_chars[index] = marker
         bar_text = "".join(bar_chars)
         rich_style = self.renderer._rich_style_from_token(self._style_token)

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -167,6 +167,12 @@ def load_config(path: str) -> AppConfig:
         ),
     )
 
+    if hasattr(app.cli, "progress") and hasattr(app.cli.progress, "style"):
+        normalized_style = str(app.cli.progress.style).strip().lower()
+        if normalized_style not in {"fill", "dot"}:
+            raise ConfigError("cli.progress.style must be 'fill' or 'dot'")
+        app.cli.progress.style = normalized_style
+
     if app.analysis.step < 1:
         raise ConfigError("analysis.step must be >= 1")
     if app.analysis.downscale_height < 0:

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -201,6 +201,11 @@ def load_config(path: str) -> AppConfig:
         raise ConfigError("screenshots.pad_to_canvas must be 'off', 'on', or 'auto'")
     app.screenshots.pad_to_canvas = pad_mode
 
+    progress_style = str(app.cli.progress.style).strip().lower()
+    if progress_style not in {"fill", "dot"}:
+        raise ConfigError("cli.progress.style must be 'fill' or 'dot'")
+    app.cli.progress.style = progress_style
+
     if app.slowpics.remove_after_days < 0:
         raise ConfigError("slowpics.remove_after_days must be >= 0")
     if app.slowpics.image_upload_timeout_seconds <= 0:

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -118,10 +118,18 @@ class NamingConfig:
 
 
 @dataclass
+class CLIProgressConfig:
+    """Presentation preferences for progress indicators."""
+
+    style: str = "fill"
+
+
+@dataclass
 class CLIConfig:
     """CLI presentation controls."""
 
     emit_json_tail: bool = True
+    progress: CLIProgressConfig = field(default_factory=CLIProgressConfig)
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,6 +38,7 @@ def test_load_defaults(tmp_path: Path) -> None:
     assert app.tmdb.cache_ttl_seconds == 86400
     assert app.tmdb.category_preference is None
     assert app.cli.emit_json_tail is True
+    assert app.cli.progress.style == "fill"
 
 
 @pytest.mark.parametrize(
@@ -95,6 +96,9 @@ category_preference = "tv"
 [cli]
 emit_json_tail = false
 
+[cli.progress]
+style = "dot"
+
 [paths]
 input_dir = "D:/comparisons"
 
@@ -130,3 +134,4 @@ preferred = "ffms2"
     assert app.tmdb.cache_ttl_seconds == 120
     assert app.tmdb.category_preference == "TV"
     assert app.cli.emit_json_tail is False
+    assert app.cli.progress.style == "dot"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,7 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[tmdb]\nyear_tolerance = -1\n", "tmdb.year_tolerance"),
         ("[tmdb]\ncache_ttl_seconds = -5\n", "tmdb.cache_ttl_seconds"),
         ("[tmdb]\ncategory_preference = \"documentary\"\n", "tmdb.category_preference"),
+        ("[cli.progress]\nstyle = \"blink\"\n", "cli.progress.style"),
     ],
 )
 def test_validation_errors(tmp_path: Path, toml_snippet: str, message: str) -> None:
@@ -97,7 +98,7 @@ category_preference = "tv"
 emit_json_tail = false
 
 [cli.progress]
-style = "dot"
+style = "DOT"
 
 [paths]
 input_dir = "D:/comparisons"

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -168,7 +168,7 @@ def test_cli_applies_overrides_and_naming(tmp_path, monkeypatch, runner):
     assert "ignore_lead=0.00s" in result.output
     assert "[SUMMARY]" in result.output
     assert "• Clips:" in result.output
-    assert "Output frames:" in result.output
+    assert "Output frames (" in result.output
 
     assert ram_limits == [cfg.runtime.ram_limit_mb]
 


### PR DESCRIPTION
## Summary
- add a CLI progress configuration dataclass, nested config loading, and template defaults
- normalize the layout specification: explicit section accent roles, cleaned writer/overlay rows, full-frame summary output, and progress bar styling toggle
- teach the renderer to format booleans consistently, warn on unknown roles, support wrap indentation, and respect the JSON tail flag in the CLI entry point
- update and extend tests for the new configuration, layout output, and progress styles

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e8a80469848321b44ce07d7f5824e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable CLI progress style ("fill" or "dot"); new themed accents for sections: discover, prepare, analyze, render, publish, warnings, summary.

* **Improvements**
  * Booleans render as "true"/"false"; writer labels normalized to lowercase; FPS shows two decimals.
  * Summary can emit an optional JSON tail or expanded full frame list; conditional/boolean summary lines and subtitle-aware section styling.
  * One-time warnings for unknown roles; enhanced progress visuals.

* **Tests**
  * Updated tests for progress styles, boolean rendering, and summary variants.

* **Documentation**
  * Changelog and decision notes updated for progress validation and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->