### PR TITLE
Validate CLI progress style configuration

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2164,9 +2164,16 @@ def run_cli(
     progress_style = "fill"
 
     if hasattr(cfg, "cli"):
-        emit_json_tail_flag = bool(getattr(cfg.cli, "emit_json_tail", True))
-        if hasattr(cfg.cli, "progress") and hasattr(cfg.cli.progress, "style"):
-            progress_style = str(cfg.cli.progress.style)
+        cli_cfg = cfg.cli
+        emit_json_tail_flag = bool(getattr(cli_cfg, "emit_json_tail", True))
+        if hasattr(cli_cfg, "progress"):
+            style_value = getattr(cli_cfg.progress, "style", "fill")
+            progress_style = str(style_value).strip().lower()
+            if progress_style not in {"fill", "dot"}:
+                logger.warning(
+                    "Invalid progress style '%s', falling back to 'fill'", style_value
+                )
+                progress_style = "fill"
     reporter.set_flag("progress_style", progress_style)
     reporter.set_flag("emit_json_tail", emit_json_tail_flag)
     collected_warnings: List[str] = []
@@ -3563,7 +3570,8 @@ def main(
 
     emit_json_tail_flag = True
     if hasattr(cfg, "cli"):
-        emit_json_tail_flag = bool(getattr(cfg.cli, "emit_json_tail", True))
+        cli_cfg = cfg.cli
+        emit_json_tail_flag = bool(getattr(cli_cfg, "emit_json_tail", True))
 
     if emit_json_tail_flag:
         if json_pretty:

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -167,11 +167,10 @@ def load_config(path: str) -> AppConfig:
         ),
     )
 
-    if hasattr(app.cli, "progress") and hasattr(app.cli.progress, "style"):
-        normalized_style = str(app.cli.progress.style).strip().lower()
-        if normalized_style not in {"fill", "dot"}:
-            raise ConfigError("cli.progress.style must be 'fill' or 'dot'")
-        app.cli.progress.style = normalized_style
+    normalized_style = str(app.cli.progress.style).strip().lower()
+    if normalized_style not in {"fill", "dot"}:
+        raise ConfigError("cli.progress.style must be 'fill' or 'dot'")
+    app.cli.progress.style = normalized_style
 
     if app.analysis.step < 1:
         raise ConfigError("analysis.step must be >= 1")


### PR DESCRIPTION
## Summary
- normalize CLI progress style usage when running the reporter and guard against unexpected values
- validate `cli.progress.style` during configuration loading so invalid values are rejected early

## Testing
- uv run pytest *(fails: missing system dependency `libvapoursynth` needed to build vapoursynth)*

------
https://chatgpt.com/codex/tasks/task_e_68e8b8cff5f4832185d3c8eb77620b3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI progress style is now validated and normalized (case-insensitive), supporting only “fill” and “dot”.
  * Invalid or unrecognized progress styles default to “fill” with a warning.
  * Earlier, clearer errors surface for missing or malformed progress style configuration.

* **Refactor**
  * Standardized retrieval of CLI settings for consistent behavior, including handling of JSON tail emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->