### PR TITLE
Refine VapourSynth stubs for bound clip helpers

### DIFF
--- a/typings/vapoursynth/__init__.pyi
+++ b/typings/vapoursynth/__init__.pyi
@@ -5,8 +5,7 @@ class _FrameLike(Protocol):
     props: Mapping[str, Any]
 
 
-class _StdOps(Protocol):
-class _StdOps(Protocol):
+class _StdCoreOps(Protocol):
     def PlaneStats(
         self,
         clip: "VideoNode",
@@ -17,8 +16,18 @@ class _StdOps(Protocol):
     def Prewitt(self, clip: "VideoNode") -> "VideoNode": ...
     def Expr(self, clips: Sequence["VideoNode"], expr: str) -> "VideoNode": ...
     def Trim(self, clip: "VideoNode", first: int, last: int) -> "VideoNode": ...
-    def SelectEvery(self, clip: "VideoNode", cycle: int, offsets: Sequence[int]) -> "VideoNode": ...
-    def ShufflePlanes(self, clip: "VideoNode", planes: Sequence[int] | int, colorfamily: Any) -> "VideoNode": ...
+    def SelectEvery(
+        self,
+        clip: "VideoNode",
+        cycle: int,
+        offsets: Sequence[int],
+    ) -> "VideoNode": ...
+    def ShufflePlanes(
+        self,
+        clip: "VideoNode",
+        planes: Sequence[int] | int,
+        colorfamily: Any,
+    ) -> "VideoNode": ...
     def CropRel(
         self,
         clip: "VideoNode",
@@ -27,6 +36,31 @@ class _StdOps(Protocol):
         right: int = ...,
         bottom: int = ...,
     ) -> "VideoNode": ...
+    def AddBorders(
+        self,
+        clip: "VideoNode",
+        left: int = ...,
+        right: int = ...,
+        top: int = ...,
+        bottom: int = ...,
+    ) -> "VideoNode": ...
+    def SetFrameProps(self, clip: "VideoNode", **props: Any) -> "VideoNode": ...
+
+
+class _StdBoundOps(Protocol):
+    def PlaneStats(
+        self,
+        plane: int | None = ...,
+        prop: str | None = ...,
+    ) -> "VideoNode": ...
+    def CropRel(
+        self,
+        left: int = ...,
+        top: int = ...,
+        right: int = ...,
+        bottom: int = ...,
+    ) -> "VideoNode": ...
+    def SetFrameProps(self, **props: Any) -> "VideoNode": ...
 
 
 class _ResizeOps(Protocol):
@@ -39,10 +73,28 @@ class _ResizeOps(Protocol):
         format: Any | None = ...,
         **kwargs: Any,
     ) -> "VideoNode": ...
+    def Point(
+        self,
+        clip: "VideoNode",
+        *,
+        width: int | None = ...,
+        height: int | None = ...,
+        format: Any | None = ...,
+        **kwargs: Any,
+    ) -> "VideoNode": ...
+    def Spline36(
+        self,
+        clip: "VideoNode",
+        *,
+        width: int | None = ...,
+        height: int | None = ...,
+        format: Any | None = ...,
+        **kwargs: Any,
+    ) -> "VideoNode": ...
 
 
 class _Core(Protocol):
-    std: _StdOps
+    std: _StdCoreOps
     resize: _ResizeOps
 
 
@@ -52,7 +104,8 @@ class VideoNode(Protocol):
     width: int
     height: int
     num_frames: int
-    std: _StdOps
+    core: _Core
+    std: _StdBoundOps
 
     def __getitem__(self, item: slice) -> "VideoNode": ...
     def get_frame(self, index: int) -> _FrameLike: ...


### PR DESCRIPTION
## Summary
- split VapourSynth std operations into core and bound protocols so bound calls no longer require explicit clip arguments
- extend resize and std stubs with the operations used by analysis and screenshot helpers so downstream nodes stay strongly typed

## Testing
- ✅ `npx --yes pyright --warnings --outputjson`
- ⚠️ `pytest -q` *(fails: missing optional runtime dependencies such as rich, requests, httpx, vapoursynth)*

------
https://chatgpt.com/codex/tasks/task_e_68e9dfeb60108321b1aa185e5a252b47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add borders to clips.
  - Set frame properties both globally and per-clip.
  - Compute per-plane statistics.
  - Crop by relative margins.
  - Additional resize methods, including nearest-neighbor and Spline36.

- Refactor
  - Reorganized standard operations between core-level and clip-bound contexts for clearer usage.
  - Type hints and signatures streamlined for consistency without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->