### PR TITLE
Fix multiline summary list rendering

### DIFF
--- a/tests/test_cli_layout_render.py
+++ b/tests/test_cli_layout_render.py
@@ -310,6 +310,40 @@ def test_layout_renderer_sample_output(tmp_path, monkeypatch):
         assert any(expected in log for log in section_logs), expected
 
 
+def test_summary_output_frames_full_list_without_ellipsis(tmp_path: Path) -> None:
+    layout_path = _project_root() / "cli_layout.v1.json"
+    layout = load_cli_layout(layout_path)
+    console = Console(width=160, record=True, color_system=None)
+    renderer = CliLayoutRenderer(layout, console, quiet=False, verbose=False, no_color=True)
+
+    sample_values = _sample_values(tmp_path)
+    long_frames = ", ".join(str(index) for index in range(50))
+    sample_values["analysis"]["output_frames_full"] = f"[{long_frames}]"
+    sample_values["analysis"]["output_frame_count"] = 50
+    sample_values["analysis"]["output_frames_preview"] = "0, 1, 2, 3"
+
+    flags: Dict[str, Any] = {
+        "emit_json_tail": False,
+        "verbose": False,
+        "quiet": False,
+        "no_color": True,
+    }
+
+    renderer.bind_context(sample_values, flags)
+    summary_section = next(section for section in layout.sections if section["id"] == "summary")
+    renderer.render_section(summary_section, sample_values, flags)
+
+    output_text = console.export_text()
+    normalized = " ".join(line.strip() for line in output_text.splitlines() if line.strip())
+
+    assert "• Output frames (50):" in normalized
+    assert f"[{long_frames}]" in normalized
+
+    summary_start = normalized.index("• Output frames (50):")
+    summary_text = normalized[summary_start:]
+    assert "…" not in summary_text
+
+
 def test_layout_expression_rejects_dunder_access(tmp_path):
     layout_path = _project_root() / "cli_layout.v1.json"
     layout = load_cli_layout(layout_path)


### PR DESCRIPTION
## Summary
- skip two-column formatting when list items contain wrapped output so multiline content prints in full
- split multiline entries into separate lines while preserving existing single-line behavior
- add a regression test to ensure the summary section shows the complete output frame list when JSON tail emission is disabled

## Testing
- pytest tests/test_cli_layout_render.py::test_summary_output_frames_full_list_without_ellipsis

------
https://chatgpt.com/codex/tasks/task_e_68e9f805f2d48321960943f899bff7fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Smarter CLI layout: uses two columns only when appropriate and preserves multiline items without splitting across columns.
  * Cleaner output: skips empty/falsy items, renders multiline entries line-by-line, and handles blank lines explicitly.
  * Improved list rendering: avoids showing ellipses when a full list is intended and console width allows.

* **Bug Fixes**
  * Prevents empty list artifacts by returning early when there’s nothing to display.

* **Tests**
  * Added coverage to verify full, non-ellipsized list rendering and correct count labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->