### PR TITLE
Fix Windows 256-color detection regression

### DIFF
--- a/tests/test_cli_layout_render.py
+++ b/tests/test_cli_layout_render.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict
 
 import pytest
@@ -10,7 +11,9 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.cli_layout import CliLayoutRenderer, LayoutContext, load_cli_layout
+import src.cli_layout as cli_layout
+
+from src.cli_layout import CliLayoutRenderer, LayoutContext, _AnsiColorMapper, load_cli_layout
 
 
 def _project_root() -> Path:
@@ -328,3 +331,107 @@ def test_layout_expression_rejects_dunder_access(tmp_path):
     )
 
     assert renderer._evaluate_expression("__import__('os')", context) is None
+
+
+def test_windows_terminal_enables_256_colors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure Windows Terminal environments are detected as 256-color capable."""
+
+    layout_path = _project_root() / "cli_layout.v1.json"
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+    monkeypatch.delenv("WT_SESSION", raising=False)
+    monkeypatch.delenv("FRAME_COMPARE_FORCE_256_COLOR", raising=False)
+    monkeypatch.setenv("TERM_PROGRAM", "Windows_Terminal")
+    monkeypatch.setattr(cli_layout.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        _AnsiColorMapper,
+        "_enable_windows_vt_mode",
+        staticmethod(lambda: None),
+    )
+
+    capability = _AnsiColorMapper._detect_capability()
+    assert capability == "256"
+
+    mapper = _AnsiColorMapper(no_color=False)
+    layout = load_cli_layout(layout_path)
+    section_token = layout.theme.colors["section_analyze"]
+    accent_token = layout.theme.colors["accent_subhead"]
+
+    section = mapper._lookup(section_token)
+    accent = mapper._lookup(accent_token)
+
+    assert mapper._capability == "256"
+    assert section.startswith("\x1b[")
+    assert accent.startswith("\x1b[")
+    assert section != accent
+
+
+def test_force_256_color_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit override should force the mapper into 256-color mode."""
+
+    monkeypatch.setenv("FRAME_COMPARE_FORCE_256_COLOR", "yes")
+    monkeypatch.delenv("COLORTERM", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+    monkeypatch.setattr(
+        _AnsiColorMapper,
+        "_enable_windows_vt_mode",
+        staticmethod(lambda: None),
+    )
+
+    capability = _AnsiColorMapper._detect_capability()
+    assert capability == "256"
+
+    mapper = _AnsiColorMapper(no_color=False)
+    assert mapper._capability == "256"
+
+
+def test_windows_terminal_bypasses_colorama_convert(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Modern Windows consoles should leave ANSI escapes intact for 256-color output."""
+
+    fake_colorama = ModuleType("colorama")
+    fake_colorama.init_kwargs: Dict[str, Any] = {}
+
+    def just_fix_windows_console() -> None:
+        return None
+
+    def init(*, strip: bool, convert: bool) -> None:
+        fake_colorama.init_kwargs = {"strip": strip, "convert": convert}
+
+    fake_colorama.just_fix_windows_console = just_fix_windows_console  # type: ignore[attr-defined]
+    fake_colorama.init = init  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("TERM_PROGRAM", "Windows_Terminal")
+    monkeypatch.delenv("WT_SESSION", raising=False)
+    monkeypatch.delenv("FRAME_COMPARE_FORCE_256_COLOR", raising=False)
+    monkeypatch.setattr(cli_layout.os, "name", "nt", raising=False)
+    monkeypatch.setitem(sys.modules, "colorama", fake_colorama)
+
+    _AnsiColorMapper._enable_windows_vt_mode()
+
+    assert fake_colorama.init_kwargs == {"strip": False, "convert": False}
+
+
+def test_legacy_windows_console_keeps_colorama_convert(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy Windows consoles should keep colorama conversion enabled for 16-color escapes."""
+
+    fake_colorama = ModuleType("colorama")
+    fake_colorama.init_kwargs: Dict[str, Any] = {}
+
+    def just_fix_windows_console() -> None:
+        return None
+
+    def init(*, strip: bool, convert: bool) -> None:
+        fake_colorama.init_kwargs = {"strip": strip, "convert": convert}
+
+    fake_colorama.just_fix_windows_console = just_fix_windows_console  # type: ignore[attr-defined]
+    fake_colorama.init = init  # type: ignore[attr-defined]
+
+    monkeypatch.delenv("TERM_PROGRAM", raising=False)
+    monkeypatch.delenv("WT_SESSION", raising=False)
+    monkeypatch.delenv("FRAME_COMPARE_FORCE_256_COLOR", raising=False)
+    monkeypatch.setattr(cli_layout.os, "name", "nt", raising=False)
+    monkeypatch.setitem(sys.modules, "colorama", fake_colorama)
+
+    _AnsiColorMapper._enable_windows_vt_mode()
+
+    assert fake_colorama.init_kwargs == {"strip": False, "convert": True}


### PR DESCRIPTION
## Summary
- add helpers to reuse Windows terminal heuristics and truthy flag parsing in the ANSI color mapper
- disable colorama's ANSI conversion when modern Windows terminals or the 256-color override are detected so 256-color escape codes render
- extend CLI layout tests to cover the colorama conversion logic for modern and legacy Windows consoles

## Testing
- pytest tests/test_cli_layout_render.py::test_windows_terminal_enables_256_colors tests/test_cli_layout_render.py::test_force_256_color_override tests/test_cli_layout_render.py::test_windows_terminal_bypasses_colorama_convert tests/test_cli_layout_render.py::test_legacy_windows_console_keeps_colorama_convert


------
https://chatgpt.com/codex/tasks/task_e_68e9f2c6fbc4832193cf79bda420c96e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically detects modern Windows terminals and adjusts ANSI color handling accordingly for more accurate color output.
- Bug Fixes
  - Improves reliability of color rendering on Windows by disabling conversion when true/256-color support is detected, reducing mismatched or degraded colors.
  - Maintains graceful behavior when optional VT features aren’t available, avoiding crashes.
- Tests
  - Minor test updates with no impact on user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->