### PR TITLE
Realign CLI summary output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-14:* Clarified CLI hierarchy by softening section badge colors, brightening subhead prefixes, expanding the At-a-Glance box with alignment, sampling, and canvas metrics for quicker triage, and realigning the Summary section with key/value formatting to remove ragged rows.
 - *2025-10-13:* Removed the `types-pytest` dev dependency so `uv run` can resolve environments on fresh clones without relying on a non-existent stub package while keeping the actual `pytest` runtime dependency in the dev group for CI and local tests.
 - *2025-10-10:* Reject invalid `cli.progress.style` values during configuration loading and persist normalized styles for downstream flag handling to keep CLI reporters consistent.
 - *2025-10-12:* Added local type stubs for optional CLI/testing dependencies and hardened JSON-tail assertions in tests so Pyright runs cleanly without relaxing diagnostic settings.

--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -9,13 +9,13 @@
       "accent_render": "magenta.bright",
       "accent_publish": "green.bright",
       "section_discover": "cyan.bold",
-      "section_prepare": "blue.bright",
-      "section_analyze": "purple.bright",
-      "section_render": "magenta.bright",
-      "section_publish": "green.bright",
+      "section_prepare": "blue",
+      "section_analyze": "purple",
+      "section_render": "magenta",
+      "section_publish": "green",
       "section_warnings": "yellow.bold",
       "section_summary": "cyan.bold",
-      "accent_subhead": "magenta.bold",
+      "accent_subhead": "yellow.bright",
       "value": "white.bright",
       "unit": "grey.dim",
       "key": "blue",
@@ -78,10 +78,12 @@
       "title": "At-a-Glance",
       "when": "true",
       "lines": [
-        "Clips=[[value]]{clips.count}[[/]] • Step=[[value]]{analysis.step}[[/]] • Downscale=[[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]] • Plan: Dark=[[value]]{analysis.counts.dark}[[/]] Bright=[[value]]{analysis.counts.bright}[[/]] Motion=[[value]]{analysis.counts.motion}[[/]]",
-        "Window: lead=[[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]] trail=[[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]] • Align(audio)=[[value]]{audio_alignment.enabled}[[/]] [[unit]]({audio_alignment.offsets_sec:+.3f}s)[[/]]",
-        "Canvas: single_res=[[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale=[[value]]{render.upscale}[[/]]  crop=mod[[value]]{render.mod_crop}[[/]]  pad=[[value]]{render.center_pad}[[/]],[[unit]]tol={render.letterbox_px_tolerance}px[[/]]",
-        "Tonemap: curve=[[value]]{tonemap.tone_curve}[[/]]  dpd=[[value]]{tonemap.dynamic_peak_detection}[[/]]  target=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] • Seed=[[value]]{analysis.random_seed}[[/]] • Cache=[[value]]{cache.status}[[/]]"
+        "[[key]]Clips[[/]] [[value]]{clips.count}[[/]]  [[key]]Step[[/]] [[value]]{analysis.step}[[/]]  [[key]]Downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]  [[key]]Frames[[/]] [[value]]{analysis.output_frame_count}[[/]]",
+        "[[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  min [[value]]{window.min_window_seconds:.2f}[[/]][[unit]]s[[/]]",
+        "[[key]]Plan[[/]] dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]",
+        "[[key]]Audio align[[/]] [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  corr [[value]]{audio_alignment.corr:.2f}[[/]]",
+        "[[key]]Canvas[[/]] single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
+        "[[key]]Tonemap[[/]] [[value]]{tonemap.tone_curve}[[/]] → [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  [[key]]Cache[[/]] [[value]]{cache.status}[[/]]"
       ]
     },
     {
@@ -236,14 +238,14 @@
       "title_badge": "[SUMMARY]",
       "accent_role": "section_summary",
       "items": [
-        "• Clips:[[value]]{clips.count}[[/]] Window: lead=[[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]] trail=[[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]] step=[[value]]{analysis.step}[[/]] downscale=[[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
-        "• Align: audio=[[value]]{audio_alignment.enabled|bool}[[/]] offsets=[[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]] file=[[path]]{audio_alignment.offsets_filename.e}[[/]]",
-        "• Plan: Dark=[[value]]{analysis.counts.dark}[[/]] Bright=[[value]]{analysis.counts.bright}[[/]] Motion=[[value]]{analysis.counts.motion}[[/]] Random=[[value]]{analysis.counts.random}[[/]] User=[[value]]{analysis.counts.user}[[/]]  sep=[[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
-        "• Canvas: single_res=[[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]] upscale=[[value]]{render.upscale|bool}[[/]] crop=mod[[value]]{render.mod_crop}[[/]] pad=[[value]]{render.center_pad|bool}[[/]]",
-        "• Tonemap: [[value]]{tonemap.tone_curve}[[/]]@[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] dpd=[[value]]{tonemap.dynamic_peak_detection|bool}[[/]] verify≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? Δ=[[value]]{verify.delta.max}[[/]]:''}",
-        "• Output: [[path]]{render.out_dir.e}[[/]]  compression=[[value]]{render.compression}[[/]]",
-        "• Cache: [[path]]{cache.file}[[/]]  status=[[value]]{cache.status}[[/]]",
-        "• Output frames ([[value]]{analysis.output_frame_count}[[/]]):{emit_json_tail? [[dim]][{analysis.output_frames_preview}][[/]]  (full list in JSON{verbose?' and above':''}) :}{emit_json_tail? : [[value]]{analysis.output_frames_full|wrap_indent2}[[/]]}"
+        "[[key]]Clips[[/]] [[value]]{clips.count}[[/]]  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  step [[value]]{analysis.step}[[/]]  downscale [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
+        "[[key]]Align[[/]] audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
+        "[[key]]Plan[[/]] dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
+        "[[key]]Canvas[[/]] single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
+        "[[key]]Tonemap[[/]] curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]]  verify ≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] Δ=[[value]]{verify.delta.max}[[/]][[/]]:''}",
+        "[[key]]Output[[/]] [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]  frames [[value]]{analysis.output_frame_count}[[/]]",
+        "[[key]]Cache[[/]] [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
+        "[[key]]Frames[[/]] total [[value]]{analysis.output_frame_count}[[/]]{emit_json_tail? [[dim]]  preview [[value]]{analysis.output_frames_preview}[[/]]  (full list in JSON{verbose?' and above':''})[[/]] : [[value]]{analysis.output_frames_full|wrap_indent2}[[/]]}"
       ]
     }
   ],

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-14:* Adjusted CLI theming to separate hierarchy (muted section badges, yellow subheads) and rewrote the At-a-Glance summary to surface sampling, window, and alignment metrics requested in the usability review.
 - *2025-10-13:* Dropped the unused `types-pytest` dependency from the dev group because the package is unavailable on PyPI and broke `uv run` environment creation on fresh clones. CI keeps installing real `pytest` through the dev group, so workflows and local test runs continue to function normally.
 - *2025-10-12:* Introduced local stubs for click, requests, httpx, and rich plus tighter JSON-tail helpers in tests to eliminate Pyright/Pylance import and indexing errors while keeping diagnostics strict.
 - *2025-10-11:* Audited the `docs/` catalog, refreshed the deep-review memo with current safeguards/follow-ups, and corrected README reference defaults to match the live config schema.
@@ -12,3 +13,4 @@
 - *2025-09-30:* Standardised group subhead styling across CLI sections: accent-subhead prefixes (`›`/`>` fallback), dim divider rules sized to block content, column alignment for numeric values, and verbose legends describing token roles to satisfy `features/CLI/GUIDE.md`.
 - *2025-09-30:* Simplified diagnostic overlays by replacing the HDR MAX/AVG measurement block with render resolution, mastering display luminance (for HDR sources), and cached frame-selection metadata while trimming redundant frame-info lines to keep CLI banners uncluttered.
 - *2025-09-29:* Adopted CLI layout styling DSL with semantic spans and data-driven highlight rules. Renderer now consumes palette roles (`value`, `unit`, `path`, etc.), honors section accent theming, and evaluates JSON-configured thresholds (e.g., tonemap verification, boolean states) to keep formatting declarative.
+- *2025-10-14:* Adopted key/value styling in the CLI Summary list to mirror At-a-Glance key/value formatting and keep closing metrics aligned.


### PR DESCRIPTION
## Summary
- restyle the CLI SUMMARY section entries to use key/value tokens so labels align with their metrics
- clarify documentation by noting the summary alignment change in the changelog and decisions log

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea277405c883219c4b9053d4931992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CLI “At-a-Glance” and Summary now use structured key/value blocks with expanded metrics (e.g., Clips, Step, Downscale, Frames, Window lead/trail/min, Plan counts, Audio align details, Canvas options, Tonemap settings, Cache status, Output frames).
- Style
  - Refreshed CLI color scheme (less bright tones) and unified key/value styling for improved readability and alignment.
- Documentation
  - Added a new changelog entry for 2025-10-14.
  - Updated decisions log describing the adoption of key/value styling in CLI summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->