### PR TITLE
Restore summary bullets in CLI layout

### DIFF
--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -238,14 +238,14 @@
       "title_badge": "[SUMMARY]",
       "accent_role": "section_summary",
       "items": [
-        "[[key]]Clips[[/]] [[value]]{clips.count}[[/]]  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  step [[value]]{analysis.step}[[/]]  downscale [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
-        "[[key]]Align[[/]] audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
-        "[[key]]Plan[[/]] dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
-        "[[key]]Canvas[[/]] single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
-        "[[key]]Tonemap[[/]] curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]]  verify ≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] Δ=[[value]]{verify.delta.max}[[/]][[/]]:''}",
-        "[[key]]Output[[/]] [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]  frames [[value]]{analysis.output_frame_count}[[/]]",
-        "[[key]]Cache[[/]] [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
-        "[[key]]Frames[[/]] total [[value]]{analysis.output_frame_count}[[/]]{emit_json_tail? [[dim]]  preview [[value]]{analysis.output_frames_preview}[[/]]  (full list in JSON{verbose?' and above':''})[[/]] : [[value]]{analysis.output_frames_full|wrap_indent2}[[/]]}"
+        "• [[key]]Clips[[/]]: [[value]]{clips.count}[[/]]  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  [[key]]step[[/]] [[value]]{analysis.step}[[/]]  [[key]]downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
+        "• [[key]]Align[[/]]: audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
+        "• [[key]]Plan[[/]]: dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
+        "• [[key]]Canvas[[/]]: single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
+        "• [[key]]Tonemap[[/]]: curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]]  verify ≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] Δ=[[value]]{verify.delta.max}[[/]][[/]]:''}",
+        "• [[key]]Output[[/]]: [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]  frames [[value]]{analysis.output_frame_count}[[/]]",
+        "• [[key]]Cache[[/]]: [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
+        "• [[key]]Output frames[[/]] ([[value]]{analysis.output_frame_count}[[/]]):{emit_json_tail? [[dim]]  preview [[value]]{analysis.output_frames_preview}[[/]]  (full list in JSON{verbose?' and above':''})[[/]] : [[value]]{analysis.output_frames_full|wrap_indent2}[[/]]}"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- restore bullet prefixes and colons in the summary list layout so output matches the expected CLI format
- update the output-frames line to emit "Output frames (n):" for readability

## Testing
- uv run pytest tests/test_cli_layout_formatting.py::test_list_section_two_column_layout tests/test_cli_layout_render.py::test_summary_output_frames_full_list_without_ellipsis *(fails: requires system libvapoursynth for vapoursynth wheel)*

------
https://chatgpt.com/codex/tasks/task_e_68ea32099fe08321b33ab2db31c67416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Reformatted the Summary section to bullet-style entries with dot-and-colon prefixes for improved readability.
  * Standardized key/value display while preserving existing data bindings and behavior.
  * Expanded and clearly labeled the “Output frames” item with consistent preview/full list presentation.
  * Overall presentation is cleaner and more consistent, with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->