### PR TITLE
Improve summary bullet hanging indentation

### DIFF
--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -238,14 +238,14 @@
       "title_badge": "[SUMMARY]",
       "accent_role": "section_summary",
       "items": [
-        "• [[key]]Clips[[/]]: [[value]]{clips.count}[[/]]  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  [[key]]step[[/]] [[value]]{analysis.step}[[/]]  [[key]]downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
-        "• [[key]]Align[[/]]: audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
-        "• [[key]]Plan[[/]]: dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
-        "• [[key]]Canvas[[/]]: single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
-        "• [[key]]Tonemap[[/]]: curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]]  verify ≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] Δ=[[value]]{verify.delta.max}[[/]][[/]]:''}",
-        "• [[key]]Output[[/]]: [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]  frames [[value]]{analysis.output_frame_count}[[/]]",
-        "• [[key]]Cache[[/]]: [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
-        "• [[key]]Output frames[[/]] ([[value]]{analysis.output_frame_count}[[/]]):{emit_json_tail? [[dim]]  preview [[value]]{analysis.output_frames_preview}[[/]]  (full list in JSON{verbose?' and above':''})[[/]] : [[value]]{analysis.output_frames_full|wrap_indent2}[[/]]}"
+        "• [[key]]Clips[[/]] [[value]]{clips.count}[[/]]\n  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]\n  [[key]]Step[[/]] [[value]]{analysis.step}[[/]]  [[key]]Downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
+        "• [[key]]Align[[/]]\n  audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]\n  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
+        "• [[key]]Plan[[/]]\n  dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]\n  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
+        "• [[key]]Canvas[[/]]\n  single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]\n  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
+        "• [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]\n  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]]  verify ≤[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] Δ=[[value]]{verify.delta.max}[[/]][[/]]:''}",
+        "• [[key]]Output[[/]]\n  dir [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]\n  frames [[value]]{analysis.output_frame_count}[[/]]",
+        "• [[key]]Cache[[/]]\n  file [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
+        "• [[key]]Output frames[[/]] ([[value]]{analysis.output_frame_count}[[/]])\n  {emit_json_tail?[[dim]]preview [[value]]{analysis.output_frames_preview}[[/]]  (full list in JSON{verbose?' and above':''})[[/]]:[[value]]{analysis.output_frames_full|summary_wrap}[[/]]}"
       ]
     }
   ],

--- a/src/cli_layout.py
+++ b/src/cli_layout.py
@@ -1364,6 +1364,18 @@ class CliLayoutRenderer:
                 break_long_words=False,
                 break_on_hyphens=False,
             )
+        if filter_name == "summary_wrap":
+            text = "" if value is None else str(value)
+            if not text:
+                return ""
+            width = max(10, self._console_width() - 4)
+            return textwrap.fill(
+                text,
+                width=width,
+                subsequent_indent="  ",
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
         if filter_name == "none":
             return value if value not in (None, "") else "none"
         if filter_name == "unchanged":

--- a/src/cli_layout.py
+++ b/src/cli_layout.py
@@ -1364,18 +1364,41 @@ class CliLayoutRenderer:
                 break_long_words=False,
                 break_on_hyphens=False,
             )
+    def _wrap_with_indent(self, value: Any, padding: int) -> str:
+        """
+        Wrap text to console width minus padding, with 2-space continuation indent.
+        
+        Parameters:
+            value (Any): The input value to wrap (converted to string).
+            padding (int): Number of columns to subtract from console width.
+        
+        Returns:
+            str: Wrapped text with 2-space hanging indent, or empty string if input is empty.
+        """
+        text = "" if value is None else str(value)
+        if not text:
+            return ""
+        width = max(10, self._console_width() - padding)
+        return textwrap.fill(
+            text,
+            width=width,
+            subsequent_indent="  ",
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+
+    def _apply_filter(self, value: Any, filter_name: str) -> Any:
+        """
+        Apply a named simple display filter to a value.
+        ...
+        """
+        if filter_name == "bool":
+            return "true" if bool(value) else "false"
+        if filter_name == "wrap_indent2":
+            return self._wrap_with_indent(value, 2)
         if filter_name == "summary_wrap":
-            text = "" if value is None else str(value)
-            if not text:
-                return ""
-            width = max(10, self._console_width() - 4)
-            return textwrap.fill(
-                text,
-                width=width,
-                subsequent_indent="  ",
-                break_long_words=False,
-                break_on_hyphens=False,
-            )
+            return self._wrap_with_indent(value, 4)
+        # ... other filters unchanged ...
         if filter_name == "none":
             return value if value not in (None, "") else "none"
         if filter_name == "unchanged":

--- a/tests/test_cli_layout_render.py
+++ b/tests/test_cli_layout_render.py
@@ -293,9 +293,16 @@ def test_layout_renderer_sample_output(tmp_path, monkeypatch):
     assert any("add_frame_info=true" in line for line in lines)
     assert not any("template=" in line for line in lines)
 
-    summary_lines = [line for line in lines if "Output frames" in line]
-    assert any("Output frames (6)" in line for line in summary_lines)
-    assert any("[0, 10, 20" in line for line in summary_lines)
+    header_idx = next(i for i, line in enumerate(lines) if "Output frames (6)" in line)
+    header_line = lines[header_idx]
+    assert header_line.lstrip().startswith("• Output frames (6)")
+
+    assert header_idx + 1 < len(lines), "Expected detail line after Output frames header"
+    detail_line = lines[header_idx + 1]
+    header_indent = len(header_line) - len(header_line.lstrip())
+    detail_indent = len(detail_line) - len(detail_line.lstrip())
+    assert detail_indent == header_indent + 2
+    assert "[0, 10, 20" in detail_line
 
     section_logs = [line for line in lines if "section[" in line and "header role" in line]
     for expected in (
@@ -337,10 +344,10 @@ def test_summary_output_frames_full_list_without_ellipsis(tmp_path: Path) -> Non
     output_text = console.export_text()
     normalized = " ".join(line.strip() for line in output_text.splitlines() if line.strip())
 
-    assert "• Output frames (50):" in normalized
+    assert "• Output frames (50)" in normalized
     assert f"[{long_frames}]" in normalized
 
-    summary_start = normalized.index("• Output frames (50):")
+    summary_start = normalized.index("• Output frames (50)")
     summary_text = normalized[summary_start:]
     assert "…" not in summary_text
 


### PR DESCRIPTION
## Summary
- break the summary items in `cli_layout.v1.json` into concise bullet headers with indented detail lines and wrap the long frame list with the new formatter
- add a `summary_wrap` hanging-indent filter to the CLI renderer and update layout tests to assert the new structure

## Testing
- pytest tests/test_cli_layout_render.py tests/test_cli_layout_formatting.py

------
https://chatgpt.com/codex/tasks/task_e_68ea36f48e4c8321ba56c4081bda665e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - CLI Summary now uses bullet-prefixed headers with multi-line detail blocks and consistent two-space hanging indentation.
  - Summary items are reformatted into newline-separated subfields for clearer separation (steps, alignment, planning, canvas/tonemap/output) without changing content.
  - Improved wrapping behavior for better readability on narrow and wide terminals.

- Tests
  - Updated tests to validate bullet headers and the new header/detail indentation and grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->