### PR TITLE
Restore colon marker in summary clips row

### DIFF
--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -78,7 +78,7 @@
       "title": "At-a-Glance",
       "when": "true",
       "lines": [
-        "[[key]]Clips[[/]] [[value]]{clips.count}[[/]]  [[key]]Step[[/]] [[value]]{analysis.step}[[/]]  [[key]]Downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]  [[key]]Frames[[/]] [[value]]{analysis.output_frame_count}[[/]]",
+        "[[key]]Clips[[/]]: [[value]]{clips.count}[[/]]  [[key]]Step[[/]] [[value]]{analysis.step}[[/]]  [[key]]Downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]  [[key]]Frames[[/]] [[value]]{analysis.output_frame_count}[[/]]",
         "[[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]  min [[value]]{window.min_window_seconds:.2f}[[/]][[unit]]s[[/]]",
         "[[key]]Plan[[/]] dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]",
         "[[key]]Audio align[[/]] [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]  corr [[value]]{audio_alignment.corr:.2f}[[/]]",
@@ -238,7 +238,7 @@
       "title_badge": "[SUMMARY]",
       "accent_role": "section_summary",
       "items": [
-        "• [[key]]Clips[[/]] [[value]]{clips.count}[[/]]\n  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]\n  [[key]]Step[[/]] [[value]]{analysis.step}[[/]]  [[key]]Downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
+        "• [[key]]Clips[[/]]: [[value]]{clips.count}[[/]]\n  [[key]]Window[[/]] lead [[value]]{window.ignore_lead_seconds:.2f}[[/]][[unit]]s[[/]]  trail [[value]]{window.ignore_trail_seconds:.2f}[[/]][[unit]]s[[/]]\n  [[key]]Step[[/]] [[value]]{analysis.step}[[/]]  [[key]]Downscale[[/]] [[value]]{analysis.downscale_height}[[/]][[unit]]px[[/]]",
         "• [[key]]Align[[/]]\n  audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]\n  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
         "• [[key]]Plan[[/]]\n  dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]\n  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
         "• [[key]]Canvas[[/]]\n  single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]\n  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",


### PR DESCRIPTION
## Summary
- add explicit colon after the "Clips" label in the at-a-glance and summary templates so the legacy bullet text matches test expectations

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ea3b4ca0f08321869b93a9da33bdab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined UI copy for consistency: added a colon after the “Clips” label in the At‑a‑Glance lines.
  - Updated the corresponding SUMMARY bullet to match the new punctuation.
  - Improves readability and visual alignment of labels across the interface.
  - No changes to functionality or behavior; users will only notice the punctuation and formatting update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->