### PR TITLE
Remove VapourSynth from core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "librosa",
     "soundfile",
     "tqdm",
-    "vapoursynth",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -240,19 +240,17 @@ dependencies = [
     { name = "colorama" },
     { name = "guessit" },
     { name = "httpx" },
-    { name = "natsort" },
     { name = "librosa" },
+    { name = "natsort" },
     { name = "numpy" },
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "rich" },
     { name = "soundfile" },
     { name = "tqdm" },
-    { name = "vapoursynth" },
 ]
 
 [package.optional-dependencies]
-audio = []
 vapoursynth = [
     { name = "vapoursynth" },
 ]
@@ -281,7 +279,6 @@ requires-dist = [
     { name = "rich" },
     { name = "soundfile" },
     { name = "tqdm" },
-    { name = "vapoursynth" },
     { name = "vapoursynth", marker = "extra == 'vapoursynth'", specifier = ">=72" },
 ]
 provides-extras = ["vapoursynth", "audio"]


### PR DESCRIPTION
## Summary
- remove VapourSynth from the project’s default dependency list while keeping the optional extra intact
- regenerate the `uv.lock` file so VapourSynth only appears in the optional extra metadata

## Testing
- uv sync --group dev
- uv run python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68eb108e7d54832197ae898269d0eb65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined base installation by moving certain video-processing functionality to an optional add-on.
  - Reduces default install size and potential setup friction for users who don’t need this capability.
  - Users who require advanced video processing can still enable it via optional extras during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->