### PR TITLE
Align default config helper with CLI default path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
 - *2025-10-14:* Clarified CLI hierarchy by softening section badge colors, brightening subhead prefixes, expanding the At-a-Glance box with alignment, sampling, and canvas metrics for quicker triage, and realigning the Summary section with key/value formatting to remove ragged rows.
+- *2025-10-15:* Restored the CLI default configuration to the packaged template, updated documentation to describe copying into user-writable locations, and stopped `copy_default_config()` from writing into site-packages by requiring an explicit destination.
 - *2025-10-13:* Removed the `types-pytest` dev dependency so `uv run` can resolve environments on fresh clones without relying on a non-existent stub package while keeping the actual `pytest` runtime dependency in the dev group for CI and local tests.
 - *2025-10-10:* Reject invalid `cli.progress.style` values during configuration loading and persist normalized styles for downstream flag handling to keep CLI reporters consistent.
 - *2025-10-12:* Added local type stubs for optional CLI/testing dependencies and hardened JSON-tail assertions in tests so Pyright runs cleanly without relaxing diagnostic settings.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ uv pip install vapoursynth  # or `uv add vapoursynth` to persist it to your proj
 uv run python frame_compare.py --input tests/fixtures/media/comparison_videos
 ```
 
-The CLI ships with a configuration template stored at `data/config.toml.template`. Copy or rename it to a `.toml` file when you want to edit the defaults, and pass `--config` to point at a custom file when needed; you can seed one with `python -c "from src.config_template import copy_default_config; copy_default_config('~/frame_compare.toml')"`.
+The CLI ships with a configuration template stored at `data/config.toml.template`. Run `python -c "from src.config_template import copy_default_config; copy_default_config()"` to populate `data/config.toml`, which is the default config consumed by the CLI. Pass `--config` to point at another file when needed, or provide a path to `copy_default_config()` to seed an alternate location.
 
 Install VapourSynth manually after `uv sync` so the renderer is available:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ uv pip install vapoursynth  # or `uv add vapoursynth` to persist it to your proj
 uv run python frame_compare.py --input tests/fixtures/media/comparison_videos
 ```
 
-The CLI ships with a configuration template stored at `data/config.toml.template`. Run `python -c "from src.config_template import copy_default_config; copy_default_config()"` to populate `data/config.toml`, which is the default config consumed by the CLI. Pass `--config` to point at another file when needed, or provide a path to `copy_default_config()` to seed an alternate location.
+The CLI ships with a configuration template stored at `data/config.toml.template`, which is also the default configuration consumed by the CLI. Pass `--config` to point at another file when needed, or call `python -c "from src.config_template import copy_default_config; copy_default_config('config.toml')"` to copy the template into a writable location for customization.
 
 Install VapourSynth manually after `uv sync` so the renderer is available:
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-15:* Reverted the CLI default config path to the packaged template and required explicit destinations when copying the template so installations no longer attempt to write into site-packages.
 - *2025-10-14:* Adjusted CLI theming to separate hierarchy (muted section badges, yellow subheads) and rewrote the At-a-Glance summary to surface sampling, window, and alignment metrics requested in the usability review.
 - *2025-10-13:* Dropped the unused `types-pytest` dependency from the dev group because the package is unavailable on PyPI and broke `uv run` environment creation on fresh clones. CI keeps installing real `pytest` through the dev group, so workflows and local test runs continue to function normally.
 - *2025-10-12:* Introduced local stubs for click, requests, httpx, and rich plus tighter JSON-tail helpers in tests to eliminate Pyright/Pylance import and indexing errors while keeping diagnostics strict.

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -90,7 +90,7 @@ Repository fixtures mirroring the default `paths.input_dir` live under
 <!-- markdownlint-disable MD013 -->
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--config PATH` | Use a specific configuration file. | `data/config.toml.template` |
+| `--config PATH` | Use a specific configuration file. | `data/config.toml` |
 | `--input PATH` | Override `[paths.input_dir]` for this run. | `None` |
 | `--quiet` | Show minimal console output. | `false` |
 | `--verbose` | Emit additional diagnostics. | `false` |

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -90,7 +90,7 @@ Repository fixtures mirroring the default `paths.input_dir` live under
 <!-- markdownlint-disable MD013 -->
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--config PATH` | Use a specific configuration file. | `data/config.toml` |
+| `--config PATH` | Use a specific configuration file. | `data/config.toml.template` |
 | `--input PATH` | Override `[paths.input_dir]` for this run. | `None` |
 | `--quiet` | Show minimal console output. | `false` |
 | `--verbose` | Emit additional diagnostics. | `false` |

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -3463,8 +3463,9 @@ def run_cli(
     default=str(DEFAULT_CONFIG_PATH),
     show_default=True,
     help=(
-        "Path to the configuration file (defaults to data/config.toml; seed it "
-        "from the packaged template with src.config_template.copy_default_config)."
+        "Path to the configuration file (defaults to the packaged "
+        "data/config.toml.template; call src.config_template.copy_default_config "
+        "to write a copy elsewhere)."
     ),
 )
 @click.option("--input", "input_dir", default=None, help="Override [paths.input_dir] from config.toml")

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -29,6 +29,7 @@ from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn, Ti
 from natsort import os_sorted
 
 from src.config_loader import ConfigError, load_config
+from src import config_paths
 from src.datatypes import AppConfig
 from src import audio_alignment
 from src.utils import parse_filename_metadata
@@ -58,7 +59,7 @@ from src.cli_layout import CliLayoutRenderer, CliLayoutError, load_cli_layout
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG_PATH = Path(__file__).resolve().with_name("data") / "config.toml.template"
+DEFAULT_CONFIG_PATH = config_paths.DEFAULT_CONFIG_PATH
 
 SUPPORTED_EXTS = (
     ".mkv",
@@ -3462,8 +3463,8 @@ def run_cli(
     default=str(DEFAULT_CONFIG_PATH),
     show_default=True,
     help=(
-        "Path to the configuration file (defaults to the packaged "
-        "data/config.toml.template; rename or copy it to .toml when customising)."
+        "Path to the configuration file (defaults to data/config.toml; seed it "
+        "from the packaged template with src.config_template.copy_default_config)."
     ),
 )
 @click.option("--input", "input_dir", default=None, help="Override [paths.input_dir] from config.toml")

--- a/src/config_paths.py
+++ b/src/config_paths.py
@@ -1,0 +1,19 @@
+"""Common configuration path helpers shared across the CLI and utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+_DATA_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "data"
+
+DEFAULT_CONFIG_TEMPLATE_PATH: Final[Path] = _DATA_DIR / "config.toml.template"
+"""Path to the packaged configuration template."""
+
+DEFAULT_CONFIG_PATH: Final[Path] = _DATA_DIR / "config.toml"
+"""Default destination for the generated configuration file."""
+
+__all__ = [
+    "DEFAULT_CONFIG_PATH",
+    "DEFAULT_CONFIG_TEMPLATE_PATH",
+]

--- a/src/config_paths.py
+++ b/src/config_paths.py
@@ -10,8 +10,8 @@ _DATA_DIR: Final[Path] = Path(__file__).resolve().parent.parent / "data"
 DEFAULT_CONFIG_TEMPLATE_PATH: Final[Path] = _DATA_DIR / "config.toml.template"
 """Path to the packaged configuration template."""
 
-DEFAULT_CONFIG_PATH: Final[Path] = _DATA_DIR / "config.toml"
-"""Default destination for the generated configuration file."""
+DEFAULT_CONFIG_PATH: Final[Path] = DEFAULT_CONFIG_TEMPLATE_PATH
+"""Default configuration consumed by the CLI (uses the packaged template)."""
 
 __all__ = [
     "DEFAULT_CONFIG_PATH",

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -6,14 +6,12 @@ from importlib import resources
 from pathlib import Path
 from typing import Final
 
-from src import config_paths
-
 _TEMPLATE_PACKAGE: Final[str] = "data"
 _TEMPLATE_FILENAME: Final[str] = "config.toml.template"
 
 
 def copy_default_config(
-    destination: str | Path | None = None,
+    destination: str | Path,
     *,
     overwrite: bool = False,
 ) -> Path:
@@ -22,8 +20,8 @@ def copy_default_config(
     Parameters
     ----------
     destination:
-        File path to write. When omitted, the file is written to the same
-        ``data/config.toml`` path that the CLI uses by default.
+        File path to write. This must point to a user-writable location such as a
+        project workspace or configuration directory.
     overwrite:
         Whether to overwrite an existing file. When ``False`` (the default), a
         :class:`FileExistsError` is raised if the destination already exists.
@@ -32,9 +30,17 @@ def copy_default_config(
     -------
     Path
         The path where the configuration template was written.
+
+    Raises
+    ------
+    ValueError
+        If ``destination`` is ``None``.
     """
 
-    target = Path(destination) if destination is not None else config_paths.DEFAULT_CONFIG_PATH
+    if destination is None:
+        raise ValueError("destination must be provided")
+
+    target = Path(destination)
     template = resources.files(_TEMPLATE_PACKAGE).joinpath(_TEMPLATE_FILENAME)
 
     if target.exists() and not overwrite:

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -6,6 +6,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Final
 
+from src import config_paths
+
 _TEMPLATE_PACKAGE: Final[str] = "data"
 _TEMPLATE_FILENAME: Final[str] = "config.toml.template"
 
@@ -20,8 +22,8 @@ def copy_default_config(
     Parameters
     ----------
     destination:
-        File path to write. When omitted, the file is written as ``config.toml``
-        in the current working directory.
+        File path to write. When omitted, the file is written to the same
+        ``data/config.toml`` path that the CLI uses by default.
     overwrite:
         Whether to overwrite an existing file. When ``False`` (the default), a
         :class:`FileExistsError` is raised if the destination already exists.
@@ -32,7 +34,7 @@ def copy_default_config(
         The path where the configuration template was written.
     """
 
-    target = Path(destination) if destination is not None else Path.cwd() / "config.toml"
+    target = Path(destination) if destination is not None else config_paths.DEFAULT_CONFIG_PATH
     template = resources.files(_TEMPLATE_PACKAGE).joinpath(_TEMPLATE_FILENAME)
 
     if target.exists() and not overwrite:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from src.config_template import copy_default_config
 
 
 def _copy_default_config(tmp_path: Path) -> Path:
-    cfg_dst = tmp_path / "config.toml.template"
+    cfg_dst = tmp_path / "config.toml"
     return copy_default_config(cfg_dst)
 
 
@@ -59,7 +59,7 @@ def test_load_defaults(tmp_path: Path) -> None:
     ],
 )
 def test_validation_errors(tmp_path: Path, toml_snippet: str, message: str) -> None:
-    cfg_path = tmp_path / "config.toml.template"
+    cfg_path = tmp_path / "config.toml"
     cfg_path.write_text(toml_snippet, encoding="utf-8")
     with pytest.raises(ConfigError) as exc_info:
         load_config(str(cfg_path))
@@ -67,7 +67,7 @@ def test_validation_errors(tmp_path: Path, toml_snippet: str, message: str) -> N
 
 
 def test_override_values(tmp_path: Path) -> None:
-    cfg_path = tmp_path / "config.toml.template"
+    cfg_path = tmp_path / "config.toml"
     cfg_path.write_text(
         """
 [analysis]

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from importlib import resources
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from src import config_paths
 from src.config_template import copy_default_config
 
 
@@ -23,16 +23,9 @@ def test_copy_default_config_writes_template(tmp_path: Path, template_bytes: byt
     assert destination.read_bytes() == template_bytes
 
 
-def test_copy_default_config_uses_cli_default_path(
-    tmp_path: Path, template_bytes: bytes, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    default_path = tmp_path / "data" / "config.toml"
-    monkeypatch.setattr(config_paths, "DEFAULT_CONFIG_PATH", default_path)
-
-    written_path = copy_default_config()
-
-    assert written_path == default_path
-    assert default_path.read_bytes() == template_bytes
+def test_copy_default_config_requires_destination() -> None:
+    with pytest.raises(ValueError):
+        copy_default_config(cast(Path, None))
 
 
 def test_copy_default_config_refuses_to_overwrite(tmp_path: Path, template_bytes: bytes) -> None:

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from src import config_paths
 from src.config_template import copy_default_config
 
 
@@ -20,6 +21,18 @@ def test_copy_default_config_writes_template(tmp_path: Path, template_bytes: byt
 
     assert written_path == destination
     assert destination.read_bytes() == template_bytes
+
+
+def test_copy_default_config_uses_cli_default_path(
+    tmp_path: Path, template_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    default_path = tmp_path / "data" / "config.toml"
+    monkeypatch.setattr(config_paths, "DEFAULT_CONFIG_PATH", default_path)
+
+    written_path = copy_default_config()
+
+    assert written_path == default_path
+    assert default_path.read_bytes() == template_bytes
 
 
 def test_copy_default_config_refuses_to_overwrite(tmp_path: Path, template_bytes: bytes) -> None:

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -41,13 +41,13 @@ def test_cli_uses_packaged_config_by_default(runner: CliRunner) -> None:
 
     default_path = frame_compare.DEFAULT_CONFIG_PATH
     assert default_path.parent.name == "data"
-    assert default_path.name == "config.toml"
+    assert default_path.name == "config.toml.template"
 
     config_option = next(
         param for param in frame_compare.main.params if param.name == "config_path"
     )
     assert config_option.default == str(default_path)
-    assert "data/config.toml" in result.output
+    assert "data/config.toml.template" in result.output
 
 
 class DummyProgress:

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -41,14 +41,13 @@ def test_cli_uses_packaged_config_by_default(runner: CliRunner) -> None:
 
     default_path = frame_compare.DEFAULT_CONFIG_PATH
     assert default_path.parent.name == "data"
-    assert default_path.name == "config.toml.template"
-    assert default_path.exists()
+    assert default_path.name == "config.toml"
 
     config_option = next(
         param for param in frame_compare.main.params if param.name == "config_path"
     )
     assert config_option.default == str(default_path)
-    assert "data/config.toml.template" in result.output
+    assert "data/config.toml" in result.output
 
 
 class DummyProgress:


### PR DESCRIPTION
## Summary
- add a shared config path helper so the CLI and copy helper agree on data/config.toml
- update copy_default_config, CLI defaults, docs, and tests to use data/config.toml as the default destination

## Testing
- pytest *(fails: missing optional dependencies such as rich/requests/httpx in the test environment)*
- PYTHONPATH=. pytest tests/test_config_template.py tests/test_config.py tests/test_frame_compare.py *(fails: missing optional dependency rich)*

------
https://chatgpt.com/codex/tasks/task_e_68eb214e5c8483218312fa6dffedada6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now uses the packaged template as the default configuration. Use --config to point to another file. Added a way to copy the default config into a writable location; an explicit destination is now required.

* **Documentation**
  * Updated setup instructions to reflect the new default and seeding workflow. Improved CLI help text. Added a decision log entry explaining the change.

* **Tests**
  * Updated tests to align with the new default config file name and explicit copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->