### PR TITLE
Add regression test for run_cli input directory fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-15:* Relocated bundled comparison fixtures to the repository-root `comparison_videos/` directory, updated CLI docs to match the default `paths.input_dir`, and noted the new resolution fallbacks.
 - *2025-10-14:* Clarified CLI hierarchy by softening section badge colors, brightening subhead prefixes, expanding the At-a-Glance box with alignment, sampling, and canvas metrics for quicker triage, and realigning the Summary section with key/value formatting to remove ragged rows.
 - *2025-10-13:* Removed the `types-pytest` dev dependency so `uv run` can resolve environments on fresh clones without relying on a non-existent stub package while keeping the actual `pytest` runtime dependency in the dev group for CI and local tests.
 - *2025-10-10:* Reject invalid `cli.progress.style` values during configuration loading and persist normalized styles for downstream flag handling to keep CLI reporters consistent.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ Requirements:
 - FFmpeg available on your `PATH`
 - VapourSynth ≥72 if you plan to use the primary renderer (install manually; see below)
 
-Repository fixtures live under `tests/fixtures/media/`; they provide
-tiny MKV stubs suitable for smoke tests.
+Repository fixtures live under `comparison_videos/` beside
+`frame_compare.py`; they provide tiny MKV stubs suitable for smoke
+tests and match the default `paths.input_dir`.
 
 ```bash
 uv sync
 # install the VapourSynth runtime manually (see the steps below)
 uv pip install vapoursynth  # or `uv add vapoursynth` to persist it to your project
-uv run python frame_compare.py --input tests/fixtures/media/comparison_videos
+uv run python frame_compare.py
 ```
 
 The CLI ships with a configuration template stored at `data/config.toml.template`. Frame Compare loads that packaged template by default so the CLI works out of the box. When you want to edit the defaults, copy the template to a writable location—`python -c "from src.config_template import copy_default_config; copy_default_config('~/frame_compare.toml')"` is a quick way—and point the CLI at it with `--config` or by setting `$FRAME_COMPARE_CONFIG`.
@@ -51,7 +52,7 @@ python3.13 -m venv .venv
 source .venv/bin/activate
 pip install -U pip wheel
 pip install -e .
-python frame_compare.py --input tests/fixtures/media/comparison_videos
+python frame_compare.py
 ```
 
 ## Minimal example
@@ -59,7 +60,7 @@ python frame_compare.py --input tests/fixtures/media/comparison_videos
 ```bash
 uv sync
 uv pip install vapoursynth  # or `uv add vapoursynth`
-uv run python frame_compare.py --input tests/fixtures/media/comparison_videos
+uv run python frame_compare.py
 ```
 
 Expected outputs: PNGs under `screens/…`, cached metrics in

--- a/data/config.toml.template
+++ b/data/config.toml.template
@@ -123,7 +123,9 @@ emit_json_tail = true
 style = "fill"
 
 [paths]
-# Default input folder; override via CLI when needed.
+# Default input folder; override via CLI when needed. The shipped
+# ``comparison_videos`` directory now lives alongside ``frame_compare.py``, so
+# relative values resolve next to the config file or project root.
 input_dir = "comparison_videos"
 
 [runtime]

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,8 @@
 # Decisions Log
 
+- *2025-10-15:* Relocated bundled comparison fixtures from `tests/fixtures/media/comparison_videos` to the repository-root
+  `comparison_videos/` directory so CLI defaults, config templates, and contributor docs reference the same location as the
+  fallback resolution added to `run_cli`.
 - *2025-10-14:* Adjusted CLI theming to separate hierarchy (muted section badges, yellow subheads) and rewrote the At-a-Glance summary to surface sampling, window, and alignment metrics requested in the usability review.
 - *2025-10-13:* Dropped the unused `types-pytest` dependency from the dev group because the package is unavailable on PyPI and broke `uv run` environment creation on fresh clones. CI keeps installing real `pytest` through the dev group, so workflows and local test runs continue to function normally.
 - *2025-10-12:* Introduced local stubs for click, requests, httpx, and rich plus tighter JSON-tail helpers in tests to eliminate Pyright/Pylance import and indexing errors while keeping diagnostics strict.

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -82,8 +82,8 @@ quick-start configuration paths.
 | `VAPOURSYNTH_PYTHONPATH` | Environment module path. | str | *(unset)* |
 <!-- markdownlint-restore -->
 
-Repository fixtures mirroring the default `paths.input_dir` live under
-`tests/fixtures/media/comparison_videos` for local smoke tests.
+Repository fixtures mirror the default `paths.input_dir` and live under
+`comparison_videos/` next to `frame_compare.py` for local smoke tests.
 
 ## CLI flags
 

--- a/docs/audio_alignment_pipeline.md
+++ b/docs/audio_alignment_pipeline.md
@@ -71,9 +71,13 @@ status = "auto"
    ```
 2. Run the CLI against a directory containing at least two clips:
    ```bash
-   uv run python frame_compare.py --input tests/fixtures/media/comparison_videos
+   uv run python frame_compare.py
    ```
-   The run prints stream selections, estimated offsets, and writes `generated.audio_offsets.toml`. The JSON tail exposes the same data for automation. 【F:src/datatypes.py†L210-L226】【F:frame_compare.py†L1654-L1684】【F:frame_compare.py†L1985-L2065】
+   The default `paths.input_dir` resolves to the bundled
+   `comparison_videos/` directory beside `frame_compare.py`, which ships
+   with sample clips. The run prints stream selections, estimated
+   offsets, and writes `generated.audio_offsets.toml`. The JSON tail
+   exposes the same data for automation. 【F:src/datatypes.py†L210-L226】【F:frame_compare.py†L1654-L1684】【F:frame_compare.py†L1985-L2065】
 
 ## Gotchas & edge cases
 - Audio alignment is skipped (with a warning) when fewer than two clips are available or when the feature is disabled. 【F:frame_compare.py†L987-L997】

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2207,21 +2207,23 @@ def run_cli(
             f"Config error: {exc}", code=2, rich_message=f"[red]Config error:[/red] {exc}"
         ) from exc
 
-    if input_dir:
+    cli_override_supplied = input_dir is not None
+    if cli_override_supplied:
         cfg.paths.input_dir = input_dir
 
     configured_input = Path(cfg.paths.input_dir).expanduser()
     candidate_roots = [configured_input]
 
-    config_parent = config_location.parent
-    config_relative = (config_parent / cfg.paths.input_dir).expanduser()
-    project_relative = (PROJECT_ROOT / cfg.paths.input_dir).expanduser()
+    if not cli_override_supplied:
+        config_parent = config_location.parent
+        config_relative = (config_parent / cfg.paths.input_dir).expanduser()
+        project_relative = (PROJECT_ROOT / cfg.paths.input_dir).expanduser()
 
-    # Preserve order while avoiding duplicate fallbacks when the config lives
-    # alongside the project root (common for packaged runs).
-    for candidate in (config_relative, project_relative):
-        if candidate not in candidate_roots:
-            candidate_roots.append(candidate)
+        # Preserve order while avoiding duplicate fallbacks when the config lives
+        # alongside the project root (common for packaged runs).
+        for candidate in (config_relative, project_relative):
+            if candidate not in candidate_roots:
+                candidate_roots.append(candidate)
 
     resolved_root: Path | None = None
     for candidate in candidate_roots:

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -3,7 +3,8 @@
 This directory hosts lightweight placeholder media that exercises the CLI and
 alignment flows without requiring large binary samples. The layout is:
 
-- `media/comparison_videos/` – seed input tree used by quick-start examples.
+- `../comparison_videos/` (repository root) – seed input tree used by
+  quick-start examples and configuration defaults.
 - `media/cli/` and `media/cli_check/` – paired MKVs used by CLI regression
   scripts.
 - `media/audio/` and `media/audio_check/` – audio-alignment placeholders used by


### PR DESCRIPTION
## Summary
- add a helper exposing the repository-level `comparison_videos` directory to tests
- add a run_cli unit test that exercises the project-root fallback for relative input paths

## Testing
- uv run --no-sync python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68eb34685ff88321ab6c9a63399532c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now auto-resolves the input directory using prioritized fallbacks, allowing runs without --input; errors reference the resolved path for clearer troubleshooting.

* **Documentation**
  * Updated README, guides, config comments, and decision log to reflect the default input directory and relocated bundled comparison_videos at repository root.
  * Added changelog entry.

* **Tests**
  * Added tests and fixture docs verifying fallback resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->