### PR TITLE
Improve cache probing feedback and CLI messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-16:* Documented deep-review finding: screenshot cleanup must enforce path containment before deleting outputs; remediation planned.
+
 - *2025-10-15:* Relocated bundled comparison fixtures to the repository-root `comparison_videos/` directory, updated CLI docs to match the default `paths.input_dir`, and noted the new resolution fallbacks.
 - *2025-10-14:* Clarified CLI hierarchy by softening section badge colors, brightening subhead prefixes, expanding the At-a-Glance box with alignment, sampling, and canvas metrics for quicker triage, and realigning the Summary section with key/value formatting to remove ragged rows.
 - *2025-10-13:* Removed the `types-pytest` dev dependency so `uv run` can resolve environments on fresh clones without relying on a non-existent stub package while keeping the actual `pytest` runtime dependency in the dev group for CI and local tests.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-16:* Deep review flagged that `screenshots.directory_name` must be constrained to stay under the resolved input root before cleanup; follow-up will enforce containment checks before writing or deleting screenshot outputs (see `docs/deep_review.md`).
 - *2025-10-15:* Relocated bundled comparison fixtures from `tests/fixtures/media/comparison_videos` to the repository-root
   `comparison_videos/` directory so CLI defaults, config templates, and contributor docs reference the same location as the
   fallback resolution added to `run_cli`.

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 import frame_compare
 from src.audio_alignment import AlignmentMeasurement, AudioStreamInfo
-from src.analysis import FrameMetricsCacheInfo
+from src.analysis import CacheLoadResult, FrameMetricsCacheInfo
 from src.datatypes import (
     AnalysisConfig,
     AppConfig,
@@ -266,6 +266,7 @@ def test_cli_applies_overrides_and_naming(
         frame_window: tuple[int, int] | None = None,
         return_metadata: bool = False,
         color_cfg: ColorConfig | None = None,
+        cache_probe: CacheLoadResult | None = None,
     ) -> list[int]:
         cache_infos.append(cache_info)
         assert frame_window is not None
@@ -459,6 +460,7 @@ def test_cli_disables_json_tail_output(
         frame_window: tuple[int, int] | None = None,
         return_metadata: bool = False,
         color_cfg: ColorConfig | None = None,
+        cache_probe: CacheLoadResult | None = None,
     ) -> list[int]:
         return [12]
 
@@ -547,6 +549,7 @@ def test_label_dedupe_preserves_short_labels(
         frame_window: tuple[int, int] | None = None,
         return_metadata: bool = False,
         color_cfg: ColorConfig | None = None,
+        cache_probe: CacheLoadResult | None = None,
     ) -> list[int]:
         return [42]
 
@@ -617,6 +620,7 @@ def test_cli_reuses_frame_cache(
         frame_window: tuple[int, int] | None = None,
         return_metadata: bool = False,
         color_cfg: ColorConfig | None = None,
+        cache_probe: CacheLoadResult | None = None,
     ) -> list[int]:
         call_state["calls"] += 1
         assert cache_info is not None
@@ -704,6 +708,7 @@ def test_cli_input_override_and_cleanup(
         frame_window: tuple[int, int] | None = None,
         return_metadata: bool = False,
         color_cfg: ColorConfig | None = None,
+        cache_probe: CacheLoadResult | None = None,
     ) -> list[int]:
         return [7]
 
@@ -831,6 +836,7 @@ def test_cli_tmdb_resolution_populates_slowpics(
         frame_window: tuple[int, int] | None = None,
         return_metadata: bool = False,
         color_cfg: ColorConfig | None = None,
+        cache_probe: CacheLoadResult | None = None,
     ) -> list[int]:
         assert frame_window is not None
         return [12, 24]


### PR DESCRIPTION
## Summary
- add an explicit cache probe result so cached metrics are only reused when configuration and clip metadata still match
- surface cache-loading progress in the CLI, treat stale caches as recomputations, and pass probe results to frame selection to avoid frozen output
- add regression coverage for cache probing and cached selection reuse helpers

## Testing
- PYTHONPATH=. pytest tests/test_analysis.py::test_probe_cached_metrics_detects_config_change tests/test_analysis.py::test_select_frames_uses_cache_probe


------
https://chatgpt.com/codex/tasks/task_e_68eb3c64b7f0832185f41a6340d38541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter cache reuse with granular statuses and clearer progress/messages; reduced unnecessary recomputation.
  * Outputs and messages now reference the resolved workspace root for more predictable behavior.

* **Bug Fixes**
  * Safer post-upload cleanup: deletion is guarded to prevent removing files outside the workspace.

* **Documentation**
  * Updated changelog and added a critical security review describing risks and planned mitigations for screenshot/output handling.

* **Tests**
  * Expanded coverage for cache-aware analysis and selection flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->