### PR TITLE
Normalize verification stats for integer clips

### DIFF
--- a/src/vs_core.py
+++ b/src/vs_core.py
@@ -962,6 +962,26 @@ def _compute_verification(
     props = stats.get_frame(frame_idx).props
     average = float(props.get("PlaneStatsAverage", 0.0))
     maximum = float(props.get("PlaneStatsMax", 0.0))
+    fmt = getattr(expr, "format", None)
+    bits = getattr(fmt, "bits_per_sample", None) if fmt is not None else None
+    sample_type = getattr(fmt, "sample_type", None) if fmt is not None else None
+
+    is_integer_format = False
+    if sample_type is not None:
+        name = getattr(sample_type, "name", None)
+        if isinstance(name, str):
+            is_integer_format = name.upper() == "INTEGER"
+        else:
+            try:
+                is_integer_format = int(sample_type) == 0
+            except Exception:
+                is_integer_format = False
+
+    if is_integer_format and isinstance(bits, int) and bits > 0:
+        peak = float((1 << bits) - 1)
+        if peak > 0.0:
+            average /= peak
+            maximum /= peak
     return VerificationResult(
         frame=frame_idx,
         average=average,

--- a/tests/test_vs_core.py
+++ b/tests/test_vs_core.py
@@ -1,9 +1,19 @@
+import math
+import sys
 import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from src import vs_core
+from src.vs_core import VerificationResult
 
 
-def test_pick_verify_frame_warns_when_no_frames():
+def test_pick_verify_frame_warns_when_no_frames() -> None:
     clip = types.SimpleNamespace(num_frames=0)
     cfg = types.SimpleNamespace(
         verify_frame=None,
@@ -28,7 +38,7 @@ def test_pick_verify_frame_warns_when_no_frames():
     assert warnings == ["[VERIFY] clip.mkv has no frames; using frame 0"]
 
 
-def test_resolve_effective_tonemap_uses_preset_defaults():
+def test_resolve_effective_tonemap_uses_preset_defaults() -> None:
     cfg = types.SimpleNamespace(
         preset="contrast",
         tone_curve="bt.2390",
@@ -44,3 +54,80 @@ def test_resolve_effective_tonemap_uses_preset_defaults():
     assert resolved["tone_curve"] == "mobius"
     assert resolved["target_nits"] == 120.0
     assert resolved["dynamic_peak_detection"] is False
+
+
+class _FakeSampleType:
+    def __init__(self, name: str, value: int) -> None:
+        self.name = name
+        self._value = value
+
+    def __int__(self) -> int:
+        return self._value
+
+
+@dataclass
+class _FakeFormat:
+    bits_per_sample: int
+    sample_type: _FakeSampleType
+
+
+class _FakeClip:
+    def __init__(self, fmt: _FakeFormat) -> None:
+        self.format = fmt
+
+
+class _FakeFrame:
+    def __init__(self, props: Dict[str, float]) -> None:
+        self.props = props
+
+
+class _FakeStatsClip:
+    def __init__(self, props: Dict[str, float]) -> None:
+        self._props = props
+
+    def get_frame(self, index: int) -> _FakeFrame:
+        return _FakeFrame(self._props)
+
+
+class _FakeStd:
+    def __init__(self, expr_clip: _FakeClip, stats_clip: _FakeStatsClip) -> None:
+        self._expr_clip = expr_clip
+        self._stats_clip = stats_clip
+        self.expr_calls: List[Sequence[Any]] = []
+
+    def Expr(self, clips: Sequence[Any], expr: str) -> _FakeClip:
+        self.expr_calls.append(clips)
+        return self._expr_clip
+
+    def PlaneStats(self, clip: _FakeClip) -> _FakeStatsClip:
+        return self._stats_clip
+
+
+class _FakeCore:
+    def __init__(self, expr_clip: _FakeClip, stats_clip: _FakeStatsClip) -> None:
+        self.std = _FakeStd(expr_clip, stats_clip)
+
+
+def _run_compute_verification(
+    fmt: _FakeFormat, props: Dict[str, float]
+) -> VerificationResult:
+    expr_clip = _FakeClip(fmt)
+    stats_clip = _FakeStatsClip(props)
+    core = _FakeCore(expr_clip, stats_clip)
+    return vs_core._compute_verification(core, object(), object(), 3, auto_selected=False)
+
+
+def test_compute_verification_normalizes_integer_clip() -> None:
+    fmt = _FakeFormat(bits_per_sample=8, sample_type=_FakeSampleType("INTEGER", 0))
+    props = {"PlaneStatsAverage": 25.5, "PlaneStatsMax": 51.0}
+    result = _run_compute_verification(fmt, props)
+    assert math.isclose(result.average, 0.1)
+    assert math.isclose(result.maximum, 0.2)
+
+
+def test_compute_verification_preserves_float_clip() -> None:
+    fmt = _FakeFormat(bits_per_sample=32, sample_type=_FakeSampleType("FLOAT", 1))
+    props = {"PlaneStatsAverage": 0.25, "PlaneStatsMax": 0.75}
+    result = _run_compute_verification(fmt, props)
+    assert math.isclose(result.average, 0.25)
+    assert math.isclose(result.maximum, 0.75)


### PR DESCRIPTION
## Summary
- normalize PlaneStats averages/maxima to 0-1 for integer verification clips using the format bit depth
- add regression coverage for verification deltas with fake VapourSynth clips, including float behavior

## Testing
- pytest tests/test_vs_core.py

------
https://chatgpt.com/codex/tasks/task_e_68eb4c05e82c8321afdf6414eced6228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Correctly normalizes verification statistics for integer-formatted tonemapped frames by scaling averages and maxima to a 0–1 range, ensuring consistent results across integer and float formats.

- Tests
  - Added comprehensive unit tests covering normalization behavior for integer and float clips, frame selection, and tonemap resolution, with improved typing in test signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->