### PR TITLE
Add FFmpeg timeout safeguard for screenshot renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
 - *2025-10-19:* Seed the packaged default config into a per-user directory when the project tree is read-only so packaged installs no longer fail to start on permission errors.
+- *2025-10-20:* Allow disabling the per-frame FFmpeg timeout by setting `screenshots.ffmpeg_timeout_seconds` to 0 while keeping negative values invalid in validation and docs.
 - *2025-10-18:* Added a per-frame FFmpeg timeout and disabled stdin consumption to prevent hung screenshot renders and shell freezes on Windows.
 - *2025-10-17:* Streamlined CLI framing: removed the banner row, surfaced cached-metrics reuse inside the Analyze block, dropped the At-a-Glance crop-mod readout in favour of effective tonemap nits, and trimmed the Summary output frames line to match the refreshed console layout and tests.
 - *2025-10-16:* Documented deep-review finding: screenshot cleanup must enforce path containment before deleting outputs; remediation planned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-19:* Seed the packaged default config into a per-user directory when the project tree is read-only so packaged installs no longer fail to start on permission errors.
 - *2025-10-18:* Added a per-frame FFmpeg timeout and disabled stdin consumption to prevent hung screenshot renders and shell freezes on Windows.
 - *2025-10-17:* Streamlined CLI framing: removed the banner row, surfaced cached-metrics reuse inside the Analyze block, dropped the At-a-Glance crop-mod readout in favour of effective tonemap nits, and trimmed the Summary output frames line to match the refreshed console layout and tests.
 - *2025-10-16:* Documented deep-review finding: screenshot cleanup must enforce path containment before deleting outputs; remediation planned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-18:* Added a per-frame FFmpeg timeout and disabled stdin consumption to prevent hung screenshot renders and shell freezes on Windows.
 - *2025-10-17:* Streamlined CLI framing: removed the banner row, surfaced cached-metrics reuse inside the Analyze block, dropped the At-a-Glance crop-mod readout in favour of effective tonemap nits, and trimmed the Summary output frames line to match the refreshed console layout and tests.
 - *2025-10-16:* Documented deep-review finding: screenshot cleanup must enforce path containment before deleting outputs; remediation planned.
 

--- a/data/config.toml.template
+++ b/data/config.toml.template
@@ -59,6 +59,8 @@ auto_letterbox_crop = false
 pad_to_canvas = "off"
 letterbox_px_tolerance = 8
 center_pad = true
+# Abort FFmpeg renders that exceed this many seconds per frame (0 disables timeout).
+ffmpeg_timeout_seconds = 120.0
 
 [color]
 # HDR → SDR pipeline controls. Presets: reference (bt.2390/100nits/dpd=1),

--- a/data/config.toml.template
+++ b/data/config.toml.template
@@ -59,7 +59,7 @@ auto_letterbox_crop = false
 pad_to_canvas = "off"
 letterbox_px_tolerance = 8
 center_pad = true
-# Abort FFmpeg renders that exceed this many seconds per frame (0 disables timeout).
+# Abort FFmpeg renders that exceed this many seconds per frame (must be > 0; use a large value to effectively disable).
 ffmpeg_timeout_seconds = 120.0
 
 [color]

--- a/data/config.toml.template
+++ b/data/config.toml.template
@@ -59,7 +59,7 @@ auto_letterbox_crop = false
 pad_to_canvas = "off"
 letterbox_px_tolerance = 8
 center_pad = true
-# Abort FFmpeg renders that exceed this many seconds per frame (must be > 0; use a large value to effectively disable).
+# Abort FFmpeg renders that exceed this many seconds per frame (must be >= 0; set to 0 to disable).
 ffmpeg_timeout_seconds = 120.0
 
 [color]

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-19:* When the packaged install directory is read-only we now seed the default config under `~/.frame-compare/config.toml`, logging the relocation so users know to point overrides there instead of the site-packages path.
 - *2025-10-18:* Added `screenshots.ffmpeg_timeout_seconds` plus `-nostdin` when spawning FFmpeg to stop runaway renders from freezing Windows shells; surfaced the timeout in CLI render metadata and config docs.
 - *2025-10-17:* CLI layout tweaks: dropped the banner headline, repurposed the Analyze slot to show cached-metric reuse, removed the At-a-Glance crop-mod snippet in favour of resolved tonemap nits, and slimmed the Summary output block to avoid redundant frame counts.
 - *2025-10-16:* Deep review flagged that `screenshots.directory_name` must be constrained to stay under the resolved input root before cleanup; follow-up will enforce containment checks before writing or deleting screenshot outputs (see `docs/deep_review.md`).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,7 @@
 # Decisions Log
 
 - *2025-10-19:* When the packaged install directory is read-only we now seed the default config under `~/.frame-compare/config.toml`, logging the relocation so users know to point overrides there instead of the site-packages path.
+- *2025-10-20:* Restored the ability to disable FFmpeg screenshot timeouts by permitting `screenshots.ffmpeg_timeout_seconds = 0` and treating non-positive values as "no timeout" when invoking FFmpeg.
 - *2025-10-18:* Added `screenshots.ffmpeg_timeout_seconds` plus `-nostdin` when spawning FFmpeg to stop runaway renders from freezing Windows shells; surfaced the timeout in CLI render metadata and config docs.
 - *2025-10-17:* CLI layout tweaks: dropped the banner headline, repurposed the Analyze slot to show cached-metric reuse, removed the At-a-Glance crop-mod snippet in favour of resolved tonemap nits, and slimmed the Summary output block to avoid redundant frame counts.
 - *2025-10-16:* Deep review flagged that `screenshots.directory_name` must be constrained to stay under the resolved input root before cleanup; follow-up will enforce containment checks before writing or deleting screenshot outputs (see `docs/deep_review.md`).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-18:* Added `screenshots.ffmpeg_timeout_seconds` plus `-nostdin` when spawning FFmpeg to stop runaway renders from freezing Windows shells; surfaced the timeout in CLI render metadata and config docs.
 - *2025-10-17:* CLI layout tweaks: dropped the banner headline, repurposed the Analyze slot to show cached-metric reuse, removed the At-a-Glance crop-mod snippet in favour of resolved tonemap nits, and slimmed the Summary output block to avoid redundant frame counts.
 - *2025-10-16:* Deep review flagged that `screenshots.directory_name` must be constrained to stay under the resolved input root before cleanup; follow-up will enforce containment checks before writing or deleting screenshot outputs (see `docs/deep_review.md`).
 - *2025-10-15:* Relocated bundled comparison fixtures from `tests/fixtures/media/comparison_videos` to the repository-root

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -50,7 +50,7 @@ quick-start configuration paths.
 | `[screenshots].single_res` | Fixed output height (0 keeps source). | int | `0` |
 | `[screenshots].mod_crop` | Crop modulus. | int | `2` |
 | `[screenshots].auto_letterbox_crop` | Auto crop black bars. | bool | `false` |
-| `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout. | float | `120.0` |
+| `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be > 0). | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |
 | `[color].preset` | Tonemapping preset. | str | `"reference"` |
 | `[color].overlay_enabled` | Tonemap overlay flag. | bool | `true` |

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -50,7 +50,7 @@ quick-start configuration paths.
 | `[screenshots].single_res` | Fixed output height (0 keeps source). | int | `0` |
 | `[screenshots].mod_crop` | Crop modulus. | int | `2` |
 | `[screenshots].auto_letterbox_crop` | Auto crop black bars. | bool | `false` |
-| `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be > 0). | float | `120.0` |
+| `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be >= 0; set 0 to disable). | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |
 | `[color].preset` | Tonemapping preset. | str | `"reference"` |
 | `[color].overlay_enabled` | Tonemap overlay flag. | bool | `true` |

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -91,7 +91,7 @@ Repository fixtures mirror the default `paths.input_dir` and live under
 <!-- markdownlint-disable MD013 -->
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--config PATH` | Use a specific configuration file. | ``$FRAME_COMPARE_CONFIG`` or the repo ``config.toml`` (seeded from the bundled template) |
+| `--config PATH` | Use a specific configuration file. | ``$FRAME_COMPARE_CONFIG`` or the repo ``config.toml`` (seeded from the bundled template; falls back to ``~/.frame-compare/config.toml`` when the install tree is read-only) |
 | `--input PATH` | Override `[paths.input_dir]` for this run. | `None` |
 | `--quiet` | Show minimal console output. | `false` |
 | `--verbose` | Emit additional diagnostics. | `false` |

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -50,6 +50,7 @@ quick-start configuration paths.
 | `[screenshots].single_res` | Fixed output height (0 keeps source). | int | `0` |
 | `[screenshots].mod_crop` | Crop modulus. | int | `2` |
 | `[screenshots].auto_letterbox_crop` | Auto crop black bars. | bool | `false` |
+| `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout. | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |
 | `[color].preset` | Tonemapping preset. | str | `"reference"` |
 | `[color].overlay_enabled` | Tonemap overlay flag. | bool | `true` |

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -3373,6 +3373,7 @@ def run_cli(
         "center_pad": bool(cfg.screenshots.center_pad),
         "letterbox_px_tolerance": int(cfg.screenshots.letterbox_px_tolerance),
         "compression": int(cfg.screenshots.compression_level),
+        "ffmpeg_timeout_seconds": float(cfg.screenshots.ffmpeg_timeout_seconds),
     }
     layout_data["render"] = json_tail["render"]
     effective_tonemap = vs_core.resolve_effective_tonemap(cfg.color)

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -201,6 +201,13 @@ def load_config(path: str) -> AppConfig:
         raise ConfigError("screenshots.letterbox_px_tolerance must be an integer")
     if app.screenshots.letterbox_px_tolerance < 0:
         raise ConfigError("screenshots.letterbox_px_tolerance must be >= 0")
+    try:
+        timeout_value = float(app.screenshots.ffmpeg_timeout_seconds)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("screenshots.ffmpeg_timeout_seconds must be a number") from exc
+    if timeout_value <= 0:
+        raise ConfigError("screenshots.ffmpeg_timeout_seconds must be > 0")
+    app.screenshots.ffmpeg_timeout_seconds = timeout_value
     pad_mode = str(app.screenshots.pad_to_canvas).strip().lower()
     if pad_mode not in {"off", "on", "auto"}:
         raise ConfigError("screenshots.pad_to_canvas must be 'off', 'on', or 'auto'")

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import tomllib
 from dataclasses import fields, is_dataclass
 from typing import Any, Dict
@@ -205,6 +206,10 @@ def load_config(path: str) -> AppConfig:
         timeout_value = float(app.screenshots.ffmpeg_timeout_seconds)
     except (TypeError, ValueError) as exc:
         raise ConfigError("screenshots.ffmpeg_timeout_seconds must be a number") from exc
+    if not math.isfinite(timeout_value):
+        raise ConfigError(
+            "screenshots.ffmpeg_timeout_seconds must be a finite non-negative number"
+        )
     if timeout_value < 0:
         raise ConfigError("screenshots.ffmpeg_timeout_seconds must be >= 0")
     app.screenshots.ffmpeg_timeout_seconds = timeout_value

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -28,6 +28,13 @@ class ConfigError(ValueError):
     """Raised when the configuration file is malformed or fails validation."""
 
 
+_FFMPEG_TIMEOUT_NOT_NUMBER_MSG = "screenshots.ffmpeg_timeout_seconds must be a number"
+_FFMPEG_TIMEOUT_NOT_FINITE_MSG = (
+    "screenshots.ffmpeg_timeout_seconds must be a finite number"
+)
+_FFMPEG_TIMEOUT_NEGATIVE_MSG = "screenshots.ffmpeg_timeout_seconds must be >= 0"
+
+
 def _coerce_bool(value: Any, dotted_key: str) -> bool:
     """Return a bool, coercing simple 0/1 representations when necessary."""
 
@@ -205,13 +212,11 @@ def load_config(path: str) -> AppConfig:
     try:
         timeout_value = float(app.screenshots.ffmpeg_timeout_seconds)
     except (TypeError, ValueError) as exc:
-        raise ConfigError("screenshots.ffmpeg_timeout_seconds must be a number") from exc
+        raise ConfigError(_FFMPEG_TIMEOUT_NOT_NUMBER_MSG) from exc
     if not math.isfinite(timeout_value):
-        raise ConfigError(
-            "screenshots.ffmpeg_timeout_seconds must be a finite non-negative number"
-        )
+        raise ConfigError(_FFMPEG_TIMEOUT_NOT_FINITE_MSG)
     if timeout_value < 0:
-        raise ConfigError("screenshots.ffmpeg_timeout_seconds must be >= 0")
+        raise ConfigError(_FFMPEG_TIMEOUT_NEGATIVE_MSG)
     app.screenshots.ffmpeg_timeout_seconds = timeout_value
     pad_mode = str(app.screenshots.pad_to_canvas).strip().lower()
     if pad_mode not in {"off", "on", "auto"}:

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -205,8 +205,8 @@ def load_config(path: str) -> AppConfig:
         timeout_value = float(app.screenshots.ffmpeg_timeout_seconds)
     except (TypeError, ValueError) as exc:
         raise ConfigError("screenshots.ffmpeg_timeout_seconds must be a number") from exc
-    if timeout_value <= 0:
-        raise ConfigError("screenshots.ffmpeg_timeout_seconds must be > 0")
+    if timeout_value < 0:
+        raise ConfigError("screenshots.ffmpeg_timeout_seconds must be >= 0")
     app.screenshots.ffmpeg_timeout_seconds = timeout_value
     pad_mode = str(app.screenshots.pad_to_canvas).strip().lower()
     if pad_mode not in {"off", "on", "auto"}:

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -49,6 +49,7 @@ class ScreenshotConfig:
     pad_to_canvas: str = "off"
     letterbox_px_tolerance: int = 8
     center_pad: bool = True
+    ffmpeg_timeout_seconds: float = 120.0
 
 
 @dataclass

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -1283,11 +1283,16 @@ def _save_frame_with_ffmpeg(
     ]
 
     timeout_value = getattr(cfg, "ffmpeg_timeout_seconds", None)
-    timeout_seconds: float | None
+    timeout_seconds_raw: float | None
     try:
-        timeout_seconds = float(timeout_value) if timeout_value is not None else None
+        timeout_seconds_raw = float(timeout_value) if timeout_value is not None else None
     except (TypeError, ValueError):
-        timeout_seconds = None
+        timeout_seconds_raw = None
+
+    if timeout_seconds_raw is not None and timeout_seconds_raw <= 0:
+        timeout_seconds: float | None = None
+    else:
+        timeout_seconds = timeout_seconds_raw
 
     try:
         process = subprocess.run(

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -1265,6 +1265,7 @@ def _save_frame_with_ffmpeg(
     filter_chain = ",".join(filters)
     cmd = [
         "ffmpeg",
+        "-nostdin",
         "-loglevel",
         "error",
         "-y",
@@ -1281,7 +1282,26 @@ def _save_frame_with_ffmpeg(
         str(path),
     ]
 
-    process = subprocess.run(cmd, capture_output=True)
+    timeout_value = getattr(cfg, "ffmpeg_timeout_seconds", None)
+    timeout_seconds: float | None
+    try:
+        timeout_seconds = float(timeout_value) if timeout_value is not None else None
+    except (TypeError, ValueError):
+        timeout_seconds = None
+
+    try:
+        process = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration = timeout_seconds if timeout_seconds is not None else 0.0
+        raise ScreenshotWriterError(
+            f"FFmpeg timed out after {duration:.1f}s for frame {frame_idx}"
+        ) from exc
     if process.returncode != 0:
         stderr = process.stderr.decode("utf-8", "ignore").strip()
         message = stderr or "unknown error"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,6 +17,7 @@ def test_load_defaults(tmp_path: Path) -> None:
     assert app.analysis.frame_count_dark == 20
     assert app.analysis.downscale_height == 720
     assert app.screenshots.directory_name == "screens"
+    assert app.screenshots.ffmpeg_timeout_seconds == 120.0
     assert app.naming.always_full_filename is True
     assert app.runtime.ram_limit_mb == 4000
     assert isinstance(app.runtime.vapoursynth_python_paths, list)
@@ -52,6 +53,7 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[color]\nverify_step_seconds = 0\n", "color.verify_step_seconds"),
         ("[color]\ntarget_nits = -10\n", "color.target_nits"),
         ("[source]\npreferred = \"bogus\"\n", "source.preferred"),
+        ("[screenshots]\nffmpeg_timeout_seconds = 0\n", "screenshots.ffmpeg_timeout_seconds"),
         ("[tmdb]\nyear_tolerance = -1\n", "tmdb.year_tolerance"),
         ("[tmdb]\ncache_ttl_seconds = -5\n", "tmdb.cache_ttl_seconds"),
         ("[tmdb]\ncategory_preference = \"documentary\"\n", "tmdb.category_preference"),
@@ -79,6 +81,7 @@ min_window_seconds = 2.5
 
 [screenshots]
 compression_level = 2
+ffmpeg_timeout_seconds = 45.5
 
 [slowpics]
 auto_upload = "1"
@@ -120,6 +123,7 @@ preferred = "ffms2"
     assert app.analysis.ignore_trail_seconds == 1.25
     assert app.analysis.min_window_seconds == 2.5
     assert app.screenshots.compression_level == 2
+    assert app.screenshots.ffmpeg_timeout_seconds == 45.5
     assert app.slowpics.auto_upload is True
     assert app.slowpics.remove_after_days == 14
     assert app.naming.always_full_filename is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,6 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[color]\nverify_step_seconds = 0\n", "color.verify_step_seconds"),
         ("[color]\ntarget_nits = -10\n", "color.target_nits"),
         ("[source]\npreferred = \"bogus\"\n", "source.preferred"),
-        ("[screenshots]\nffmpeg_timeout_seconds = 0\n", "screenshots.ffmpeg_timeout_seconds"),
         ("[tmdb]\nyear_tolerance = -1\n", "tmdb.year_tolerance"),
         ("[tmdb]\ncache_ttl_seconds = -5\n", "tmdb.cache_ttl_seconds"),
         ("[tmdb]\ncategory_preference = \"documentary\"\n", "tmdb.category_preference"),
@@ -66,6 +65,18 @@ def test_validation_errors(tmp_path: Path, toml_snippet: str, message: str) -> N
     with pytest.raises(ConfigError) as exc_info:
         load_config(str(cfg_path))
     assert message in str(exc_info.value)
+
+
+def test_ffmpeg_timeout_zero_is_allowed(tmp_path: Path) -> None:
+    cfg_path = _copy_default_config(tmp_path)
+    original = cfg_path.read_text(encoding="utf-8")
+    cfg_path.write_text(
+        original.replace("ffmpeg_timeout_seconds = 120.0", "ffmpeg_timeout_seconds = 0.0", 1),
+        encoding="utf-8",
+    )
+
+    app = load_config(str(cfg_path))
+    assert app.screenshots.ffmpeg_timeout_seconds == 0.0
 
 
 def test_override_values(tmp_path: Path) -> None:

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import subprocess
 import types
 from typing import Optional, TypedDict
 
@@ -1041,3 +1042,68 @@ def test_overlay_state_warning_helpers_roundtrip() -> None:
     screenshot._append_overlay_warning(state, "first")
     screenshot._append_overlay_warning(state, "second")
     assert screenshot._get_overlay_warnings(state) == ["first", "second"]
+
+
+def test_save_frame_with_ffmpeg_honours_timeout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = ScreenshotConfig(ffmpeg_timeout_seconds=37.5)
+    recorded: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):  # type: ignore[override]
+        recorded.update(kwargs)
+        recorded["cmd"] = cmd
+
+        class _Result:
+            returncode = 0
+            stderr = b""
+
+        return _Result()
+
+    monkeypatch.setattr(screenshot.shutil, "which", lambda _: "ffmpeg")
+    monkeypatch.setattr(screenshot.subprocess, "run", fake_run)
+
+    screenshot._save_frame_with_ffmpeg(
+        source="video.mkv",
+        frame_idx=12,
+        crop=(0, 0, 0, 0),
+        scaled=(1920, 1080),
+        pad=(0, 0, 0, 0),
+        path=tmp_path / "frame.png",
+        cfg=cfg,
+        width=1920,
+        height=1080,
+        selection_label=None,
+    )
+
+    cmd = recorded.get("cmd")
+    assert isinstance(cmd, list)
+    assert "-nostdin" in cmd
+    assert recorded.get("stdin") is subprocess.DEVNULL
+    assert recorded.get("stdout") is subprocess.DEVNULL
+    assert recorded.get("stderr") is subprocess.PIPE
+    assert recorded.get("timeout") == pytest.approx(37.5)
+
+
+def test_save_frame_with_ffmpeg_raises_on_timeout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg = ScreenshotConfig(ffmpeg_timeout_seconds=5.0)
+
+    def fake_run(*args, **kwargs):  # type: ignore[override]
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(screenshot.shutil, "which", lambda _: "ffmpeg")
+    monkeypatch.setattr(screenshot.subprocess, "run", fake_run)
+
+    with pytest.raises(screenshot.ScreenshotWriterError) as exc_info:
+        screenshot._save_frame_with_ffmpeg(
+            source="video.mkv",
+            frame_idx=99,
+            crop=(0, 0, 0, 0),
+            scaled=(1280, 720),
+            pad=(0, 0, 0, 0),
+            path=tmp_path / "frame.png",
+            cfg=cfg,
+            width=1280,
+            height=720,
+            selection_label=None,
+        )
+
+    assert "timed out" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add a configurable FFmpeg timeout and disable stdin consumption for screenshot rendering to avoid hangs
- surface the timeout in CLI render metadata, configuration loading, and docs
- cover the new configuration and timeout handling with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb7c7f62448321b94118b9beda1c51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-frame FFmpeg timeout for screenshots (default 120s); 0 disables the timeout. Adds user-level fallback to seed a writable config when the install tree is read-only.
* **Bug Fixes**
  * Prevented FFmpeg from reading stdin to avoid hung renders; timeouts now abort long renders.
* **Documentation**
  * Updated docs and CLI reference for timeout and config fallback.
* **Tests**
  * Added tests for timeout handling and config fallback.
* **Chores**
  * Added changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->