### PR TITLE
Close slow.pics sessions after upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-22:* Default config now seeds to `~/.frame-compare/config.toml`, `[paths].input_dir` defaults to `~/comparison_videos`, and the packaged template ships from `src/data/` (with wheel coverage) to avoid site-packages permission issues.
 - *2025-10-21:* Added an optional `$FRAME_COMPARE_TEMPLATE_PATH` override and filesystem fallback for the packaged config template plus clearer screenshot permission errors so runs targeting read-only `comparison_videos` trees fail fast with guidance.
 - *2025-10-19:* Seed the packaged default config into a per-user directory when the project tree is read-only so packaged installs no longer fail to start on permission errors.
 - *2025-10-20:* Allow disabling the per-frame FFmpeg timeout by setting `screenshots.ffmpeg_timeout_seconds` to 0 while keeping negative values invalid in validation and docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-21:* Added an optional `$FRAME_COMPARE_TEMPLATE_PATH` override and filesystem fallback for the packaged config template plus clearer screenshot permission errors so runs targeting read-only `comparison_videos` trees fail fast with guidance.
 - *2025-10-19:* Seed the packaged default config into a per-user directory when the project tree is read-only so packaged installs no longer fail to start on permission errors.
 - *2025-10-20:* Allow disabling the per-frame FFmpeg timeout by setting `screenshots.ffmpeg_timeout_seconds` to 0 while keeping negative values invalid in validation and docs.
 - *2025-10-18:* Added a per-frame FFmpeg timeout and disabled stdin consumption to prevent hung screenshot renders and shell freezes on Windows.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Requirements:
 
 Repository fixtures live under `comparison_videos/` beside
 `frame_compare.py`; they provide tiny MKV stubs suitable for smoke
-tests and match the default `paths.input_dir`.
+tests. The default configuration now scans `~/comparison_videos`, so
+copy the fixtures there (or point `[paths].input_dir` somewhere else)
+before running comparisons.
 
 ```bash
 uv sync
@@ -37,7 +39,7 @@ uv pip install vapoursynth  # or `uv add vapoursynth` to persist it to your proj
 uv run python frame_compare.py
 ```
 
-The CLI ships with a configuration template stored at `data/config.toml.template`. Frame Compare resolves that template by first honouring `$FRAME_COMPARE_TEMPLATE_PATH` (useful when you store templates outside the repository), then falling back to the packaged copy or the on-disk file. When you want to edit the defaults, copy the template to a writable location—`python -c "from src.config_template import copy_default_config; copy_default_config('~/frame_compare.toml')"` is a quick way—and point the CLI at it with `--config` or by setting `$FRAME_COMPARE_CONFIG`.
+The CLI ships with a configuration template stored at `src/data/config.toml.template` (packaged as `data/config.toml.template`). Frame Compare resolves that template by first honouring `$FRAME_COMPARE_TEMPLATE_PATH` (useful when you store templates outside the repository), then falling back to the packaged copy or the on-disk file. When you want to edit the defaults, copy the template to a writable location—`python -c "from src.config_template import copy_default_config; copy_default_config('~/frame_compare.toml')"` is a quick way—and point the CLI at it with `--config` or by setting `$FRAME_COMPARE_CONFIG`.
 
 Install VapourSynth manually after `uv sync` so the renderer is available:
 
@@ -68,18 +70,18 @@ Expected outputs: PNGs under `screens/…`, cached metrics in
 `generated.audio_offsets.toml`, and (when uploads are enabled) a
 slow.pics shortcut file.
 
-Screenshot renders are written beneath the resolved input directory (for example `comparison_videos/screens`). Make sure that directory is writable before running the CLI—if you installed the project somewhere read-only, point `[paths].input_dir` at a location you control or invoke the CLI with `--input` so Frame Compare can create the screenshot subdirectories it needs.
+Screenshot renders are written beneath the resolved input directory (for example `~/comparison_videos/screens`). Make sure that directory exists and is writable before running the CLI—if you installed the project somewhere read-only, point `[paths].input_dir` at a location you control or invoke the CLI with `--input` so Frame Compare can create the screenshot subdirectories it needs.
 
 ## Configuration essentials
 
 Frame Compare looks for its configuration at the path specified by the
 ``$FRAME_COMPARE_CONFIG`` environment variable. When the variable is unset, the
-CLI uses ``config.toml`` alongside ``frame_compare.py``. If that file does not
-exist, the CLI seeds it from ``data/config.toml.template`` (falling back to the
-repository copy when the package data is unavailable) before loading so a fresh
-checkout is immediately runnable. To customise the settings, edit ``config.toml``
-directly or copy the template to another writable location with ``python -c
-'from src.config_template import copy_default_config; copy_default_config("~/frame-compare.toml")'``
+CLI uses ``~/.frame-compare/config.toml``. If that file does not exist, the CLI
+seeds it from ``data/config.toml.template`` (falling back to the repository copy
+when the package data is unavailable) before loading so a fresh install is
+immediately runnable. To customise the settings, edit the seeded file directly
+or copy the template to another writable location with ``python -c 'from
+src.config_template import copy_default_config; copy_default_config("~/frame-compare.toml")'``
 and either set ``$FRAME_COMPARE_CONFIG`` or pass ``--config`` when invoking the
 CLI. Export ``$FRAME_COMPARE_TEMPLATE_PATH`` when you need ``copy_default_config``
 to source the template from somewhere other than ``data/config.toml.template``.
@@ -90,7 +92,7 @@ The most common toggles are below; see the
 <!-- markdownlint-disable MD013 -->
 | Key | What it controls | Default | Example |
 | --- | --- | --- | --- |
-| `[paths].input_dir` | Base scan directory. | `"comparison_videos"` | `input_dir="comparison_videos"` |
+| `[paths].input_dir` | Base scan directory. | `"~/comparison_videos"` | `input_dir="~/comparison_videos"` |
 | `--input PATH` | One-off scan override. | `None` | `--input /data/releases` |
 | `[analysis].frame_count_dark / frame_count_bright` | Scene quotas for shadows and highlights. | `20 / 10` | `frame_count_dark=12` |
 | `[analysis].frame_count_motion` | Motion-heavy frame quota. | `10` | `frame_count_motion=24` |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uv pip install vapoursynth  # or `uv add vapoursynth` to persist it to your proj
 uv run python frame_compare.py
 ```
 
-The CLI ships with a configuration template stored at `data/config.toml.template`. Frame Compare loads that packaged template by default so the CLI works out of the box. When you want to edit the defaults, copy the template to a writable location—`python -c "from src.config_template import copy_default_config; copy_default_config('~/frame_compare.toml')"` is a quick way—and point the CLI at it with `--config` or by setting `$FRAME_COMPARE_CONFIG`.
+The CLI ships with a configuration template stored at `data/config.toml.template`. Frame Compare resolves that template by first honouring `$FRAME_COMPARE_TEMPLATE_PATH` (useful when you store templates outside the repository), then falling back to the packaged copy or the on-disk file. When you want to edit the defaults, copy the template to a writable location—`python -c "from src.config_template import copy_default_config; copy_default_config('~/frame_compare.toml')"` is a quick way—and point the CLI at it with `--config` or by setting `$FRAME_COMPARE_CONFIG`.
 
 Install VapourSynth manually after `uv sync` so the renderer is available:
 
@@ -68,17 +68,21 @@ Expected outputs: PNGs under `screens/…`, cached metrics in
 `generated.audio_offsets.toml`, and (when uploads are enabled) a
 slow.pics shortcut file.
 
+Screenshot renders are written beneath the resolved input directory (for example `comparison_videos/screens`). Make sure that directory is writable before running the CLI—if you installed the project somewhere read-only, point `[paths].input_dir` at a location you control or invoke the CLI with `--input` so Frame Compare can create the screenshot subdirectories it needs.
+
 ## Configuration essentials
 
 Frame Compare looks for its configuration at the path specified by the
 ``$FRAME_COMPARE_CONFIG`` environment variable. When the variable is unset, the
 CLI uses ``config.toml`` alongside ``frame_compare.py``. If that file does not
-exist, the CLI seeds it from the bundled ``data/config.toml.template`` before
-loading so a fresh checkout is immediately runnable. To customise the
-settings, edit ``config.toml`` directly or copy the template to another
-writable location with ``python -c 'from src.config_template import
-copy_default_config; copy_default_config("~/frame-compare.toml")'`` and either
-set ``$FRAME_COMPARE_CONFIG`` or pass ``--config`` when invoking the CLI.
+exist, the CLI seeds it from ``data/config.toml.template`` (falling back to the
+repository copy when the package data is unavailable) before loading so a fresh
+checkout is immediately runnable. To customise the settings, edit ``config.toml``
+directly or copy the template to another writable location with ``python -c
+'from src.config_template import copy_default_config; copy_default_config("~/frame-compare.toml")'``
+and either set ``$FRAME_COMPARE_CONFIG`` or pass ``--config`` when invoking the
+CLI. Export ``$FRAME_COMPARE_TEMPLATE_PATH`` when you need ``copy_default_config``
+to source the template from somewhere other than ``data/config.toml.template``.
 
 The most common toggles are below; see the
 [full reference](docs/README_REFERENCE.md) for every option.

--- a/data/config.toml.template
+++ b/data/config.toml.template
@@ -126,9 +126,8 @@ style = "fill"
 
 [paths]
 # Default input folder; override via CLI when needed. The shipped
-# ``comparison_videos`` directory now lives alongside ``frame_compare.py``, so
-# relative values resolve next to the config file or project root.
-input_dir = "comparison_videos"
+# ``comparison_videos`` defaults to a folder in the user's home directory.
+input_dir = "~/comparison_videos"
 
 [runtime]
 ram_limit_mb = 4000

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,7 @@
 # Decisions Log
 
+- *2025-10-21:* `copy_default_config` now honours `$FRAME_COMPARE_TEMPLATE_PATH` and falls back to the repository template when the packaged `data` module is unavailable, letting us drop the setuptools package-dir mapping without breaking config seeding.
+- *2025-10-21:* Screenshot generation wraps directory creation failures in `ScreenshotError` so permission-denied errors surface with actionable guidance about choosing a writable `[paths].input_dir`.
 - *2025-10-19:* When the packaged install directory is read-only we now seed the default config under `~/.frame-compare/config.toml`, logging the relocation so users know to point overrides there instead of the site-packages path.
 - *2025-10-20:* Restored the ability to disable FFmpeg screenshot timeouts by permitting `screenshots.ffmpeg_timeout_seconds = 0` and treating non-positive values as "no timeout" when invoking FFmpeg.
 - *2025-10-18:* Added `screenshots.ffmpeg_timeout_seconds` plus `-nostdin` when spawning FFmpeg to stop runaway renders from freezing Windows shells; surfaced the timeout in CLI render metadata and config docs.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-22:* Default config seeding now targets `~/.frame-compare/config.toml`, the packaged template lives under `src/data/` with explicit package data so wheels retain it, and `[paths].input_dir` defaults to `~/comparison_videos` to avoid site-packages permission traps.
 - *2025-10-21:* `copy_default_config` now honours `$FRAME_COMPARE_TEMPLATE_PATH` and falls back to the repository template when the packaged `data` module is unavailable, letting us drop the setuptools package-dir mapping without breaking config seeding.
 - *2025-10-21:* Screenshot generation wraps directory creation failures in `ScreenshotError` so permission-denied errors surface with actionable guidance about choosing a writable `[paths].input_dir`.
 - *2025-10-19:* When the packaged install directory is read-only we now seed the default config under `~/.frame-compare/config.toml`, logging the relocation so users know to point overrides there instead of the site-packages path.

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -76,22 +76,23 @@ quick-start configuration paths.
 <!-- markdownlint-disable MD013 -->
 | Key | Purpose | Type | Default |
 | --- | --- | --- | --- |
-| `[paths].input_dir` | Default scan directory. | str | `"comparison_videos"` |
+| `[paths].input_dir` | Default scan directory. | str | `"~/comparison_videos"` |
 | `[runtime].ram_limit_mb` | VapourSynth RAM ceiling. | int | `4000` |
 | `[runtime].vapoursynth_python_paths` | Extra VapourSynth module paths. | list[str] | `[]` |
 | `[source].preferred` | Preferred source filter. | str | `"lsmas"` |
 | `VAPOURSYNTH_PYTHONPATH` | Environment module path. | str | *(unset)* |
 <!-- markdownlint-restore -->
 
-Repository fixtures mirror the default `paths.input_dir` and live under
-`comparison_videos/` next to `frame_compare.py` for local smoke tests.
+Repository fixtures mirror the historical `paths.input_dir` default and live under
+`comparison_videos/` next to `frame_compare.py`; copy them into `~/comparison_videos`
+if you want to use the bundled samples.
 
 ## CLI flags
 
 <!-- markdownlint-disable MD013 -->
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--config PATH` | Use a specific configuration file. | ``$FRAME_COMPARE_CONFIG`` or the repo ``config.toml`` (seeded from the bundled template; falls back to ``~/.frame-compare/config.toml`` when the install tree is read-only) |
+| `--config PATH` | Use a specific configuration file. | ``$FRAME_COMPARE_CONFIG`` or ``~/.frame-compare/config.toml`` seeded from the bundled template |
 | `--input PATH` | Override `[paths.input_dir]` for this run. | `None` |
 | `--quiet` | Show minimal console output. | `false` |
 | `--verbose` | Emit additional diagnostics. | `false` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,12 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = {find = {where = ["src"]}}
+package-dir = {"src" = "src", "src.frame_compare" = "src/frame_compare", "data" = "src/data"}
+packages = ["src", "src.frame_compare", "data"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"data" = ["config.toml.template"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,19 +38,14 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["frame_compare", "data"]
-include-package-data = true
-
-[tool.setuptools.package-dir]
-frame_compare = "src/frame_compare"
-data = "data"
-
-[tool.setuptools.package-data]
-data = ["config.toml.template"]
+packages = {find = {where = ["src"]}}
 
 [tool.black]
 line-length = 100
 target-version = ["py313"]
+
+[tool.pytest.ini_options]
+pythonpath = [".", "src"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 package-dir = {"src" = "src", "src.frame_compare" = "src/frame_compare", "data" = "src/data"}
 packages = ["src", "src.frame_compare", "data"]
 include-package-data = true
+py-modules = ["frame_compare"]
 
 [tool.setuptools.package-data]
 "data" = ["config.toml.template"]

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -11,7 +11,7 @@ _TEMPLATE_PACKAGE: Final[str] = "data"
 _TEMPLATE_FILENAME: Final[str] = "config.toml.template"
 TEMPLATE_ENV_VAR: Final[str] = "FRAME_COMPARE_TEMPLATE_PATH"
 FILESYSTEM_TEMPLATE_PATH: Final[Path] = (
-    Path(__file__).resolve().parent.parent / "data" / _TEMPLATE_FILENAME
+    Path(__file__).resolve().parent / "data" / _TEMPLATE_FILENAME
 )
 
 

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -77,7 +77,7 @@ def copy_default_config(
 
 
 __all__ = [
-    "copy_default_config",
     "FILESYSTEM_TEMPLATE_PATH",
     "TEMPLATE_ENV_VAR",
+    "copy_default_config",
 ]

--- a/src/config_template.py
+++ b/src/config_template.py
@@ -1,13 +1,46 @@
-"""Helpers for working with the packaged configuration template."""
+"""Helpers for copying the configuration template in both packaged and source layouts."""
 
 from __future__ import annotations
 
+import os
 from importlib import resources
 from pathlib import Path
 from typing import Final
 
 _TEMPLATE_PACKAGE: Final[str] = "data"
 _TEMPLATE_FILENAME: Final[str] = "config.toml.template"
+TEMPLATE_ENV_VAR: Final[str] = "FRAME_COMPARE_TEMPLATE_PATH"
+FILESYSTEM_TEMPLATE_PATH: Final[Path] = (
+    Path(__file__).resolve().parent.parent / "data" / _TEMPLATE_FILENAME
+)
+
+
+def _read_template_bytes() -> bytes:
+    """Return the template bytes from the packaged module or filesystem fallback."""
+
+    override = os.environ.get(TEMPLATE_ENV_VAR)
+    if override:
+        candidate = Path(override).expanduser()
+        if candidate.is_dir():
+            candidate = candidate / _TEMPLATE_FILENAME
+        try:
+            return candidate.read_bytes()
+        except OSError as exc:
+            raise FileNotFoundError(
+                f"Unable to read config template override at {candidate}: {exc}"
+            ) from exc
+
+    try:
+        template = resources.files(_TEMPLATE_PACKAGE).joinpath(_TEMPLATE_FILENAME)
+        return template.read_bytes()
+    except (FileNotFoundError, ModuleNotFoundError):
+        try:
+            return FILESYSTEM_TEMPLATE_PATH.read_bytes()
+        except OSError as exc:
+            raise FileNotFoundError(
+                "Unable to locate config template; expected packaged module 'data' "
+                f"or filesystem fallback {FILESYSTEM_TEMPLATE_PATH}: {exc}"
+            ) from exc
 
 
 def copy_default_config(
@@ -33,14 +66,18 @@ def copy_default_config(
     """
 
     target = Path(destination) if destination is not None else Path.cwd() / "config.toml"
-    template = resources.files(_TEMPLATE_PACKAGE).joinpath(_TEMPLATE_FILENAME)
+    template_bytes = _read_template_bytes()
 
     if target.exists() and not overwrite:
         raise FileExistsError(f"{target} already exists; pass overwrite=True to replace it.")
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_bytes(template.read_bytes())
+    target.write_bytes(template_bytes)
     return target
 
 
-__all__ = ["copy_default_config"]
+__all__ = [
+    "copy_default_config",
+    "FILESYSTEM_TEMPLATE_PATH",
+    "TEMPLATE_ENV_VAR",
+]

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,2 @@
+"""Embedded data files packaged with frame-compare."""
+

--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -1,0 +1,149 @@
+﻿# All user-editable settings live here.
+
+[analysis]
+# Frame selection knobs. The legacy quantile, motion, and random heuristics are all exposed here.
+frame_count_dark = 20
+frame_count_bright = 10
+frame_count_motion = 10
+user_frames = []
+random_frames = 10
+save_frames_data = true
+downscale_height = 720
+step = 2
+analyze_in_sdr = true
+use_quantiles = true
+dark_quantile = 0.20
+bright_quantile = 0.80
+motion_use_absdiff = false
+motion_scenecut_quantile = 0.0
+screen_separation_sec = 6
+motion_diff_radius = 4
+analyze_clip = ""
+random_seed = 20202020
+frame_data_filename = "generated.compframes"
+# Ignore head/tail segments when sampling frames (seconds).
+ignore_lead_seconds = 0.0
+ignore_trail_seconds = 0.0
+# Guarantee at least this much selectable footage after trimming.
+min_window_seconds = 5.0
+
+[audio_alignment]
+# Estimate offsets via audio cross-correlation before frame analysis.
+enable = false
+# reference = ""          # Optional: pick specific reference label/filename; defaults to analyze clip
+sample_rate = 16000        # Audio extraction rate (Hz)
+hop_length = 512           # Onset envelope hop length
+# start_seconds = 0.0      # Optional: analysis window start (seconds)
+# duration_seconds = 600.0 # Optional: analysis window length (seconds)
+correlation_threshold = 0.55
+max_offset_seconds = 12.0
+offsets_filename = "generated.audio_offsets.toml"
+confirm_with_screenshots = true
+random_seed = 2025
+frame_offset_bias = 1        # Frames to move toward zero (negative values push further away)
+
+[screenshots]
+# Output planning and rendering behaviour for both VapourSynth and FFmpeg writers.
+directory_name = "screens"
+add_frame_info = true
+use_ffmpeg = false
+compression_level = 1
+# Allow global upscaling of shorter clips; width stays within the widest input
+# unless `single_res` requests a fixed height.
+upscale = true
+single_res = 0
+mod_crop = 2
+letterbox_pillarbox_aware = true
+# Estimate and crop out scope letterbox bars using aspect ratio heuristics.
+auto_letterbox_crop = false
+pad_to_canvas = "off"
+letterbox_px_tolerance = 8
+center_pad = true
+# Abort FFmpeg renders that exceed this many seconds per frame (must be >= 0; set to 0 to disable).
+ffmpeg_timeout_seconds = 120.0
+
+[color]
+# HDR → SDR pipeline controls. Presets: reference (bt.2390/100nits/dpd=1),
+# contrast (mobius/120nits/dpd=0), filmic (hable/100nits/dpd=1), or custom values below.
+enable_tonemap = true
+preset = "reference"
+tone_curve = "bt.2390"
+dynamic_peak_detection = true
+target_nits = 100.0
+dst_min_nits = 0.1
+overlay_enabled = true
+overlay_text_template = "Tonemapping Algorithm: {tone_curve} dpd = {dynamic_peak_detection} dst = {target_nits} nits"
+overlay_mode = "minimal"  # Options: "minimal", "diagnostic"
+verify_enabled = true
+# verify_frame = 4123  # Uncomment to force a specific frame index for verification
+verify_auto = true
+verify_start_seconds = 10.0
+verify_step_seconds = 10.0
+verify_max_seconds = 90.0
+verify_luma_threshold = 0.10
+strict = false
+
+[slowpics]
+# Auto-upload settings. Leave `auto_upload` off for local runs.
+auto_upload = true
+collection_name = ""
+collection_suffix = ""
+is_hentai = false
+is_public = true
+tmdb_id = ""
+tmdb_category = ""
+# slow.pics expects identifiers like MOVIE_603; digits are auto-normalized when the TMDB category is known.
+remove_after_days = 0
+webhook_url = ""
+open_in_browser = true
+create_url_shortcut = true
+delete_screen_dir_after_upload = true
+
+[tmdb]
+# TMDB lookup automation. Provide an API key to enable matching.
+api_key = ""
+unattended = true
+confirm_matches = false
+year_tolerance = 2
+enable_anime_parsing = true
+cache_ttl_seconds = 86400
+# Maximum number of distinct TMDB responses cached in-process (0 disables caching)
+cache_max_entries = 256
+category_preference = ""
+
+[naming]
+# Controls how GuessIt/Anitopy metadata is turned into labels.
+always_full_filename = true
+prefer_guessit = true
+
+[cli]
+# Control CLI output behaviours.
+emit_json_tail = true
+
+[cli.progress]
+# Progress bar appearance: "fill" for filled bar, "dot" for single indicator.
+style = "fill"
+
+[paths]
+# Default input folder; override via CLI when needed. The shipped
+# ``comparison_videos`` defaults to a folder in the user's home directory.
+input_dir = "~/comparison_videos"
+
+[runtime]
+ram_limit_mb = 4000
+vapoursynth_python_paths = []
+
+[source]
+# VapourSynth source filter preference. Valid options: "lsmas" or "ffms2".
+preferred = "lsmas"
+
+
+[overrides]
+# Per-source trim/FPS overrides. Keys may be an index, filename, or parsed label (case-insensitive).
+# Example:
+# trim = { "0" = 120, "my_encode" = 48 }
+# trim_end = { "my_encode" = -24 }
+# change_fps = { "1" = "60000/1001" }
+trim = {}
+trim_end = {}
+change_fps = {}

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -137,7 +137,7 @@ class CLIConfig:
 class PathsConfig:
     """Filesystem paths configured by the user."""
 
-    input_dir: str = "."
+    input_dir: str = "~/comparison_videos"
 
 
 @dataclass

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -1373,7 +1373,17 @@ def generate_screenshots(
     if len(trim_offsets) != len(files):
         raise ScreenshotError("trim_offsets and files must have matching lengths")
 
-    out_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError as exc:
+        raise ScreenshotError(
+            "Unable to create screenshot directory "
+            f"'{out_dir}': {exc.strerror or exc}"
+        ) from exc
+    except OSError as exc:
+        raise ScreenshotError(
+            f"Unable to prepare screenshot directory '{out_dir}': {exc}"
+        ) from exc
     created: List[str] = []
 
     processed_results: List[vs_core.ClipProcessResult] = []

--- a/src/slowpics.py
+++ b/src/slowpics.py
@@ -284,23 +284,23 @@ def upload_comparison(
     if not image_files:
         raise SlowpicsAPIError("No image files provided for upload")
 
-    session = requests.Session()
-    try:
-        session.get("https://slow.pics/comparison", timeout=_CONNECT_TIMEOUT_SECONDS)
-    except requests.RequestException as exc:
-        raise SlowpicsAPIError(f"Failed to establish slow.pics session: {exc}") from exc
+    with requests.Session() as session:
+        try:
+            session.get("https://slow.pics/comparison", timeout=_CONNECT_TIMEOUT_SECONDS)
+        except requests.RequestException as exc:
+            raise SlowpicsAPIError(f"Failed to establish slow.pics session: {exc}") from exc
 
-    xsrf_token = session.cookies.get("XSRF-TOKEN")
-    if not xsrf_token:
-        raise SlowpicsAPIError("Missing XSRF token from slow.pics response")
+        xsrf_token = session.cookies.get("XSRF-TOKEN")
+        if not xsrf_token:
+            raise SlowpicsAPIError("Missing XSRF token from slow.pics response")
 
-    logger.info("Using slow.pics legacy upload endpoints")
-    url = _upload_comparison_legacy(
-        session,
-        image_files,
-        screen_dir,
-        cfg,
-        progress_callback=progress_callback,
-    )
-    logger.info("Slow.pics: %s", url)
-    return url
+        logger.info("Using slow.pics legacy upload endpoints")
+        url = _upload_comparison_legacy(
+            session,
+            image_files,
+            screen_dir,
+            cfg,
+            progress_callback=progress_callback,
+        )
+        logger.info("Slow.pics: %s", url)
+        return url

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-from importlib import resources
-from pathlib import Path
-
 import os
 import subprocess
 import sys
-from importlib import resources
 from pathlib import Path
 
 import pytest
@@ -14,13 +10,14 @@ import pytest
 from src.config_template import (
     FILESYSTEM_TEMPLATE_PATH,
     TEMPLATE_ENV_VAR,
+    _read_template_bytes,
     copy_default_config,
 )
 
 
 @pytest.fixture(name="template_bytes")
 def fixture_template_bytes() -> bytes:
-    return FILESYSTEM_TEMPLATE_PATH.read_bytes()
+    return _read_template_bytes()
 
 
 def test_copy_default_config_writes_template(tmp_path: Path, template_bytes: bytes) -> None:
@@ -57,7 +54,7 @@ def test_copy_default_config_falls_back_without_packaged_module(
 ) -> None:
     destination = tmp_path / "config.toml"
 
-    def _raise(*args: object, **kwargs: object) -> resources.Traversable:
+    def _raise(*_args: object, **_kwargs: object) -> object:
         raise ModuleNotFoundError("data")
 
     monkeypatch.setattr(

--- a/tests/test_config_template.py
+++ b/tests/test_config_template.py
@@ -3,14 +3,21 @@ from __future__ import annotations
 from importlib import resources
 from pathlib import Path
 
+from importlib import resources
+from pathlib import Path
+
 import pytest
 
-from src.config_template import copy_default_config
+from src.config_template import (
+    FILESYSTEM_TEMPLATE_PATH,
+    TEMPLATE_ENV_VAR,
+    copy_default_config,
+)
 
 
 @pytest.fixture(name="template_bytes")
 def fixture_template_bytes() -> bytes:
-    return resources.files("data").joinpath("config.toml.template").read_bytes()
+    return FILESYSTEM_TEMPLATE_PATH.read_bytes()
 
 
 def test_copy_default_config_writes_template(tmp_path: Path, template_bytes: bytes) -> None:
@@ -38,3 +45,42 @@ def test_copy_default_config_overwrites_when_requested(tmp_path: Path) -> None:
 
     contents = destination.read_text(encoding="utf-8")
     assert "[analysis]" in contents
+
+
+def test_copy_default_config_falls_back_without_packaged_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    template_bytes: bytes,
+) -> None:
+    destination = tmp_path / "config.toml"
+
+    def _raise(*args: object, **kwargs: object) -> resources.Traversable:
+        raise ModuleNotFoundError("data")
+
+    monkeypatch.setattr(
+        "src.config_template.resources.files",
+        _raise,
+    )
+
+    written = copy_default_config(destination, overwrite=True)
+
+    assert written == destination
+    assert destination.read_bytes() == template_bytes
+
+
+def test_copy_default_config_respects_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "config.toml"
+    override_template = tmp_path / "custom-template.toml"
+    override_template.write_text("[custom]\nvalue=1\n", encoding="utf-8")
+
+    monkeypatch.setenv(TEMPLATE_ENV_VAR, str(override_template))
+
+    try:
+        written = copy_default_config(destination, overwrite=True)
+    finally:
+        monkeypatch.delenv(TEMPLATE_ENV_VAR, raising=False)
+
+    assert written == destination
+    assert destination.read_text(encoding="utf-8") == "[custom]\nvalue=1\n"

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -1,6 +1,7 @@
 import json
 import types
 import importlib
+import pathlib
 from pathlib import Path
 from collections.abc import Iterable, Sequence
 from typing import Any, Mapping, cast
@@ -36,10 +37,11 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def test_cli_uses_repo_config_by_default(
+def test_cli_defaults_to_user_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
 ) -> None:
     monkeypatch.delenv("FRAME_COMPARE_CONFIG", raising=False)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     module_default = importlib.reload(frame_compare)
 
     try:
@@ -47,10 +49,11 @@ def test_cli_uses_repo_config_by_default(
         assert module_default_file is not None
         project_config = Path(module_default_file).resolve().with_name("config.toml")
         template_path = (
-            Path(module_default_file).resolve().with_name("data") / "config.toml.template"
+            Path(module_default_file).resolve().with_name("src") / "data" / "config.toml.template"
         ).resolve()
+        expected_user_config = (tmp_path / ".frame-compare" / "config.toml").resolve()
 
-        assert module_default.DEFAULT_CONFIG_PATH == project_config
+        assert module_default.DEFAULT_CONFIG_PATH == expected_user_config
         assert module_default.PROJECT_CONFIG_PATH == project_config
         assert module_default.PACKAGED_TEMPLATE_PATH == template_path
 
@@ -61,8 +64,8 @@ def test_cli_uses_repo_config_by_default(
         default_option = next(
             param for param in module_default.main.params if param.name == "config_path"
         )
-        assert default_option.default == str(project_config)
-        assert str(project_config) in default_output
+        assert default_option.default == str(expected_user_config)
+        assert str(expected_user_config) in default_output
 
         override_target = (tmp_path / "config" / "config.toml").resolve()
         monkeypatch.setenv("FRAME_COMPARE_CONFIG", str(override_target))
@@ -94,12 +97,13 @@ def test_cli_uses_repo_config_by_default(
 def test_ensure_config_present_seeds_missing_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("FRAME_COMPARE_CONFIG", str(tmp_path / "config.toml"))
+    monkeypatch.delenv("FRAME_COMPARE_CONFIG", raising=False)
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     module = importlib.reload(frame_compare)
 
     try:
         target = module.DEFAULT_CONFIG_PATH
-        assert target == tmp_path / "config.toml"
+        assert target == tmp_path / ".frame-compare" / "config.toml"
         assert not target.exists()
 
         calls: list[Path] = []
@@ -124,74 +128,45 @@ def test_ensure_config_present_seeds_missing_default(
 def test_ensure_config_present_skips_copy_for_non_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     module = importlib.reload(frame_compare)
-
-    other_path = tmp_path / "custom" / "config.toml"
-    calls: list[Path] = []
-
-    def fake_copy(destination: Path) -> Path:  # pragma: no cover - should not run
-        calls.append(destination)
-        return destination
-
-    monkeypatch.setattr(module, "copy_default_config", fake_copy)
-
-    result = module._ensure_config_present(other_path)
-    assert result == other_path
-    assert calls == []
-
-
-def test_ensure_config_present_falls_back_to_user_config(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("FRAME_COMPARE_CONFIG", str(tmp_path / "package" / "config.toml"))
-    module = importlib.reload(frame_compare)
-
-    fallback_target = tmp_path / "user" / "config.toml"
-    written: list[Path] = []
-
-    def fake_copy(destination: Path) -> Path:
-        if destination == module.DEFAULT_CONFIG_PATH:
-            raise PermissionError("read-only")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_text("seeded")
-        written.append(destination)
-        return destination
-
-    monkeypatch.setattr(module, "copy_default_config", fake_copy)
-    monkeypatch.setattr(module, "_default_user_config_path", lambda: fallback_target)
 
     try:
-        result = module._ensure_config_present(module.DEFAULT_CONFIG_PATH)
-        assert result == fallback_target
-        assert fallback_target.exists()
-        assert written == [fallback_target]
+        other_path = tmp_path / "custom" / "config.toml"
+        calls: list[Path] = []
+
+        def fake_copy(destination: Path) -> Path:  # pragma: no cover - should not run
+            calls.append(destination)
+            return destination
+
+        monkeypatch.setattr(module, "copy_default_config", fake_copy)
+
+        result = module._ensure_config_present(other_path)
+        assert result == other_path
+        assert calls == []
     finally:
-        monkeypatch.delenv("FRAME_COMPARE_CONFIG", raising=False)
         importlib.reload(frame_compare)
 
 
-def test_ensure_config_present_raises_when_all_writes_fail(
+def test_ensure_config_present_raises_when_default_unwritable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("FRAME_COMPARE_CONFIG", str(tmp_path / "package" / "config.toml"))
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     module = importlib.reload(frame_compare)
 
-    fallback_target = tmp_path / "user" / "config.toml"
-
-    def fake_copy(destination: Path) -> Path:
+    def fake_copy(destination: Path) -> Path:  # pragma: no cover - should be re-raised
         raise PermissionError("read-only")
 
     monkeypatch.setattr(module, "copy_default_config", fake_copy)
-    monkeypatch.setattr(module, "_default_user_config_path", lambda: fallback_target)
 
     try:
         with pytest.raises(frame_compare.CLIAppError) as excinfo:
             module._ensure_config_present(module.DEFAULT_CONFIG_PATH)
+
         message = str(excinfo.value)
-        assert "fallback path" in message
-        assert str(fallback_target) in message
+        assert "Unable to create default config" in message
+        assert str(module.DEFAULT_CONFIG_PATH) in message
     finally:
-        monkeypatch.delenv("FRAME_COMPARE_CONFIG", raising=False)
         importlib.reload(frame_compare)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -233,7 +233,7 @@ wheels = [
 [[package]]
 name = "frame-compare"
 version = "0.0.1"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "anitopy" },
     { name = "click" },


### PR DESCRIPTION
## Summary
- wrap slow.pics upload orchestration in a requests.Session context manager so connections are released promptly
- update slowpics test doubles to support context management and assert the session closes after upload

## Testing
- not run (requires approval)

------
https://chatgpt.com/codex/tasks/task_e_68ec2273867883219075f73feee48ab8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Upload flow now uses a context-managed session so sessions are closed automatically.

* **Bug Fixes**
  * Screenshot generation surfaces clear permission errors when output directories can’t be created.

* **New Features**
  * Template resolution supports an environment override and filesystem fallback; packaged template included.
  * Defaults updated: input_dir → ~/comparison_videos; default config seeds to ~/.frame-compare/config.toml.

* **Documentation**
  * README, changelog, and decisions updated with new defaults and template/resolution guidance.

* **Tests**
  * Added tests for session closure, template fallback/override, wheel loading, and screenshot permission errors.

* **Chores**
  * Packaging and test discovery settings adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->