### PR TITLE
Add VSPreview FPS harmonisation and module detection

### DIFF
--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -277,6 +277,7 @@ def test_launch_vspreview_generates_script(
             self.returncode = returncode
 
     monkeypatch.setattr(frame_compare.shutil, "which", lambda _: None)
+    monkeypatch.setattr(frame_compare.importlib.util, "find_spec", lambda name: object())
     monkeypatch.setattr(
         frame_compare.subprocess,
         "run",
@@ -293,6 +294,7 @@ def test_launch_vspreview_generates_script(
     assert "OFFSET_MAP" in script_text
     assert "vs_core.configure" in script_text
     assert "ColorConfig" in script_text
+    assert "AssumeFPS" in script_text
     assert recorded_command, "VSPreview command should be invoked when interactive"
     assert recorded_command[0][0] == frame_compare.sys.executable
     assert recorded_command[0][-1] == str(script_path)


### PR DESCRIPTION
## Summary
- embed FPS harmonisation helpers in the generated VSPreview script so reference and target clips match playback cadence
- guard VSPreview invocation by checking for an installed module when the standalone executable is unavailable
- extend the VSPreview launcher test to expect the new behaviour and verify the script includes the AssumeFPS hook

## Testing
- pytest tests/test_frame_compare.py::test_launch_vspreview_generates_script *(fails: missing rich dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4451b905c8321ade9d84fd7629453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic frame rate harmonization: clips now align their frame rates during loading for proper comparison
  * VSPreview launcher enhancements: Python module invocation now used as fallback when executable is unavailable

* **Bug Fixes**
  * Improved error handling when VSPreview cannot be launched, providing informative feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->