### PR TITLE
Implement VSPreview manual offset persistence flow

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -3014,8 +3014,11 @@ def _apply_vspreview_manual_offsets(
         desired_value = desired_map[key]
         updated = desired_value + shift
         updated_int = int(updated)
-        plan.trim_start = updated_int
-        plan.has_trim_start_override = plan.has_trim_start_override or updated_int != 0
+        safe_updated = max(0, updated_int)
+        plan.trim_start = safe_updated
+        plan.has_trim_start_override = (
+            plan.has_trim_start_override or safe_updated != 0
+        )
         manual_trim_starts[key] = updated_int
         applied_delta = updated_int - baseline_value
         delta_map[key] = applied_delta
@@ -3028,10 +3031,11 @@ def _apply_vspreview_manual_offsets(
 
     adjusted_reference = desired_map[reference_name] + shift
     adjusted_reference_int = int(adjusted_reference)
-    reference_plan.trim_start = adjusted_reference_int
+    safe_adjusted_reference = max(0, adjusted_reference_int)
+    reference_plan.trim_start = safe_adjusted_reference
     reference_plan.has_trim_start_override = (
         reference_plan.has_trim_start_override
-        or adjusted_reference_int != int(reference_baseline)
+        or safe_adjusted_reference != int(reference_baseline)
     )
     manual_trim_starts[reference_name] = adjusted_reference_int
     reference_delta = adjusted_reference_int - reference_baseline

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2273,17 +2273,20 @@ def _maybe_apply_audio_alignment(
     )
 
     try:
-        _, existing_entries = audio_alignment.load_offsets(offsets_path)
+        _, existing_entries_raw = audio_alignment.load_offsets(offsets_path)
     except audio_alignment.AudioAlignmentError as exc:
         raise CLIAppError(
             f"Failed to read audio offsets file: {exc}",
             rich_message=f"[red]Failed to read audio offsets file:[/red] {exc}",
         ) from exc
 
+    existing_entries: Dict[str, Dict[str, object]] = cast(
+        Dict[str, Dict[str, object]], existing_entries_raw
+    )
     vspreview_reuse: Dict[str, int] = {}
     if vspreview_enabled and existing_entries:
         for key, value in existing_entries.items():
-            if not isinstance(value, Mapping):
+            if not isinstance(value, dict):
                 continue
             status_obj = value.get("status")
             note_obj = value.get("note")

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -38,6 +38,7 @@ from typing import (
     Tuple,
     TypedDict,
     TypeVar,
+    TYPE_CHECKING,
     cast,
 )
 
@@ -73,6 +74,9 @@ from src.datatypes import (
     TMDBConfig,
 )
 from src import audio_alignment
+
+if TYPE_CHECKING:
+    from src.audio_alignment import AlignmentMeasurement, AudioStreamInfo
 from src.utils import parse_filename_metadata
 from src import vs_core
 from src.analysis import (
@@ -283,6 +287,16 @@ class AudioAlignmentJSON(TypedDict, total=False):
     preview_paths: list[str]
     confirmed: bool | str | None
     offsets_filename: str
+    vspreview_manual_offsets: dict[str, object]
+    vspreview_manual_deltas: dict[str, object]
+    vspreview_reference_trim: Optional[int]
+    manual_trim_summary: list[str]
+    suggestion_mode: bool
+    suggested_frames: dict[str, int]
+    manual_trim_starts: dict[str, int]
+    vspreview_script: Optional[str]
+    vspreview_invoked: bool
+    vspreview_exit_code: Optional[int]
 
 
 class TrimClipEntry(TypedDict):
@@ -415,10 +429,12 @@ class _AudioAlignmentSummary:
         suggested_frames (Dict[str, int]): Raw suggested frame offsets when VSPreview flow is enabled.
         suggestion_mode (bool): True when trims were not auto-applied (VSPreview flow).
         manual_trim_starts (Dict[str, int]): Existing manual trim starts applied before alignment.
+        vspreview_manual_offsets (Dict[str, int]): Persisted VSPreview manual offsets keyed by clip name.
+        vspreview_manual_deltas (Dict[str, int]): VSPreview deltas entered during the current session keyed by clip name.
     """
     offsets_path: Path
     reference_name: str
-    measurements: Sequence[audio_alignment.AlignmentMeasurement]
+    measurements: Sequence["AlignmentMeasurement"]
     applied_frames: Dict[str, int]
     baseline_shift: int
     statuses: Dict[str, str]
@@ -428,6 +444,8 @@ class _AudioAlignmentSummary:
     suggested_frames: Dict[str, int] = field(default_factory=dict)
     suggestion_mode: bool = False
     manual_trim_starts: Dict[str, int] = field(default_factory=dict)
+    vspreview_manual_offsets: Dict[str, int] = field(default_factory=dict)
+    vspreview_manual_deltas: Dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -2087,7 +2105,7 @@ def _maybe_apply_audio_alignment(
     plan_labels: Dict[Path, str] = {plan.path: _plan_label(plan) for plan in plans}
     name_to_label: Dict[str, str] = {plan.path.name: plan_labels[plan.path] for plan in plans}
 
-    stream_infos: Dict[Path, List[audio_alignment.AudioStreamInfo]] = {}
+    stream_infos: Dict[Path, List["AudioStreamInfo"]] = {}
     for plan in plans:
         try:
             infos = audio_alignment.probe_audio_streams(plan.path)
@@ -2118,7 +2136,7 @@ def _maybe_apply_audio_alignment(
         except (TypeError, ValueError):
             return None
 
-    def _pick_default(streams: Sequence[audio_alignment.AudioStreamInfo]) -> int:
+    def _pick_default(streams: Sequence["AudioStreamInfo"]) -> int:
         """
         Choose the index of the default audio stream from a sequence of streams.
         
@@ -2148,7 +2166,7 @@ def _maybe_apply_audio_alignment(
             reference_stream_info = candidate
             break
 
-    def _score_candidate(candidate: audio_alignment.AudioStreamInfo) -> float:
+    def _score_candidate(candidate: "AudioStreamInfo") -> float:
         """
         Compute a heuristic quality score for an audio stream candidate relative to the (closure) reference stream.
         
@@ -2262,6 +2280,69 @@ def _maybe_apply_audio_alignment(
             rich_message=f"[red]Failed to read audio offsets file:[/red] {exc}",
         ) from exc
 
+    vspreview_reuse: Dict[str, int] = {}
+    if vspreview_enabled and existing_entries:
+        for key, value in existing_entries.items():
+            if not isinstance(value, Mapping):
+                continue
+            status_obj = value.get("status")
+            note_obj = value.get("note")
+            frames_obj = value.get("frames")
+            if not isinstance(status_obj, str) or not isinstance(frames_obj, (int, float)):
+                continue
+            if status_obj.strip().lower() != "manual":
+                continue
+            note_text = str(note_obj or "").strip().lower()
+            if "vspreview" not in note_text:
+                continue
+            vspreview_reuse[key] = int(frames_obj)
+
+    if vspreview_reuse:
+        manual_trim_starts: Dict[str, int] = {}
+        if display_data.manual_trim_lines:
+            display_data.manual_trim_lines.clear()
+        label_map = {plan.path.name: plan_labels.get(plan.path, plan.path.name) for plan in plans}
+        for plan in plans:
+            key = plan.path.name
+            if key not in vspreview_reuse:
+                continue
+            frames_value = int(vspreview_reuse[key])
+            plan.trim_start = frames_value
+            plan.has_trim_start_override = plan.has_trim_start_override or frames_value != 0
+            manual_trim_starts[key] = frames_value
+            label = label_map.get(key, key)
+            display_data.manual_trim_lines.append(
+                f"VSPreview manual trim reused: {label} → {frames_value}f"
+            )
+
+        if display_data.manual_trim_lines:
+            display_data.offset_lines = ["Audio offsets: VSPreview manual offsets applied"]
+            display_data.offset_lines.extend(display_data.manual_trim_lines)
+        else:
+            display_data.offset_lines = ["Audio offsets: VSPreview manual offsets applied"]
+
+        display_data.json_offsets_frames = {
+            label_map.get(key, key): int(value)
+            for key, value in vspreview_reuse.items()
+        }
+        statuses_map = {key: "manual" for key in vspreview_reuse}
+        summary = _AudioAlignmentSummary(
+            offsets_path=offsets_path,
+            reference_name=reference_plan.path.name,
+            measurements=(),
+            applied_frames=dict(vspreview_reuse),
+            baseline_shift=0,
+            statuses=statuses_map,
+            reference_plan=reference_plan,
+            final_adjustments=dict(vspreview_reuse),
+            swap_details={},
+            suggested_frames={},
+            suggestion_mode=False,
+            manual_trim_starts=manual_trim_starts,
+            vspreview_manual_offsets=dict(vspreview_reuse),
+        )
+        return summary, display_data
+
     try:
         base_start = float(audio_cfg.start_seconds or 0.0)
         base_duration_param: Optional[float]
@@ -2271,7 +2352,7 @@ def _maybe_apply_audio_alignment(
             base_duration_param = float(audio_cfg.duration_seconds)
         hop_length = max(1, min(audio_cfg.hop_length, max(1, audio_cfg.sample_rate // 100)))
 
-        measurements: List[audio_alignment.AlignmentMeasurement]
+        measurements: List["AlignmentMeasurement"]
         negative_offsets: Dict[str, bool] = {}
 
         progress_columns: tuple[ProgressColumn, ...] = (
@@ -2371,7 +2452,7 @@ def _maybe_apply_audio_alignment(
 
         negative_override_notes: Dict[str, str] = {}
         swap_details: Dict[str, str] = {}
-        swap_candidates: List[audio_alignment.AlignmentMeasurement] = []
+        swap_candidates: List["AlignmentMeasurement"] = []
         swap_enabled = len(targets) == 1
 
         for measurement in measurements:
@@ -2387,7 +2468,7 @@ def _maybe_apply_audio_alignment(
                 )
 
         if swap_enabled and swap_candidates:
-            additional_measurements: List[audio_alignment.AlignmentMeasurement] = []
+            additional_measurements: List["AlignmentMeasurement"] = []
             reference_name: str = reference_plan.path.name
             existing_keys = {m.file.name for m in measurements}
 
@@ -2827,9 +2908,185 @@ print("Edit OFFSET_MAP values and press Ctrl+R in VSPreview to reload the script
     return script_path
 
 
+def _prompt_vspreview_offsets(
+    plans: Sequence[_ClipPlan],
+    summary: _AudioAlignmentSummary,
+    reporter: CliOutputManager,
+    display: _AudioAlignmentDisplayData | None,
+) -> dict[str, int] | None:
+    reference_plan = summary.reference_plan
+    targets = [plan for plan in plans if plan is not reference_plan]
+    if not targets:
+        return {}
+
+    baseline_map: Dict[str, int] = {
+        plan.path.name: summary.manual_trim_starts.get(plan.path.name, int(plan.trim_start))
+        for plan in plans
+    }
+
+    reference_label = _plan_label(reference_plan)
+    reporter.line(
+        "Enter VSPreview frame offsets relative to the reported baselines. Positive trims the target; negative advances the reference."
+    )
+    offsets: Dict[str, int] = {}
+    for plan in targets:
+        label = _plan_label(plan)
+        baseline_value = baseline_map.get(plan.path.name, int(plan.trim_start))
+        suggested = summary.suggested_frames.get(plan.path.name)
+        prompt_parts = [
+            f"VSPreview offset for {label} relative to {reference_label}",
+            f"baseline {baseline_value}f",
+        ]
+        if suggested is not None:
+            prompt_parts.append(f"suggested {suggested:+d}f")
+        prompt_message = " (".join([prompt_parts[0], ", ".join(prompt_parts[1:])]) + ")"
+        try:
+            delta = int(
+                click.prompt(
+                    prompt_message,
+                    type=int,
+                    default=0,
+                    show_default=True,
+                )
+            )
+        except click.exceptions.ClickException as exc:
+            if exc.__class__.__name__ == "Abort":
+                reporter.warn("VSPreview offset entry aborted; keeping existing trims.")
+                return None
+            raise
+        offsets[plan.path.name] = delta
+        if display is not None:
+            display.manual_trim_lines.append(
+                f"Baseline for {label}: {baseline_value}f"
+            )
+    return offsets
+
+
+def _apply_vspreview_manual_offsets(
+    plans: Sequence[_ClipPlan],
+    summary: _AudioAlignmentSummary,
+    deltas: Mapping[str, int],
+    reporter: CliOutputManager,
+    json_tail: JsonTail,
+    display: _AudioAlignmentDisplayData | None,
+) -> None:
+    reference_plan = summary.reference_plan
+    reference_name = reference_plan.path.name
+    targets = [plan for plan in plans if plan is not reference_plan]
+
+    baseline_map: Dict[str, int] = {
+        plan.path.name: summary.manual_trim_starts.get(plan.path.name, int(plan.trim_start))
+        for plan in plans
+    }
+    if reference_name not in baseline_map:
+        baseline_map[reference_name] = int(reference_plan.trim_start)
+
+    manual_trim_starts: Dict[str, int] = dict(baseline_map)
+    delta_map: Dict[str, int] = {}
+    manual_lines: List[str] = []
+    reference_deficit = 0
+
+    for plan in targets:
+        key = plan.path.name
+        baseline_value = baseline_map.get(key, int(plan.trim_start))
+        delta_value = int(deltas.get(key, 0))
+        delta_map[key] = delta_value
+        updated = baseline_value + delta_value
+        if updated < 0:
+            reference_deficit = max(reference_deficit, abs(updated))
+            updated = 0
+        plan.trim_start = int(updated)
+        plan.has_trim_start_override = plan.has_trim_start_override or updated != 0
+        manual_trim_starts[key] = int(updated)
+        line = (
+            f"VSPreview manual offset applied: {_plan_label(plan)} baseline {baseline_value}f "
+            f"{delta_value:+d}f → {int(updated)}f"
+        )
+        manual_lines.append(line)
+        reporter.line(line)
+
+    reference_baseline = baseline_map.get(reference_name, int(reference_plan.trim_start))
+    adjusted_reference = reference_baseline - reference_deficit
+    reference_plan.trim_start = int(adjusted_reference)
+    reference_plan.has_trim_start_override = (
+        reference_plan.has_trim_start_override or adjusted_reference != reference_baseline
+    )
+    manual_trim_starts[reference_name] = int(adjusted_reference)
+    reference_delta = int(adjusted_reference - reference_baseline)
+    delta_map[reference_name] = reference_delta
+    if reference_delta != 0:
+        ref_line = (
+            f"VSPreview reference adjustment: {_plan_label(reference_plan)} baseline {reference_baseline}f → {int(adjusted_reference)}f"
+        )
+        manual_lines.append(ref_line)
+        reporter.line(ref_line)
+
+    if display is not None:
+        if display.manual_trim_lines is None:
+            display.manual_trim_lines = []
+        display.manual_trim_lines.extend(manual_lines)
+        display.offset_lines = ["Audio offsets: VSPreview manual offsets applied"]
+        display.offset_lines.extend(display.manual_trim_lines)
+
+    fps_lookup: Dict[str, Tuple[int, int] | None] = {}
+    for plan in plans:
+        fps_lookup[plan.path.name] = (
+            plan.effective_fps or plan.source_fps or plan.fps_override
+        )
+
+    measurements: List["AlignmentMeasurement"] = []
+    existing_override_map: Dict[str, Dict[str, object]] = {}
+    notes_map: Dict[str, str] = {}
+    for plan in plans:
+        key = plan.path.name
+        frames_value = int(manual_trim_starts.get(key, int(plan.trim_start)))
+        fps_tuple = fps_lookup.get(key)
+        fps_float = _fps_to_float(fps_tuple) if fps_tuple else 0.0
+        seconds_value = float(frames_value) / fps_float if fps_float else 0.0
+        measurements.append(
+            audio_alignment.AlignmentMeasurement(
+                file=plan.path,
+                offset_seconds=seconds_value,
+                frames=frames_value,
+                correlation=1.0,
+                reference_fps=fps_float or None,
+                target_fps=fps_float or None,
+            )
+        )
+        existing_override_map[key] = {"frames": frames_value, "status": "manual"}
+        notes_map[key] = "VSPreview"
+
+    applied_frames, statuses = audio_alignment.update_offsets_file(
+        summary.offsets_path,
+        reference_plan.path.name,
+        tuple(measurements),
+        existing_override_map,
+        notes_map,
+    )
+
+    summary.applied_frames = dict(applied_frames)
+    summary.statuses = dict(statuses)
+    summary.final_adjustments = dict(manual_trim_starts)
+    summary.manual_trim_starts = dict(manual_trim_starts)
+    summary.suggestion_mode = False
+    summary.vspreview_manual_offsets = dict(manual_trim_starts)
+    summary.vspreview_manual_deltas = dict(delta_map)
+    summary.measurements = tuple(measurements)
+
+    audio_block = json_tail.setdefault("audio_alignment", {})
+    audio_block["suggestion_mode"] = False
+    audio_block["manual_trim_starts"] = dict(manual_trim_starts)
+    audio_block["vspreview_manual_offsets"] = dict(manual_trim_starts)
+    audio_block["vspreview_manual_deltas"] = dict(delta_map)
+    audio_block["vspreview_reference_trim"] = int(
+        manual_trim_starts.get(reference_name, int(reference_plan.trim_start))
+    )
+
+    reporter.line("VSPreview offsets saved to offsets file with manual status.")
 def _launch_vspreview(
     plans: Sequence[_ClipPlan],
     summary: _AudioAlignmentSummary | None,
+    display: _AudioAlignmentDisplayData | None,
     cfg: AppConfig,
     root: Path,
     reporter: CliOutputManager,
@@ -2892,6 +3149,12 @@ def _launch_vspreview(
     audio_block["vspreview_exit_code"] = int(result.returncode)
     if result.returncode != 0:
         reporter.warn(f"VSPreview exited with code {result.returncode}. Review the console output for details.")
+        return
+
+    offsets = _prompt_vspreview_offsets(plans, summary, reporter, display)
+    if offsets is None:
+        return
+    _apply_vspreview_manual_offsets(plans, summary, offsets, reporter, json_tail, display)
 
 def _pick_preview_frames(clip: object, count: int, seed: int) -> List[int]:
     """
@@ -3231,6 +3494,9 @@ def run_cli(
             "vspreview_script": None,
             "vspreview_invoked": False,
             "vspreview_exit_code": None,
+            "vspreview_manual_offsets": {},
+            "vspreview_manual_deltas": {},
+            "vspreview_reference_trim": None,
         },
         "analysis": {},
         "render": {},
@@ -3587,13 +3853,29 @@ def run_cli(
         audio_track_override_map,
         reporter=reporter,
     )
-    if cfg.audio_alignment.use_vspreview:
+    if (
+        cfg.audio_alignment.use_vspreview
+        and alignment_summary is not None
+        and alignment_summary.suggestion_mode
+    ):
         try:
-            _launch_vspreview(plans, alignment_summary, cfg, root, reporter, json_tail)
+            _launch_vspreview(
+                plans,
+                alignment_summary,
+                alignment_display,
+                cfg,
+                root,
+                reporter,
+                json_tail,
+            )
         except CLIAppError:
             raise
         except Exception as exc:
-            logger.warning("VSPreview launch failed: %s", exc, exc_info=logger.isEnabledFor(logging.DEBUG))
+            logger.warning(
+                "VSPreview launch failed: %s",
+                exc,
+                exc_info=logger.isEnabledFor(logging.DEBUG),
+            )
             reporter.warn(f"VSPreview launch failed: {exc}")
 
     if (
@@ -3648,6 +3930,27 @@ def run_cli(
     json_tail["audio_alignment"]["manual_trim_starts"] = (
         dict(alignment_summary.manual_trim_starts) if alignment_summary is not None else {}
     )
+    json_tail["audio_alignment"]["vspreview_manual_offsets"] = (
+        dict(alignment_summary.vspreview_manual_offsets)
+        if alignment_summary is not None
+        else {}
+    )
+    json_tail["audio_alignment"]["vspreview_manual_deltas"] = (
+        dict(alignment_summary.vspreview_manual_deltas)
+        if alignment_summary is not None
+        else {}
+    )
+    if (
+        alignment_summary is not None
+        and alignment_summary.vspreview_manual_offsets
+        and alignment_summary.reference_plan.path.name
+        in alignment_summary.vspreview_manual_offsets
+    ):
+        json_tail["audio_alignment"]["vspreview_reference_trim"] = int(
+            alignment_summary.vspreview_manual_offsets[
+                alignment_summary.reference_plan.path.name
+            ]
+        )
 
     try:
         _init_clips(plans, cfg.runtime, root)

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2952,11 +2952,9 @@ def _prompt_vspreview_offsets(
                     show_default=True,
                 )
             )
-        except click.exceptions.ClickException as exc:
-            if exc.__class__.__name__ == "Abort":
-                reporter.warn("VSPreview offset entry aborted; keeping existing trims.")
-                return None
-            raise
+        except click.Abort:
+            reporter.warn("VSPreview offset entry aborted; keeping existing trims.")
+            return None
         offsets[plan.path.name] = delta
         if display is not None:
             display.manual_trim_lines.append(

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -330,8 +330,8 @@ def test_launch_vspreview_generates_script(
     assert recorded_command, "VSPreview command should be invoked when interactive"
     assert recorded_command[0][0] == frame_compare.sys.executable
     assert recorded_command[0][-1] == str(script_path)
-    assert audio_block["vspreview_invoked"] is True
-    assert audio_block["vspreview_exit_code"] == 0
+    assert audio_block.get("vspreview_invoked") is True
+    assert audio_block.get("vspreview_exit_code") == 0
     assert prompt_calls, "Prompt should be invoked even when returning default offsets"
     assert apply_calls == [{}]
 
@@ -488,9 +488,12 @@ def test_vspreview_manual_offsets_positive(
     deltas_map = cast(dict[str, int], audio_block.get("vspreview_manual_deltas", {}))
     assert offsets_map[target_path.name] == 12
     assert deltas_map[target_path.name] == 7
-    assert captured["notes"][target_path.name] == "VSPreview"
-    assert captured["existing"][target_path.name]["status"] == "manual"
-    assert int(captured["existing"][target_path.name]["frames"]) == 12
+    notes_map = cast(dict[str, str], captured["notes"])
+    existing_map = cast(dict[str, Mapping[str, object]], captured["existing"])
+    assert notes_map[target_path.name] == "VSPreview"
+    entry = cast(dict[str, object], existing_map[target_path.name])
+    assert entry.get("status") == "manual"
+    assert int(cast(int | float, entry.get("frames", 0))) == 12
     assert any("VSPreview manual offset applied" in line for line in reporter.lines)
 
 

--- a/tests/test_paths_preflight.py
+++ b/tests/test_paths_preflight.py
@@ -13,10 +13,15 @@ def _block_mkdir(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
     blocked_resolved = target.resolve()
     original_mkdir = Path.mkdir
 
-    def fake(self: Path, *args: object, **kwargs: object) -> None:
+    def fake(
+        self: Path,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
         if Path(self).resolve() == blocked_resolved:
             raise PermissionError("Permission denied")
-        return original_mkdir(self, *args, **kwargs)
+        return original_mkdir(self, mode=mode, parents=parents, exist_ok=exist_ok)
 
     monkeypatch.setattr(Path, "mkdir", fake)
 

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -7,6 +7,7 @@ import pytest
 
 from src.datatypes import ColorConfig, ScreenshotConfig
 from src import screenshot, vs_core
+from src.screenshot import GeometryPlan
 
 
 class _CapturedWriterCall(TypedDict):
@@ -258,7 +259,7 @@ def _make_plan(
     scaled: tuple[int, int] = (1920, 1080),
     pad: tuple[int, int, int, int] = (0, 0, 0, 0),
     final: tuple[int, int] = (1920, 1080),
-) -> screenshot.GeometryPlan:
+) -> GeometryPlan:
     """
     Builds a rendering plan dictionary describing dimensions, crop, scaling, padding, and final output size.
     
@@ -273,16 +274,19 @@ def _make_plan(
             - "pad": 4-tuple (left, top, right, bottom) of pixels added as padding.
             - "final": 2-tuple (width, height) of the final output frame.
     """
-    plan: screenshot.GeometryPlan = {
-        "width": width,
-        "height": height,
-        "crop": crop,
-        "cropped_w": cropped_w,
-        "cropped_h": cropped_h,
-        "scaled": scaled,
-        "pad": pad,
-        "final": final,
-    }
+    plan = cast(
+        GeometryPlan,
+        {
+            "width": width,
+            "height": height,
+            "crop": crop,
+            "cropped_w": cropped_w,
+            "cropped_h": cropped_h,
+            "scaled": scaled,
+            "pad": pad,
+            "final": final,
+        },
+    )
     return plan
 
 

--- a/typings/httpx/__init__.py
+++ b/typings/httpx/__init__.py
@@ -127,7 +127,7 @@ class AsyncClient:
     ) -> None:
         self.args = args
         self.kwargs = kwargs
-        self.transport = transport or MockTransport(lambda _: Response())
+        self.transport = transport or MockTransport(lambda request: Response())
 
     async def get(
         self,

--- a/typings/rich/console.py
+++ b/typings/rich/console.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 try:
     from rich.console import Console as _RichConsole
@@ -40,8 +40,8 @@ class Console:
             console = _RichConsole(width=self.width, height=self.height)
         if console is None:
             return
-        console.width = self.width
-        console.height = self.height
+        cast(Any, console).width = self.width
+        cast(Any, console).height = self.height
         console.rule(
             title,
             characters=characters,


### PR DESCRIPTION
## Summary
- reuse persisted VSPreview manual offsets when the CLI re-runs and populate alignment displays
- add prompt/commit helpers to capture VSPreview deltas, update clip plans, and record manual offsets in the JSON tail
- extend frame compare tests with VSPreview stubs and coverage for positive, zero, and negative manual offsets

## Testing
- pytest tests/test_frame_compare.py -k vspreview

------
https://chatgpt.com/codex/tasks/task_e_68f447501b988321a82d82dabd9316d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive VSPreview integrated into the main flow for manual offset adjustments.
  * VSPreview state (manual offsets, deltas, reference trim, suggestion mode, scripts, invocation/exit info) now persists across runs and appears in run outputs and displays.
  * Run/display synchronization ensures manual VSPreview decisions update trims and reporting.

* **Tests**
  * Expanded tests for VSPreview manual-offset workflows (positive/zero/negative, multi-target) with new stubs/fixtures and persistence simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->