### PR TITLE
Document VSPreview manual alignment workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-28:* Fixed VapourSynth RGB conversion when colour metadata is absent by defaulting to Rec.709
+  limited parameters, preventing fpng "no path between colours" failures and adding regression coverage.
 - *2025-10-27:* Documented the VSPreview-assisted manual alignment flow (README, reference tables, pipeline guide), surfaced the
   CLI help text, added a fallback regression test, and published a cross-platform QA checklist for manual verification.
 - *2025-10-26:* Hardened analysis cache and audio offsets paths to stay within the workspace root, added regression tests for escape attempts, removed the generated `config.toml` from source control in favour of the packaged template, and restricted screenshot cleanup to directories created during the current run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-27:* Documented the VSPreview-assisted manual alignment flow (README, reference tables, pipeline guide), surfaced the
+  CLI help text, added a fallback regression test, and published a cross-platform QA checklist for manual verification.
 - *2025-10-26:* Hardened analysis cache and audio offsets paths to stay within the workspace root, added regression tests for escape attempts, removed the generated `config.toml` from source control in favour of the packaged template, and restricted screenshot cleanup to directories created during the current run.
 - *2025-10-26:* Limited supported Python versions to 3.13.x (`>=3.13,<3.14`) to align with current `librosa`/`numba` wheels; updated project metadata and lockfile.
 - *2025-10-24:* Locked workspace roots to `--root`/`FRAME_COMPARE_ROOT`/sentinel discovery, seeded config under `ROOT/config/config.toml`, enforced `ROOT/comparison_videos[/screens]`, added `--diagnose-paths`, and blocked site-packages writes before screenshotting.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ slow.pics shortcut file.
 
 Screenshot renders are written beneath the resolved input directory (for example `ROOT/comparison_videos/screens`). Make sure that directory exists and is writable before running the CLI—if you installed the project somewhere read-only, set `--root`/`FRAME_COMPARE_ROOT` to a directory you control so Frame Compare can create the subdirectories it needs.
 
+### Manual alignment assist (VSPreview)
+
+Need to confirm or override the offsets that audio correlation suggests? Enable the optional VSPreview hook in your config and run the CLI interactively:
+
+```toml
+[audio_alignment]
+enable = true               # optional, VSPreview can run without auto measurements
+use_vspreview = true        # surface the prompt and launch VSPreview after alignment
+confirm_with_screenshots = false  # keep the run moving; VSPreview handles the pause
+```
+
+```bash
+uv run python frame_compare.py
+```
+
+When VSPreview is available on `PATH` (or importable via `python -m vspreview`) the CLI will generate a temporary script under the workspace, launch the preview, and summarise any existing manual trims before prompting for a delta. In headless or non-interactive sessions the script path is still printed so you can open it manually later.
+
 ## Configuration essentials
 
 Frame Compare looks for its configuration at ``ROOT/config/config.toml``, where

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-27:* Finalised the VSPreview-assisted manual alignment UX, documenting the new flag in README/REFERENCE, expanding the audio-alignment guide with prerequisites and fallback behaviour, surfacing the hook in CLI help, and extending automated + manual QA coverage for the headless fallback path.
 - *2025-10-26:* Enforced workspace containment for analysis cache and audio offset files via `_resolve_workspace_subdir`, added regression coverage for escape attempts, removed the generated `config.toml` (template remains the source of defaults), and limited automatic screenshot cleanup to directories created during the active run.
 - *2025-10-26:* Constrained supported Python versions to 3.13.x (`>=3.13,<3.14`) because `librosa`/`numba` fail to build on 3.14; updated pyproject/lock files accordingly.
 - *2025-10-24:* Locked workspace root discovery to `--root`/`FRAME_COMPARE_ROOT`/sentinel hierarchy, seeded config under `ROOT/config/config.toml`, enforced `ROOT/comparison_videos[/screens]` outputs, and added diagnostics + site-packages guardrails.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-28:* When screenshot rendering receives VapourSynth clips without matrix/transfer metadata we now probe frame props and default to Rec.709 limited values so `resize.Point` can emit RGB24 without raising "no path between colours"; regression tests cover the fallback and metadata-preservation paths.
 - *2025-10-27:* Finalised the VSPreview-assisted manual alignment UX, documenting the new flag in README/REFERENCE, expanding the audio-alignment guide with prerequisites and fallback behaviour, surfacing the hook in CLI help, and extending automated + manual QA coverage for the headless fallback path.
 - *2025-10-26:* Enforced workspace containment for analysis cache and audio offset files via `_resolve_workspace_subdir`, added regression coverage for escape attempts, removed the generated `config.toml` (template remains the source of defaults), and limited automatic screenshot cleanup to directories created during the active run.
 - *2025-10-26:* Constrained supported Python versions to 3.13.x (`>=3.13,<3.14`) because `librosa`/`numba` fail to build on 3.14; updated pyproject/lock files accordingly.

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -28,7 +28,7 @@ quick-start configuration paths.
 | Key | Purpose | Type | Default |
 | --- | --- | --- | --- |
 | `[audio_alignment].enable` | Toggle automatic offset detection. | bool | `false` |
-| `[audio_alignment].use_vspreview` | Surface offsets as suggestions and transition to VSPreview manual alignment flow. | bool | `false` |
+| `[audio_alignment].use_vspreview` | Surface offsets as suggestions, launch VSPreview for manual trims, and record the accepted delta (skips launch when non-interactive or VSPreview is missing). | bool | `false` |
 | `[audio_alignment].sample_rate` | Audio extraction rate. | int | `16000` |
 | `[audio_alignment].hop_length` | Onset envelope hop length. | int | `512` |
 | `[audio_alignment].correlation_threshold` | Minimum accepted score. | float | `0.55` |

--- a/docs/context_summary.md
+++ b/docs/context_summary.md
@@ -1,0 +1,30 @@
+# Context Summary — Frame Compare
+
+## Documentation Sources Reviewed
+- Project guardrails and workflow expectations from `CODEX.md`.
+- Repository usage overview from `README.md` and detailed configuration tables in `docs/README_REFERENCE.md`.
+- Pipeline and component notes within `docs/` (including audio alignment, HDR tonemap, and VSPreview guidance).
+
+## Architecture & Structure Highlights
+- Python 3.13 project packaged via `pyproject.toml` with CLI entry point `frame_compare.py`.
+- Source modules located in `src/`, covering analysis, audio alignment, configuration, screenshot generation, slow.pics uploads, TMDB metadata, and VapourSynth helpers.
+- Tests under `tests/` mirror module coverage with pytest fixtures and integration exercises.
+- Typed helpers and vendored stubs reside in `typings/`.
+
+## Key Dependencies & Integrations
+- Core libraries: Rich for CLI rendering, Click for argument parsing, HTTPX/requests for API calls, NumPy/librosa/soundfile for audio analysis.
+- Optional VapourSynth dependency handled via extra `vapoursynth` group; FFmpeg integration for fallback renders.
+- External services: slow.pics uploads via `src/slowpics.py`, TMDB lookups managed by `src/tmdb.py` with caching and parsing helpers.
+
+## Configuration & Workflow
+- Configuration is loaded from TOML using `src/config_loader.py` with dataclass models in `src/datatypes.py`; defaults seeded from `src/data/config.toml.template`.
+- CLI layout rendering defined in `src/cli_layout.py` with formatting tests ensuring stable output.
+- Guardrails emphasise diff-plan approvals, Pyright standard typing, and documentation of decisions in `docs/DECISIONS.md`.
+
+## Testing & Quality
+- Pytest suite spans CLI behaviour (`test_cli_layout_render.py`), analysis computations, audio alignment, screenshot generation, TMDB integrations, and config loading.
+- Linting/formatting enforced via Ruff and Black settings in `pyproject.toml`; Pyright configured by `pyrightconfig.json`.
+
+## Outstanding Notes
+- MCP-based best practice refresh is pending; environment lacks direct MCP tooling, so external validation remains a follow-up action.
+- Future tasks should respect standard flow: evidence sweep, doc check, plan, diffs, persistence, verification.

--- a/docs/tests_plan_vspreview_manual_alignment.md
+++ b/docs/tests_plan_vspreview_manual_alignment.md
@@ -1,0 +1,24 @@
+# Test Plan — VSPreview Manual Alignment (Phase 4)
+
+## Manual QA matrix
+- **macOS (arm64/x86_64)**
+  1. Enable `[audio_alignment].use_vspreview = true`, run interactively with VSPreview installed on `PATH`, confirm prompt summarises auto suggestion and existing manual trims, accept delta, rerun to verify reuse.
+  2. Repeat with an existing negative `trim_start` override to ensure reference padding and persisted offsets reflect `status = "manual"` with `note = "VSPreview"`.
+  3. Launch from a non-interactive shell (`printf '' | frame-compare …`) to confirm the launch is skipped, warning printed, and script path recorded for manual follow-up.
+- **Linux (x86_64)**
+  1. Run with large auto-alignment suggestion (>200 frames) to confirm the recommended offset is surfaced before VSPreview launches and that entering a smaller manual delta updates the JSON tail.
+  2. Temporarily move/rename the `vspreview` executable so discovery fails; verify the CLI records the fallback warning and leaves trims untouched while still writing the script path.
+  3. Confirm persisted VSPreview offsets skip repeated prompts on subsequent runs until the offsets file is edited.
+- **Windows (x86_64)**
+  1. Invoke via `python -m frame_compare` with `vspreview.exe` available; ensure the generated script opens in VSPreview and Ctrl+R reloads after editing `OFFSET_MAP`.
+  2. Run inside PowerShell without a GUI session (for example, over SSH) to validate the non-interactive warning and fallback behaviour without errors.
+  3. With pre-existing manual trims per target clip, ensure additional deltas accumulate correctly and the offsets TOML retains the previous baseline + delta.
+
+## Automation hooks
+- Unit tests: `_launch_vspreview` happy-path invocation (`tests/test_frame_compare.py::test_launch_vspreview_generates_script`).
+- Regression coverage: fallback branch without VSPreview command (`tests/test_frame_compare.py::test_launch_vspreview_warns_when_command_missing`).
+- JSON tail snapshots: assertions verify `vspreview_*` fields populate once manual offsets are accepted.
+
+## Follow-ups
+- Consider a future stub package for VSPreview if we begin importing runtime helpers directly.
+- Track user feedback on script ergonomics (e.g., exposing hotkeys in CLI output or template comments) for potential Phase 5 polish.

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2952,7 +2952,7 @@ def _prompt_vspreview_offsets(
                     show_default=True,
                 )
             )
-        except click.Abort:
+        except click.exceptions.Abort:
             reporter.warn("VSPreview offset entry aborted; keeping existing trims.")
             return None
         offsets[plan.path.name] = delta
@@ -4989,7 +4989,10 @@ def main(
 ) -> None:
     """
     Run the CLI pipeline and handle post-run outputs such as slow.pics handling and JSON tail emission.
-    
+
+    Includes optional VSPreview-assisted manual alignment when `[audio_alignment].use_vspreview` is enabled and the session is
+    interactive.
+
     Runs run_cli with the provided options, handles CLIAppError by printing the rich message and exiting with the error code, processes slow.pics results (open in browser, copy to clipboard, create shortcut file, and optionally delete the screenshots directory), and finally emits the collected JSON tail to stdout (optionally pretty-printed).
     
     Parameters:

--- a/src/vs_core.py
+++ b/src/vs_core.py
@@ -652,23 +652,30 @@ def _coerce_prop(value: Any, mapping: Mapping[str, int] | None = None) -> Option
     return None
 
 
+def _first_present(props: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in props:
+            return props[key]
+    return None
+
+
 def _resolve_color_metadata(
     props: Mapping[str, Any],
 ) -> tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
     matrix = _coerce_prop(
-        props.get("_Matrix") or props.get("Matrix"),
+        _first_present(props, "_Matrix", "Matrix"),
         _MATRIX_NAME_TO_CODE,
     )
     primaries = _coerce_prop(
-        props.get("_Primaries") or props.get("Primaries"),
+        _first_present(props, "_Primaries", "Primaries"),
         _PRIMARIES_NAME_TO_CODE,
     )
     transfer = _coerce_prop(
-        props.get("_Transfer") or props.get("Transfer"),
+        _first_present(props, "_Transfer", "Transfer"),
         _TRANSFER_NAME_TO_CODE,
     )
     color_range = _coerce_prop(
-        props.get("_ColorRange") or props.get("ColorRange"),
+        _first_present(props, "_ColorRange", "ColorRange"),
         _RANGE_NAME_TO_CODE,
     )
     return matrix, transfer, primaries, color_range

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -392,7 +392,7 @@ def test_launch_vspreview_warns_when_command_missing(
 
     monkeypatch.setattr(frame_compare.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(frame_compare.shutil, "which", lambda _: None)
-    monkeypatch.setattr(frame_compare.importlib.util, "find_spec", lambda name: None)
+    monkeypatch.setattr(frame_compare.importlib.util, "find_spec", lambda _name: None)
 
     prompt_called: list[None] = []
 


### PR DESCRIPTION
## Summary
- document the VSPreview-assisted manual alignment flow across README, reference tables, and the audio alignment pipeline guide
- update CLI help, changelog, and decisions log to surface the new hook and guardrails
- add a regression test and manual QA checklist covering VSPreview fallback behaviour

## Testing
- uv run pyright
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f46043a1188321969c87ea25ee4f6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VSPreview-assisted manual alignment workflow with interactive offset confirmation and screenshot support; CLI help surfaced.

* **Documentation**
  * New and expanded guides: manual alignment workflow, configuration examples, QA checklist, reference notes, context summary, and test plan.

* **Bug Fixes**
  * RGB conversion now defaults to Rec.709 limited when color metadata is absent to avoid conversion failures.

* **Tests**
  * Added regression and unit tests covering VSPreview fallback and RGB conversion behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->