### PR TITLE
Document VSPreview audio alignment option in template

### DIFF
--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -41,6 +41,7 @@ offsets_filename = "generated.audio_offsets.toml"
 confirm_with_screenshots = true
 random_seed = 2025
 frame_offset_bias = 1        # Frames to move toward zero (negative values push further away)
+use_vspreview = false        # surface the prompt and launch VSPreview after alignment
 
 [screenshots]
 # Output planning and rendering behaviour for both VapourSynth and FFmpeg writers.


### PR DESCRIPTION
## Summary
- add the `[audio_alignment].use_vspreview` toggle to the default config template so freshly seeded configs advertise the manual alignment flow

## Testing
- pytest tests/test_config.py tests/test_paths_preflight.py::test_copy_default_config_matches_template *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_e_68f4823b4f3c8321987b2a8fa179c690