### PR TITLE
Handle optional audio dependency import failures

### DIFF
--- a/src/audio_alignment.py
+++ b/src/audio_alignment.py
@@ -112,10 +112,13 @@ def _load_optional_modules() -> Tuple[Any, Any, Any]:
             import librosa  # type: ignore
             import numpy as np  # type: ignore
             import soundfile as sf  # type: ignore
-    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
-        raise AudioAlignmentError(
+    except Exception as exc:  # pragma: no cover - optional dependency
+        message = (
             "Audio alignment requires optional dependencies: numpy, librosa, soundfile."
-        ) from exc
+            if isinstance(exc, ModuleNotFoundError)
+            else f"Audio alignment failed to load optional dependencies: {exc}"
+        )
+        raise AudioAlignmentError(message) from exc
     return np, librosa, sf
 
 


### PR DESCRIPTION
## Summary
- wrap optional dependency import failures in `AudioAlignmentError` while retaining the underlying exception message
- add a regression test that forces a runtime import failure to ensure `measure_offsets` surfaces dependency issues cleanly

## Testing
- pytest tests/test_audio_alignment.py::test_onset_envelope_suppresses_dependency_warning tests/test_audio_alignment.py::test_measure_offsets_wraps_optional_dependency_errors

------
https://chatgpt.com/codex/tasks/task_e_68f483a67dd88321b3b5e26c6aaa6543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced exception handling during audio processing module initialization with improved error messaging to distinguish between missing dependencies and other loading failures.

* **Tests**
  * Added test coverage for audio processing error scenarios and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->