### PR TITLE
Handle optional dependency failures during onset envelope calculation

### DIFF
--- a/src/audio_alignment.py
+++ b/src/audio_alignment.py
@@ -249,25 +249,35 @@ def _onset_envelope(
 ) -> Tuple[Any, int]:
     np, librosa, sf = _load_optional_modules()
 
-    with _suppress_flush_to_zero_warning():
-        data, native_sr = sf.read(str(wav_path))
-        if data.size == 0:
-            raise AudioAlignmentError(f"No audio samples extracted from {wav_path}")
-        if data.ndim > 1:
-            data = np.mean(data, axis=1)
-        if native_sr != sample_rate:
-            data = librosa.resample(data, orig_sr=native_sr, target_sr=sample_rate)
+    try:
+        with _suppress_flush_to_zero_warning():
+            data, native_sr = sf.read(str(wav_path))
+            if data.size == 0:
+                raise AudioAlignmentError(f"No audio samples extracted from {wav_path}")
+            if data.ndim > 1:
+                data = np.mean(data, axis=1)
+            if native_sr != sample_rate:
+                data = librosa.resample(data, orig_sr=native_sr, target_sr=sample_rate)
 
-        peak = float(np.max(np.abs(data))) if data.size else 0.0
-        if peak > 0:
-            data = data / peak
+            peak = float(np.max(np.abs(data))) if data.size else 0.0
+            if peak > 0:
+                data = data / peak
 
-        onset_env = librosa.onset.onset_strength(
-            y=data,
-            sr=sample_rate,
-            hop_length=hop_length,
-            center=True,
+            onset_env = librosa.onset.onset_strength(
+                y=data,
+                sr=sample_rate,
+                hop_length=hop_length,
+                center=True,
+            )
+    except AudioAlignmentError:
+        raise
+    except Exception as exc:  # pragma: no cover - optional dependency runtime
+        message = (
+            "Audio alignment failed during onset envelope calculation because an optional "
+            f"dependency raised an error: {exc}. Install numpy, librosa, and soundfile "
+            "(and their dependencies)."
         )
+        raise AudioAlignmentError(message) from exc
     return onset_env.astype(np.float32), hop_length
 
 


### PR DESCRIPTION
## Summary
- wrap onset envelope optional dependency calls in AudioAlignmentError conversion
- add a regression test covering onset strength runtime failures

## Testing
- pytest tests/test_audio_alignment.py::test_measure_offsets_wraps_optional_dependency_errors tests/test_audio_alignment.py::test_measure_offsets_wraps_onset_strength_failure

------
https://chatgpt.com/codex/tasks/task_e_68f4880314d08321938332b900f7544c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling for optional dependencies in audio alignment, providing clearer error messages when required packages are missing.

* **Tests**
  * Added test coverage for dependency error scenarios in audio alignment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->