### PR TITLE
Fix VSPreview manual alignment label lookup

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2063,13 +2063,13 @@ def _maybe_apply_audio_alignment(
                 for plan in plans
                 if plan.trim_start > 0
             }
-            labels = {plan: _plan_label(plan) for plan in plans}
+            labels = {plan.path: _plan_label(plan) for plan in plans}
             if manual_trim_starts:
                 for plan in plans:
                     trim = manual_trim_starts.get(plan.path.name)
                     if trim:
                         display_data.manual_trim_lines.append(
-                            f"Existing manual trim: {labels[plan]} → {trim}f"
+                            f"Existing manual trim: {labels[plan.path]} → {trim}f"
                         )
             display_data.offset_lines = ["Audio offsets: not computed (manual alignment only)"]
             display_data.offset_lines.extend(display_data.manual_trim_lines)


### PR DESCRIPTION
## Summary
- adjust the VSPreview manual-alignment path to key plan labels by clip paths instead of plan objects
- add a regression test covering manual VSPreview mode when audio alignment is disabled and trims are present

## Testing
- pytest tests/test_frame_compare.py::test_audio_alignment_manual_vspreview_handles_existing_trim


------
https://chatgpt.com/codex/tasks/task_e_68f48c8c86208321ba54f20c859ca831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of clip label retrieval for consistent and reliable display.

* **Tests**
  * Added test coverage for manual trim scenarios with VSPreview and disabled audio alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->