### PR TITLE
Update docs for recent audio alignment enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-10-30:* Hardened audio alignment's optional dependency handling by surfacing clear `AudioAlignmentError` messages when
+  `numpy`, `librosa`, or `soundfile` fail during onset envelope calculation, and refreshed regression coverage for the failure
+  path.
+- *2025-10-30:* VSPreview-assisted manual alignment now displays existing manual trims using friendly clip labels so operators
+  can immediately see which plan each baseline affects before accepting new deltas.
 - *2025-10-29:* Normalised VapourSynth colour metadata inference for SDR clips, cached inferred props on the
   clip to avoid redundant frame grabs, exposed config overrides for HD/SD defaults and per-file colour
   corrections, refreshed documentation, and expanded regression coverage for the new heuristics.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Requirements:
 - [`uv`](https://docs.astral.sh/uv/)
 - FFmpeg available on your `PATH`
 - VapourSynth ≥72 if you plan to use the primary renderer (install manually; see below)
+- Optional audio-alignment dependencies: `numpy`, `librosa`, and `soundfile` (install them when you plan to enable `[audio_alignment].enable`).
 
 Repository fixtures live under `comparison_videos/` beside
 `frame_compare.py`; they provide tiny MKV stubs suitable for smoke
@@ -104,6 +105,7 @@ uv run python frame_compare.py
 ```
 
 When VSPreview is available on `PATH` (or importable via `python -m vspreview`) the CLI will generate a temporary script under the workspace, launch the preview, and summarise any existing manual trims before prompting for a delta. In headless or non-interactive sessions the script path is still printed so you can open it manually later.
+Existing manual trims are reported using each clip's display label (the friendly slow.pics/TMDB label when available, otherwise the filename) so you can quickly see which trims are already in effect before accepting a new delta.
 
 ## Configuration essentials
 

--- a/docs/audio_alignment_pipeline.md
+++ b/docs/audio_alignment_pipeline.md
@@ -8,7 +8,7 @@ Frame Compare can estimate per-clip trim offsets before video analysis by correl
 * `ffmpeg` and `ffprobe` must be on `PATH`; alignment aborts early if either executable is missing. 【F:src/audio_alignment.py†L66-L118】
 
 ### Python extras
-* The optional stack `numpy`, `librosa`, and `soundfile` is required; the module raises an `AudioAlignmentError` if any import fails. 【F:src/audio_alignment.py†L76-L92】
+* The optional stack `numpy`, `librosa`, and `soundfile` is required; the module raises an `AudioAlignmentError` when an import fails or when an optional dependency errors during onset envelope calculation. 【F:src/audio_alignment.py†L76-L92】【F:src/audio_alignment.py†L240-L277】
 
 ### Configuration guard rails
 * Validation rejects non-positive sample rates, hop lengths, max offsets, or negative seeds, and constrains correlation thresholds to `[0,1]`. 【F:src/config_loader.py†L190-L214】【F:src/config_loader.py†L233-L270】
@@ -32,7 +32,7 @@ Key options live under `[audio_alignment]` in `config.toml`. Defaults and intent
 | `frame_offset_bias` | Integer bias nudging suggested frame counts toward/away from zero. | `1` |
 
 ## Workflow
-1. **Reference & target selection** – `_resolve_alignment_reference` honors the config hint, CLI-provided filename/index, or falls back to the first clip. Remaining clips become targets. 【F:frame_compare.py†L930-L999】
+1. **Reference & target selection** – `_resolve_alignment_reference` honors the config hint, CLI-provided filename/index, or falls back to the first clip. Remaining clips become targets. Existing manual trims are summarised using each plan's display label so operators can immediately see which clip the baseline applies to. 【F:frame_compare.py†L930-L999】【F:frame_compare.py†L2065-L2142】
 2. **Audio stream discovery** – `ffprobe` metadata identifies candidate streams. Forced CLI overrides (`--audio-align-track label=index`) take precedence, then the scoring heuristic prefers default language, channel count, and forced flags. 【F:frame_compare.py†L1005-L1096】【F:frame_compare.py†L2802-L2833】
 3. **Waveform extraction & onset envelopes** – `measure_offsets` extracts mono WAV snippets for the reference and each target using consistent sample-rate resampling, computes onset envelopes, and cross-correlates them to estimate lags. FPS probes translate seconds into frame counts when possible. 【F:src/audio_alignment.py†L291-L398】
 4. **Bias & negative offset handling** – `frame_offset_bias` nudges computed frame counts either toward zero (positive values) or away from zero (negative values). When only one target clip exists, negative offsets are applied to the reference clip instead, with explanatory notes recorded. 【F:frame_compare.py†L1205-L1304】

--- a/docs/tests_plan_vspreview_manual_alignment.md
+++ b/docs/tests_plan_vspreview_manual_alignment.md
@@ -2,7 +2,7 @@
 
 ## Manual QA matrix
 - **macOS (arm64/x86_64)**
-  1. Enable `[audio_alignment].use_vspreview = true`, run interactively with VSPreview installed on `PATH`, confirm prompt summarises auto suggestion and existing manual trims, accept delta, rerun to verify reuse.
+  1. Enable `[audio_alignment].use_vspreview = true`, run interactively with VSPreview installed on `PATH`, confirm prompt summarises auto suggestion and existing manual trims (display labels should match the friendly clip labels shown elsewhere), accept delta, rerun to verify reuse.
   2. Repeat with an existing negative `trim_start` override to ensure reference padding and persisted offsets reflect `status = "manual"` with `note = "VSPreview"`.
   3. Launch from a non-interactive shell (`printf '' | frame-compare …`) to confirm the launch is skipped, warning printed, and script path recorded for manual follow-up.
 - **Linux (x86_64)**


### PR DESCRIPTION
## Summary
- note the optional numpy/librosa/soundfile stack in the README requirements when enabling audio alignment
- expand the audio alignment pipeline and VSPreview docs to cover friendly clip labels and optional dependency failure handling
- document the changes in the changelog and manual QA checklist

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f53e5bf83c8321a07ff7eafe61d4f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VSPreview manual alignment now displays existing manual trims with friendly clip labels, making it easier to identify which baseline affects each plan before accepting changes.

* **Improvements**
  * Clearer error messages when audio alignment optional dependencies are unavailable.

* **Documentation**
  * Expanded audio alignment pipeline documentation with updated workflow steps, result vetting criteria, and VSPreview integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->