### PR TITLE
Enable odd-geometry promotion for SDR screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable user-visible updates will be documented in this file in reverse chro
 - *2025-10-30:* Hardened audio alignment's optional dependency handling by surfacing clear `AudioAlignmentError` messages when
   `numpy`, `librosa`, or `soundfile` fail during onset envelope calculation, and refreshed regression coverage for the failure
   path.
+- *2025-10-30:* Fixed odd-pixel crop/pad failures on subsampled SDR clips by conditionally promoting to `YUV444P16`, adding axis-aware `[screenshots].odd_geometry_policy` controls, exposing `[screenshots].rgb_dither`, logging pivots, falling back from FFmpeg when needed, and extending regression coverage for geometry planning and writer selection.
 - *2025-10-30:* VSPreview-assisted manual alignment now displays existing manual trims using friendly clip labels so operators
   can immediately see which plan each baseline affects before accepting new deltas.
 - *2025-10-29:* Normalised VapourSynth colour metadata inference for SDR clips, cached inferred props on the

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-10-30:* Enabled axis-aware odd-geometry handling for subsampled SDR captures by conditionally promoting to `YUV444P16` before geometry, adding `[screenshots].odd_geometry_policy` and `[screenshots].rgb_dither` controls, logging the axis when a pivot occurs, and falling back to the VapourSynth writer when FFmpeg would require the same promotion.
 - *2025-10-28:* When screenshot rendering receives VapourSynth clips without matrix/transfer metadata we now probe frame props and default to Rec.709 limited values so `resize.Point` can emit RGB24 without raising "no path between colours"; regression tests cover the fallback and metadata-preservation paths.
 - *2025-10-27:* Finalised the VSPreview-assisted manual alignment UX, documenting the new flag in README/REFERENCE, expanding the audio-alignment guide with prerequisites and fallback behaviour, surfacing the hook in CLI help, and extending automated + manual QA coverage for the headless fallback path.
 - *2025-10-26:* Enforced workspace containment for analysis cache and audio offset files via `_resolve_workspace_subdir`, added regression coverage for escape attempts, removed the generated `config.toml` (template remains the source of defaults), and limited automatic screenshot cleanup to directories created during the active run.

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -51,6 +51,8 @@ quick-start configuration paths.
 | `[screenshots].single_res` | Fixed output height (0 keeps source). | int | `0` |
 | `[screenshots].mod_crop` | Crop modulus. | int | `2` |
 | `[screenshots].auto_letterbox_crop` | Auto crop black bars. | bool | `false` |
+| `[screenshots].odd_geometry_policy` | Odd crop/pad policy for subsampled SDR (`auto`, `force_full_chroma`, `subsamp_safe`). | str | `"auto"` |
+| `[screenshots].rgb_dither` | Final RGB24 quantisation dither (`error_diffusion`, `ordered`, `none`). | str | `"error_diffusion"` |
 | `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be >= 0; set 0 to disable). | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |
 | `[color].preset` | Tonemapping preset. | str | `"reference"` |

--- a/docs/current_pipeline_trace.md
+++ b/docs/current_pipeline_trace.md
@@ -9,14 +9,14 @@ Scope: `frame_compare.py` + `src/screenshot.py` + `src/vs_core.py`.
 | 1 | `rgb16` | `vs_core.process_clip_for_screenshot` (`resize.Spline36`) | `RGB48` | 0 (forced) | From stage 0 | From stage 0 | 0 (forced full) | — | `_normalize_rgb_props` stamps RGB props so libplacebo can infer linearisation. |
 | 2 | `tonemapped` | `_tonemap_with_retries` | `RGB48`/`RGBS` | 0 | 1 (BT.1886) | 1 (BT.709) | 0 | `placebo:{curve},dpd={dpd},dst_max={nits}` | Retries hinted → inferred → PQ fallback, logging `[TM INPUT]` / `[TM APPLIED]` / failures. |
 | 3 | `tm_rgb24` | Verification path (`resize.Point`) | `RGB24` | 0 | 1 | 1 | 0 | Same as stage 2 | Used only for diff vs naive SDR, never written to disk. |
-| 4a | `render_clip` (VapourSynth writer) | `_save_frame_with_fpng` | `RGB24` | 0 | 1 | 1 | 0 | Preserved | Crop/resize, optional frame-info overlay, `_apply_overlay_text` (alignment=9). Diagnostic mode layers the base template plus render resolution, HDR mastering luminance when tonemapping ran, and cached `Frame Selection Type` metadata. `_ensure_rgb24` stamps BT.709/BT.1886 full-range props for downstream sanity. |
+| 4a | `render_clip` (VapourSynth writer) | `_save_frame_with_fpng` | `RGB24` (after optional `YUV444P16` pivot) | 0 | 1 | 1 | 0 | Preserved | Axis-aware odd-geometry detection may promote subsampled SDR clips to `YUV444P16` (no dither) before crop/resize/pad. Overlays land after geometry. `_ensure_rgb24` applies the configured RGB dither (`error_diffusion` default) solely on the final 16→8-bit hop and restamps BT.709/BT.1886 full-range props. |
 | 4b | FFmpeg render | `_save_frame_with_ffmpeg` | File stream | N/A | N/A | N/A | N/A | N/A | FFmpeg redoes crop/scale and injects top-right `drawtext` overlay; tonemapped pixels come from stage 2 clip via `result.clip` when available. |
 
 ## SDR bypass path
 - When `_props_signal_hdr` is false or `color.enable_tonemap=false`, the function returns the original clip (stage 0) untouched.
 - Overlay text still resolves (reason “SDR source” or “Tonemap disabled”) so every screenshot receives a stamp.
 - Verification is skipped, logging `[TM BYPASS] …` before returning.
-- `_save_frame_with_fpng` / FFmpeg perform the same geometry + overlay steps on the SDR clip, then `_ensure_rgb24` converts to RGB24 for writing.
+- `_save_frame_with_fpng` promotes subsampled SDR clips to `YUV444P16` when odd crop/pad pairs require it (policy=`[screenshots].odd_geometry_policy`), logs the axis, then runs geometry and applies RGB dither only on the final 16→8-bit hop. FFmpeg requests auto-fallback to VapourSynth when a promotion would be required.
 
 ## Overlay & verification guarantees
 - `process_clip_for_screenshot` runs **before** geometry planning; the resulting node is the one fed into `_plan_geometry` and ultimately into the writers.

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import tomllib
 from dataclasses import fields, is_dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Literal, cast
 
 from .datatypes import (
     AnalysisConfig,
@@ -33,6 +33,8 @@ _FFMPEG_TIMEOUT_NOT_FINITE_MSG = (
     "screenshots.ffmpeg_timeout_seconds must be a finite number"
 )
 _FFMPEG_TIMEOUT_NEGATIVE_MSG = "screenshots.ffmpeg_timeout_seconds must be >= 0"
+_ODD_GEOMETRY_POLICIES = {"auto", "force_full_chroma", "subsamp_safe"}
+_RGB_DITHER_MODES = {"error_diffusion", "ordered", "none"}
 
 
 def _coerce_bool(value: Any, dotted_key: str) -> bool:
@@ -247,6 +249,26 @@ def load_config(path: str) -> AppConfig:
     if pad_mode not in {"off", "on", "auto"}:
         raise ConfigError("screenshots.pad_to_canvas must be 'off', 'on', or 'auto'")
     app.screenshots.pad_to_canvas = pad_mode
+
+    policy_value = str(app.screenshots.odd_geometry_policy).strip().lower()
+    if policy_value not in _ODD_GEOMETRY_POLICIES:
+        raise ConfigError(
+            "screenshots.odd_geometry_policy must be 'auto', 'force_full_chroma', or 'subsamp_safe'"
+        )
+    app.screenshots.odd_geometry_policy = cast(
+        Literal["auto", "force_full_chroma", "subsamp_safe"],
+        policy_value,
+    )
+
+    dither_value = str(app.screenshots.rgb_dither).strip().lower()
+    if dither_value not in _RGB_DITHER_MODES:
+        raise ConfigError(
+            "screenshots.rgb_dither must be 'error_diffusion', 'ordered', or 'none'"
+        )
+    app.screenshots.rgb_dither = cast(
+        Literal["error_diffusion", "ordered", "none"],
+        dither_value,
+    )
 
     progress_style = str(app.cli.progress.style).strip().lower()
     if progress_style not in {"fill", "dot"}:

--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -60,6 +60,10 @@ auto_letterbox_crop = false
 pad_to_canvas = "off"
 letterbox_px_tolerance = 8
 center_pad = true
+# Allow odd-pixel crop/pad on subsampled SDR sources by promoting to YUV444 when needed.
+odd_geometry_policy = "auto"       # Options: auto, force_full_chroma, subsamp_safe
+# Dither strategy for the final RGB24 conversion when reducing bit depth.
+rgb_dither = "error_diffusion"     # Options: error_diffusion, ordered, none
 # Abort FFmpeg renders that exceed this many seconds per frame (must be >= 0; set to 0 to disable).
 ffmpeg_timeout_seconds = 120.0
 

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -1,6 +1,7 @@
 """Configuration dataclasses for frame comparison tool."""
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
+from typing import Literal
 
 
 @dataclass
@@ -50,6 +51,8 @@ class ScreenshotConfig:
     letterbox_px_tolerance: int = 8
     center_pad: bool = True
     ffmpeg_timeout_seconds: float = 120.0
+    odd_geometry_policy: Literal["auto", "force_full_chroma", "subsamp_safe"] = "auto"
+    rgb_dither: Literal["error_diffusion", "ordered", "none"] = "error_diffusion"
 
 
 @dataclass

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -1036,6 +1036,17 @@ def _rebalance_subsamp_safe_plan(
     plan["cropped_h"] = max(1, height - top - bottom)
 
     target_h = plan.get("target_height")
+    if isinstance(target_h, int) and target_h > 0:
+        subsampling_h = int(plan.get("subsampling_h", 0))
+        if subsampling_h > 0:
+            mod = 1 << subsampling_h
+            adjusted_target_h = target_h - (target_h % mod)
+            if adjusted_target_h <= 0:
+                adjusted_target_h = mod
+            if adjusted_target_h != target_h:
+                target_h = adjusted_target_h
+                plan["target_height"] = adjusted_target_h
+
     if isinstance(target_h, int) and target_h > 0 and target_h != plan["cropped_h"]:
         plan["scaled"] = _compute_scaled_dimensions(width, height, plan["crop"], target_h)
     else:

--- a/tests/test_audio_alignment.py
+++ b/tests/test_audio_alignment.py
@@ -6,7 +6,7 @@ import builtins
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Mapping, cast
 
 import pytest
 
@@ -162,7 +162,13 @@ def test_measure_offsets_wraps_optional_dependency_errors(
 
     original_import = builtins.__import__
 
-    def failing_import(name: str, globals: object = None, locals: object = None, fromlist: tuple[str, ...] = (), level: int = 0):  # type: ignore[override]
+    def failing_import(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:  # type: ignore[override]
         if name == "librosa":
             raise RuntimeError("boom")
         return original_import(name, globals, locals, fromlist, level)

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -186,6 +186,14 @@ def test_rebalance_subsamp_safe_plan_evenises_geometry() -> None:
     assert plan["cropped_h"] == plan["scaled"][1]
 
 
+def test_rebalance_subsamp_safe_plan_evenises_target_height() -> None:
+    plan = _fake_plan(crop=(0, 1, 0, 0), pad=(0, 0, 0, 0), subsampling_w=1, subsampling_h=1)
+    changed = screenshot._rebalance_subsamp_safe_plan(plan, adjust_horizontal=False, adjust_vertical=True)
+    assert changed
+    assert plan["target_height"] % 2 == 0
+    assert plan["scaled"][1] == plan["target_height"]
+
+
 def test_plan_geometry_letterbox_alignment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     clips = [FakeClip(3840, 2160), FakeClip(3840, 1800)]
     cfg = ScreenshotConfig(directory_name="screens", add_frame_info=False)


### PR DESCRIPTION
## Summary
- add axis-aware odd-geometry detection to screenshot planning with new `odd_geometry_policy` and `rgb_dither` config
- promote subsampled SDR clips to YUV444P16 when needed, apply configurable dithering on the final RGB24 conversion, and fall back from FFmpeg when promotion is required
- update documentation, defaults, and regression tests for geometry planning, writer selection, and optional dependency shims

## Testing
- `uv run pyright`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68f56444eac08321ab4778b27900ee62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New screenshot options: odd_geometry_policy (auto/force_full_chroma/subsamp_safe) and rgb_dither (error_diffusion/ordered/none).

* **Bug Fixes**
  * Resolved odd-pixel crop/pad failures on subsampled SDR clips with conditional chroma promotion, axis-aware geometry handling, and FFmpeg fallback for problematic frames.

* **Documentation**
  * Updated changelog, decisions, and pipeline docs to describe geometry policies, promotion behavior, dithering, and logging pivots.

* **Tests**
  * Expanded regression tests for geometry planning, chroma handling, and writer fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->