### PR TITLE
Add odd geometry policy and RGB dither configuration fields

### DIFF
--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -50,6 +50,8 @@ quick-start configuration paths.
 | `[screenshots].upscale` | Permit global upscaling. | bool | `true` |
 | `[screenshots].single_res` | Fixed output height (0 keeps source). | int | `0` |
 | `[screenshots].mod_crop` | Crop modulus. | int | `2` |
+| `[screenshots].odd_geometry_policy` | Policy for odd-pixel trims/pads on subsampled SDR (auto, force, or subsamp-safe). | str | `"auto"` |
+| `[screenshots].rgb_dither` | Dithering applied during final RGB24 conversion. | str | `"error_diffusion"` |
 | `[screenshots].auto_letterbox_crop` | Auto crop black bars. | bool | `false` |
 | `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be >= 0; set 0 to disable). | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |

--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -60,6 +60,10 @@ auto_letterbox_crop = false
 pad_to_canvas = "off"
 letterbox_px_tolerance = 8
 center_pad = true
+# Choose how odd-pixel trims/pads behave on subsampled SDR clips.
+odd_geometry_policy = "auto"
+# Dithering applied when converting the final RGB output to 8-bit PNGs.
+rgb_dither = "error_diffusion"
 # Abort FFmpeg renders that exceed this many seconds per frame (must be >= 0; set to 0 to disable).
 ffmpeg_timeout_seconds = 120.0
 

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -1,6 +1,23 @@
 """Configuration dataclasses for frame comparison tool."""
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
+
+
+class OddGeometryPolicy(str, Enum):
+    """Policies controlling how odd-pixel geometry is handled for screenshots."""
+
+    AUTO = "auto"
+    FORCE_FULL_CHROMA = "force_full_chroma"
+    SUBSAMP_SAFE = "subsamp_safe"
+
+
+class RGBDither(str, Enum):
+    """Dithering strategies used when converting RGB outputs to 8-bit."""
+
+    ERROR_DIFFUSION = "error_diffusion"
+    ORDERED = "ordered"
+    NONE = "none"
 
 
 @dataclass
@@ -50,6 +67,8 @@ class ScreenshotConfig:
     letterbox_px_tolerance: int = 8
     center_pad: bool = True
     ffmpeg_timeout_seconds: float = 120.0
+    odd_geometry_policy: OddGeometryPolicy = OddGeometryPolicy.AUTO
+    rgb_dither: RGBDither = RGBDither.ERROR_DIFFUSION
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.config_loader import ConfigError, load_config
 from src.config_template import copy_default_config
+from src.datatypes import OddGeometryPolicy, RGBDither
 
 
 def _copy_default_config(tmp_path: Path) -> Path:
@@ -18,6 +19,8 @@ def test_load_defaults(tmp_path: Path) -> None:
     assert app.analysis.downscale_height == 720
     assert app.screenshots.directory_name == "screens"
     assert app.screenshots.ffmpeg_timeout_seconds == 120.0
+    assert app.screenshots.odd_geometry_policy is OddGeometryPolicy.AUTO
+    assert app.screenshots.rgb_dither is RGBDither.ERROR_DIFFUSION
     assert app.naming.always_full_filename is True
     assert app.runtime.ram_limit_mb == 4000
     assert isinstance(app.runtime.vapoursynth_python_paths, list)
@@ -52,6 +55,8 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[color]\nverify_luma_threshold = 1.5\n", "color.verify_luma_threshold"),
         ("[color]\nverify_step_seconds = 0\n", "color.verify_step_seconds"),
         ("[color]\ntarget_nits = -10\n", "color.target_nits"),
+        ("[screenshots]\nodd_geometry_policy = \"bogus\"\n", "screenshots.odd_geometry_policy"),
+        ("[screenshots]\nrgb_dither = \"invalid\"\n", "screenshots.rgb_dither"),
         ("[source]\npreferred = \"bogus\"\n", "source.preferred"),
         ("[tmdb]\nyear_tolerance = -1\n", "tmdb.year_tolerance"),
         ("[tmdb]\ncache_ttl_seconds = -5\n", "tmdb.cache_ttl_seconds"),
@@ -93,6 +98,8 @@ min_window_seconds = 2.5
 [screenshots]
 compression_level = 2
 ffmpeg_timeout_seconds = 45.5
+odd_geometry_policy = "force_full_chroma"
+rgb_dither = "ordered"
 
 [slowpics]
 auto_upload = "1"
@@ -135,6 +142,10 @@ preferred = "ffms2"
     assert app.analysis.min_window_seconds == 2.5
     assert app.screenshots.compression_level == 2
     assert app.screenshots.ffmpeg_timeout_seconds == 45.5
+    assert (
+        app.screenshots.odd_geometry_policy is OddGeometryPolicy.FORCE_FULL_CHROMA
+    )
+    assert app.screenshots.rgb_dither is RGBDither.ORDERED
     assert app.slowpics.auto_upload is True
     assert app.slowpics.remove_after_days == 14
     assert app.naming.always_full_filename is False


### PR DESCRIPTION
## Summary
- add typed enums for odd-geometry policy and RGB dithering in the screenshot configuration
- coerce and validate the new enum-backed options when loading TOML and surface them in the default template
- document the configuration knobs and extend config loader tests to cover defaults, overrides, and error paths

## Testing
- uv run pytest -q
- uv run pyright *(fails: existing type errors in tests/test_audio_alignment.py unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f59b5ccc3c83219bc7d6eba1f55808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `odd_geometry_policy` configuration option to control odd-pixel handling on subsampled SDR images (auto/force/subsamp-safe).
  * Added `rgb_dither` configuration option to control dithering during RGB conversion (error_diffusion/ordered/none).

* **Documentation**
  * Updated configuration reference with new screenshot options and their descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->