### PR TITLE
Implement SDR full-chroma pivot in VapourSynth renderer

### DIFF
--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -51,7 +51,7 @@ quick-start configuration paths.
 | `[screenshots].single_res` | Fixed output height (0 keeps source). | int | `0` |
 | `[screenshots].mod_crop` | Crop modulus. | int | `2` |
 | `[screenshots].odd_geometry_policy` | Policy for odd-pixel trims/pads on subsampled SDR (auto, force, or subsamp-safe). | str | `"auto"` |
-| `[screenshots].rgb_dither` | Dithering applied during final RGB24 conversion. | str | `"error_diffusion"` |
+| `[screenshots].rgb_dither` | Dithering applied during final RGB24 conversion (FFmpeg path forces deterministic ordered when `"error_diffusion"` is requested). | str | `"error_diffusion"` |
 | `[screenshots].auto_letterbox_crop` | Auto crop black bars. | bool | `false` |
 | `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be >= 0; set 0 to disable). | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -455,8 +455,8 @@ def _ensure_rgb24(
         if isinstance(transfer, int):
             prop_kwargs["_Transfer"] = int(transfer)
         converted = cast(Any, converted.std.SetFrameProps(**prop_kwargs))
-    except Exception:  # pragma: no cover - best effort
-        pass
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug("Failed to set RGB frame props: %s", exc)
     return converted
 
 
@@ -769,8 +769,8 @@ def _is_sdr_pipeline(
         return False
     try:
         is_hdr = vs_core._props_signal_hdr(source_props)
-    except (AttributeError, KeyError, TypeError, ValueError):
-        logger.debug("Could not determine HDR status from props; assuming SDR")
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        logger.debug("HDR detection failed; defaulting to SDR: %s", exc)
         is_hdr = False
     return not bool(is_hdr)
 

--- a/src/screenshot.py
+++ b/src/screenshot.py
@@ -438,15 +438,14 @@ def _ensure_rgb24(
         raise ScreenshotWriterError(f"Failed to convert frame {frame_idx} to RGB24: {exc}") from exc
 
     try:
-        converted = cast(
-            Any,
-            converted.std.SetFrameProps(
-            _Matrix=0,
-            _Primaries=1,
-            _Transfer=1,
-            _ColorRange=0,
-            ),
-        )
+        prop_kwargs: Dict[str, int] = {"_Matrix": 0, "_ColorRange": 0}
+        primaries = props.get("_Primaries")
+        if isinstance(primaries, int):
+            prop_kwargs["_Primaries"] = int(primaries)
+        transfer = props.get("_Transfer")
+        if isinstance(transfer, int):
+            prop_kwargs["_Transfer"] = int(transfer)
+        converted = cast(Any, converted.std.SetFrameProps(**prop_kwargs))
     except Exception:  # pragma: no cover - best effort
         pass
     return converted

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -495,10 +495,8 @@ def test_compression_flag_passed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
         selection_label: str | None,
         *,
         overlay_text: str | None = None,
-        _geometry_plan: GeometryPlan | None = None,
         **kwargs: Any,
     ) -> None:
-        _ = kwargs.pop("geometry_plan", _geometry_plan)
         captured[frame_idx] = screenshot._map_ffmpeg_compression(cfg.compression_level)
         path.write_text("ffmpeg", encoding="utf-8")
 
@@ -537,10 +535,8 @@ def test_ffmpeg_respects_trim_offsets(tmp_path: Path, monkeypatch: pytest.Monkey
         selection_label,
         *,
         overlay_text=None,
-        _geometry_plan=None,
         **kwargs: Any,
     ):
-        _ = kwargs.pop("geometry_plan", _geometry_plan)
         calls.append(frame_idx)
         Path(path).write_text("ff", encoding="utf-8")
 
@@ -1040,10 +1036,8 @@ def test_ffmpeg_writer_receives_padding(tmp_path: Path, monkeypatch: pytest.Monk
         selection_label,
         *,
         overlay_text=None,
-        _geometry_plan=None,
         **kwargs: Any,
     ):
-        _ = kwargs.pop("geometry_plan", _geometry_plan)
         calls.append(
             {
                 "crop": crop,
@@ -1141,8 +1135,8 @@ def test_save_frame_with_ffmpeg_honours_timeout(monkeypatch: pytest.MonkeyPatch,
     cfg = ScreenshotConfig(ffmpeg_timeout_seconds=37.5)
     recorded: dict[str, object] = {}
 
-    def fake_run(cmd: Sequence[str], **_kwargs: Any):  # type: ignore[override]
-        recorded.update(_kwargs)
+    def fake_run(cmd: Sequence[str], **kwargs: Any):  # type: ignore[override]
+        recorded.update(kwargs)
         recorded["cmd"] = cmd
 
         class _Result:
@@ -1217,7 +1211,7 @@ def test_save_frame_with_ffmpeg_inserts_full_chroma_filters(
     plan = _make_plan(requires_full_chroma=True)
     recorded_cmd: list[str] = []
 
-    def fake_run(cmd: Sequence[str], **kwargs: Any):  # type: ignore[override]
+    def fake_run(cmd: Sequence[str], **_kwargs: Any):  # type: ignore[override]
         recorded_cmd[:] = list(cmd)
 
         class _Result:

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -495,8 +495,10 @@ def test_compression_flag_passed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
         selection_label: str | None,
         *,
         overlay_text: str | None = None,
-        geometry_plan: GeometryPlan | None = None,
+        _geometry_plan: GeometryPlan | None = None,
+        **kwargs: Any,
     ) -> None:
+        _ = kwargs.pop("geometry_plan", _geometry_plan)
         captured[frame_idx] = screenshot._map_ffmpeg_compression(cfg.compression_level)
         path.write_text("ffmpeg", encoding="utf-8")
 
@@ -535,8 +537,10 @@ def test_ffmpeg_respects_trim_offsets(tmp_path: Path, monkeypatch: pytest.Monkey
         selection_label,
         *,
         overlay_text=None,
-        geometry_plan=None,
+        _geometry_plan=None,
+        **kwargs: Any,
     ):
+        _ = kwargs.pop("geometry_plan", _geometry_plan)
         calls.append(frame_idx)
         Path(path).write_text("ff", encoding="utf-8")
 
@@ -1036,8 +1040,10 @@ def test_ffmpeg_writer_receives_padding(tmp_path: Path, monkeypatch: pytest.Monk
         selection_label,
         *,
         overlay_text=None,
-        geometry_plan=None,
+        _geometry_plan=None,
+        **kwargs: Any,
     ):
+        _ = kwargs.pop("geometry_plan", _geometry_plan)
         calls.append(
             {
                 "crop": crop,
@@ -1135,8 +1141,8 @@ def test_save_frame_with_ffmpeg_honours_timeout(monkeypatch: pytest.MonkeyPatch,
     cfg = ScreenshotConfig(ffmpeg_timeout_seconds=37.5)
     recorded: dict[str, object] = {}
 
-    def fake_run(cmd: Sequence[str], **kwargs: Any):  # type: ignore[override]
-        recorded.update(kwargs)
+    def fake_run(cmd: Sequence[str], **_kwargs: Any):  # type: ignore[override]
+        recorded.update(_kwargs)
         recorded["cmd"] = cmd
 
         class _Result:
@@ -1387,7 +1393,7 @@ def test_save_frame_with_fpng_promotes_subsampled_sdr(
             return clip
 
     class _FakeFpng:
-        def Write(self, clip: _FakeClip, path: str, **kwargs: Any) -> Any:
+        def Write(self, _clip: _FakeClip, path: str, **kwargs: Any) -> Any:
             writer_calls.append(kwargs)
 
             class _Job:
@@ -1402,8 +1408,8 @@ def test_save_frame_with_fpng_promotes_subsampled_sdr(
         resize=fake_resize,
         fpng=_FakeFpng(),
         std=types.SimpleNamespace(
-            SetFrameProps=lambda clip, **kwargs: clip,
-            CopyFrameProps=lambda clip, src: clip,
+            SetFrameProps=lambda clip, **_kwargs: clip,
+            CopyFrameProps=lambda clip, _src: clip,
             AddBorders=lambda clip, *, left, right, top, bottom: clip._with_dimensions(
                 width=clip.width + left + right,
                 height=clip.height + top + bottom,

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1487,12 +1487,14 @@ def test_ensure_rgb24_applies_rec709_defaults_when_metadata_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
+    captured_props: dict[str, Any] = {}
 
     class _DummyStd:
         def __init__(self, parent: "_DummyClip") -> None:
             self._parent = parent
 
         def SetFrameProps(self, **kwargs: Any) -> "_DummyClip":
+            captured_props.update(kwargs)
             return self._parent
 
     class _DummyClip:
@@ -1542,16 +1544,19 @@ def test_ensure_rgb24_applies_rec709_defaults_when_metadata_missing(
     assert captured.get("primaries_in") == 1
     assert captured.get("range_in") == 1
     assert captured.get("dither_type") == RGBDither.ERROR_DIFFUSION.value
+    assert captured_props == {"_Matrix": 0, "_ColorRange": 0}
 
 
 def test_ensure_rgb24_uses_source_colour_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
+    captured_props: dict[str, Any] = {}
 
     class _DummyStd:
         def __init__(self, parent: "_DummyClip") -> None:
             self._parent = parent
 
         def SetFrameProps(self, **kwargs: Any) -> "_DummyClip":
+            captured_props.update(kwargs)
             return self._parent
 
     class _DummyClip:
@@ -1614,3 +1619,9 @@ def test_ensure_rgb24_uses_source_colour_metadata(monkeypatch: pytest.MonkeyPatc
     assert captured.get("primaries_in") == 9
     assert captured.get("range_in") == 0
     assert captured.get("dither_type") == RGBDither.ORDERED.value
+    assert captured_props == {
+        "_Matrix": 0,
+        "_ColorRange": 0,
+        "_Primaries": 9,
+        "_Transfer": 16,
+    }


### PR DESCRIPTION
## Summary
- promote VapourSynth SDR clips that require odd-geometry adjustments to YUV444P16 before geometry operations
- add RGB24 conversion control via configurable dithering and extend renderer logging for promotion events
- expand screenshot renderer tests with a VapourSynth stub covering the promotion path and update existing RGB conversion tests

## Testing
- uv run pytest -q
- uv run pyright


------
https://chatgpt.com/codex/tasks/task_e_68f5c2862b9083218089120269c4354e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable RGB dithering during frame export; both export paths now handle dithering consistently and propagate geometry/tonemap context. SDR-aware detection can auto-promote subsampled content to 4:4:4 with richer metadata.

* **Tests**
  * Added coverage for promotion workflows, chroma-format insertion, dithering propagation, and export-path parity.

* **Documentation**
  * Clarified rgb_dither behavior and noted FFmpeg’s deterministic ordered dithering for specific settings.

* **Public API**
  * Exposed RGBDither as a public option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->