### PR TITLE
Deduplicate pivot notifications in CLI runs

### DIFF
--- a/docs/geometry_pipeline.md
+++ b/docs/geometry_pipeline.md
@@ -58,4 +58,7 @@ Whenever the pivot activates the CLI emits:
   and format/backend that triggered the promotion.
 
 The note appears for both VapourSynth and FFmpeg paths and helps operators
-confirm that odd-geometry cases are handled intentionally.
+confirm that odd-geometry cases are handled intentionally. Duplicate pivot
+messages within a single CLI run are suppressed after the first emission so the
+console highlights each pivot scenario once even if the renderer retries the
+same frame set.

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -4585,7 +4585,12 @@ def run_cli(
     verification_records: List[Dict[str, Any]] = []
 
     try:
+        seen_pivot_messages: set[str] = set()
+
         def _notify_pivot(message: str) -> None:
+            if message in seen_pivot_messages:
+                return
+            seen_pivot_messages.add(message)
             reporter.console.log(message, markup=False)
 
         if total_screens > 0:

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -1860,7 +1860,7 @@ def test_run_cli_coalesces_duplicate_pivot_logs(
     base_console = frame_compare.Console
 
     class RecordingConsole(base_console):  # type: ignore[misc]
-        pivot_logs: list[str] = []
+        pivot_logs: ClassVar[list[str]] = []
 
         def __init__(self, *args: object, **kwargs: object) -> None:
             super().__init__(*args, **kwargs)

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -5,7 +5,7 @@ import pathlib
 import types
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import Any, Mapping, cast
+from typing import Any, ClassVar, Mapping, cast
 
 import pytest
 from click.testing import CliRunner, Result


### PR DESCRIPTION
## Summary
- track per-run pivot messages when rendering screenshots so repeated notifications only log once
- document the streamlined pivot logging behaviour in the geometry pipeline notes
- add a regression test that exercises the CLI flow and asserts duplicate pivot notes are coalesced

## Testing
- pytest tests/test_frame_compare.py::test_run_cli_coalesces_duplicate_pivot_logs

------
https://chatgpt.com/codex/tasks/task_e_68f69fe8900883219ddbcc95a0569d72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate pivot notifications are now suppressed within a single CLI run so each pivot scenario is logged only once for clearer console output.

* **Documentation**
  * Geometry pipeline docs updated to describe the pivot message deduplication behavior.

* **Tests**
  * Added test coverage validating pivot message coalescing during CLI execution.

* **Chores**
  * Public export surface expanded to expose an additional analysis type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->