### PR TITLE
Implement VSPreview baseline preview mode

### DIFF
--- a/frame_compare.py
+++ b/frame_compare.py
@@ -3212,9 +3212,13 @@ def _harmonise_fps(reference_clip, target_clip, label):
 
 def _format_overlay_text(suggested_frames, suggested_seconds, applied_frames):
     applied_label = "baseline" if applied_frames == 0 else "seeded"
+    applied_value = "0" if applied_frames == 0 else f"{{applied_frames:+d}}"
+    seconds_value = f"{{suggested_seconds:.3f}}"
+    if seconds_value == "-0.000":
+        seconds_value = "0.000"
     return (
-        f"Suggested: {suggested_frames:+d}f (~{suggested_seconds:+.3f}s) • "
-        f"Applied in preview: {applied_frames:+d}f ({applied_label}) • "
+        f"Suggested: {{suggested_frames:+d}}f (~{{seconds_value}}s) • "
+        f"Applied in preview: {{applied_value}}f ({{applied_label}}) • "
         "(+ trims target / − pads reference)"
     )
 

--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -42,6 +42,8 @@ confirm_with_screenshots = true
 random_seed = 2025
 frame_offset_bias = 1        # Frames to move toward zero (negative values push further away)
 use_vspreview = false        # surface the prompt and launch VSPreview after alignment
+vspreview_mode = "baseline"  # "baseline" keeps preview untrimmed; set "seeded" to pre-apply suggestion
+show_suggested_in_preview = true  # draw suggestion overlay text in VSPreview when available
 prompt_reuse_offsets = false # prompt before recomputing; decline to reuse cached offsets
 
 [screenshots]

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -188,6 +188,8 @@ class AudioAlignmentConfig:
     enable: bool = False
     reference: str = ""
     use_vspreview: bool = False
+    vspreview_mode: str = "baseline"
+    show_suggested_in_preview: bool = True
     prompt_reuse_offsets: bool = False
     sample_rate: int = 16000
     hop_length: int = 512

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -760,7 +760,10 @@ def test_launch_vspreview_generates_script(
     assert "'Target': 0,  # Suggested delta +7f" in script_text
     assert "SUGGESTION_MAP" in script_text
     assert "'Target': (7, 0.0)" in script_text
-    assert "Suggested: {suggested_frames:+d}f (~{suggested_seconds:+.3f}s) •" in script_text
+    assert 'seconds_value = f"{suggested_seconds:.3f}"' in script_text
+    assert "Suggested: {suggested_frames:+d}f (~{seconds_value}s) •" in script_text
+    assert 'applied_value = "0" if applied_frames == 0 else f"{applied_frames:+d}"' in script_text
+    assert "Applied in preview: {applied_value}f" in script_text
     assert "preview applied=%+df" in script_text
     assert recorded_command, "VSPreview command should be invoked when interactive"
     assert recorded_command[0][0] == frame_compare.sys.executable


### PR DESCRIPTION
## Summary
- default VSPreview preview scripts to baseline mode, keeping OFFSET_MAP entries at zero while surfacing suggested alignment
- add audio alignment configuration switches for preview mode and overlay visibility and inject guidance overlay text in generated scripts
- extend VSPreview tests to cover baseline overlay composition and manual offset persistence

## Testing
- pytest tests/test_frame_compare.py::test_launch_vspreview_generates_script tests/test_frame_compare.py::test_launch_vspreview_baseline_mode_persists_manual_offsets *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68f6f5ddfd548321b48d10a4758be790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VSPreview gains configurable modes (baseline/seeded) and optional on-screen overlays showing per-clip suggested deltas and applied preview offsets (including suggested seconds).
  * Preview scripts and rendering now surface measurement-based suggestions and detailed per-target status.

* **Tests**
  * Added and expanded tests for VSPreview baseline mode, script contents, and persistence of manual offsets/deltas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->