### PR TITLE
feat: Tonemap  Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable user-visible updates will be documented in this file in reverse chronological order.
 
+- *2025-11-06:* Added BT.2390 knee, dynamic-peak-detection presets, and optional post-tonemap gamma lift. `[color]` now exposes `dst_min_nits=0.18`, `knee_offset`, `dpd_preset`, `dpd_black_cutoff`, and `post_gamma`, libplacebo calls forward `tone_mapping_param`/`peak_detection_preset`/`black_cutoff` with compatibility shims, overlays understand `{knee_offset}`, `{dpd_preset}`, `{dst_min_nits}`, and new CLI flags (`--tm-*`) allow per-run overrides. Docs, presets, and tests updated accordingly.
 - *2025-11-06:* Default screenshot exports now expand limited-range SDR to full-range RGB via a new `[screenshots].export_range` setting (default `"full"`), with `"limited"` preserving video-range PNGs. Both VapourSynth and FFmpeg writers honour the option, `_SourceColorRange` provenance is recorded when expanding, and documentation/tests/config templates were updated accordingly.
 - *2025-11-05:* Harmonised HDR tonemap range metadata with sampled RGB output, wiring detected `_ColorRange` through geometry and overlays, preserving frame props during subtitle paths, and extending regression coverage/docs for the updated pipeline.
 - *2025-10-30:* Auto-launched the configuration wizard during interactive first runs when `config/config.toml` is missing, added a `--no-wizard` flag plus `FRAME_COMPARE_NO_WIZARD` override, surfaced a fallback reminder for non-interactive sessions, and refreshed README/tests accordingly.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Offline HTML reports mirror slow.pics ergonomics: filmstrip thumbnails with sele
 | `--tm-dst-min VALUE` | Override `[color].dst_min_nits` |
 | `--tm-knee VALUE` | Override `[color].knee_offset` (0–1) |
 | `--tm-dpd-preset NAME` | Override `[color].dpd_preset` (`off`, `fast`, `balanced`, `high_quality`) |
+| `--tm-dpd-black-cutoff VALUE` | Override `[color].dpd_black_cutoff` (`0.0–0.05`) |
 | `--tm-gamma VALUE` | Override `[color].post_gamma` and enable the gamma lift |
 | `--tm-gamma-disable` | Disable the post-tonemap gamma lift for this run |
 | `--write-config` | Ensure `ROOT/config/config.toml` exists, then exit |

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Configuration highlights:
 - Workspace guardrails keep everything under the resolved root: the CLI refuses `site-packages` roots, auto-seeds `ROOT/config/config.toml`, validates writability up front, and blocks relative paths that escape the workspace. Run `frame-compare --diagnose-paths` to confirm the resolved locations when in doubt.
 - `[analysis]` governs frame quotas, random seed, and metric cache filename.
 - `[screenshots]` selects renderer, geometry policy, dithering, and output directory name.
-- `[color]` sets tonemap preset (`reference`, `contrast`, `filmic`), verification options, overlay text, and strictness.
+- `[color]` sets tonemap preset (`reference`, `contrast`, `filmic`, `bt2390_spec`, `spline`), verification options, overlay text, BT.2390 knee offsets, dynamic-peak-detection presets, post-tonemap gamma, and strictness.
 - `[audio_alignment]` enables correlation, VSPreview hooks, offsets filename, and bias.
 - `[slowpics]` toggles auto uploads (disabled by default), visibility, cleanup, webhook URL, and timeout.
 - `[report]` enables the offline HTML report, output directory, default comparison pair, and auto-open behaviour.
@@ -209,6 +209,11 @@ Common toggles (see [docs/README_REFERENCE.md](docs/README_REFERENCE.md) for ful
 
 Offline HTML reports mirror slow.pics ergonomics: filmstrip thumbnails with selection-category filters, Actual/Fit/Fill presets, an alignment selector, pointer-anchored zoom via the slider, +/- buttons, or Ctrl/⌘ + mouse wheel, and pan support (space + drag or regular drag once zoomed beyond fit). Slider, overlay, difference, and blink viewer modes plus a fullscreen toggle round out the controls. Zoom, fit, mode, alignment, and category filters persist in `localStorage` so every frame opens with the same viewer state.
 
+### Tonemap Quick Recipes
+
+- **Reference SDR (BT.2390):** keep `preset="reference"` (or select with `--tm-preset reference`), which resolves to `tone_curve="bt.2390"`, `target_nits=100`, `dst_min_nits=0.18`, `knee_offset=0.50`, and `dpd_preset="high_quality"`. This maximises texture in low APL scenes without blowing highlights. Pair with the default overlay template to surface the resolved parameters.
+- **BT.2446A Filmic:** set `preset="filmic"` (or `--tm-preset filmic`) to switch to the libplacebo BT.2446A curve with the same 100 nit target and conservative dynamic peak detection. This preset keeps a softer shoulder and works well for well-mastered PQ sources. Tweak `--tm-dst-min`/`[color].dst_min_nits` or `--tm-gamma` when you need extra lift.
+
 > **Tip:** To seed another workspace, run `uv run python -m frame_compare --root alt-root --write-config`.
 
 ## CLI Reference
@@ -219,6 +224,14 @@ Offline HTML reports mirror slow.pics ergonomics: filmstrip thumbnails with sele
 | `--config PATH` | Use a specific config file (falls back to `FRAME_COMPARE_CONFIG`) |
 | `--input PATH` | Override `[paths].input_dir` for a single run |
 | `--audio-align-track label=index` | Force the audio stream used per clip (repeatable) |
+| `--tm-preset NAME` | Override tone-mapping preset (`reference`, `contrast`, `filmic`, `bt2390_spec`, `spline`) |
+| `--tm-curve NAME` | Override `[color].tone_curve` without touching presets |
+| `--tm-target NITS` | Override `[color].target_nits` |
+| `--tm-dst-min VALUE` | Override `[color].dst_min_nits` |
+| `--tm-knee VALUE` | Override `[color].knee_offset` (0–1) |
+| `--tm-dpd-preset NAME` | Override `[color].dpd_preset` (`off`, `fast`, `balanced`, `high_quality`) |
+| `--tm-gamma VALUE` | Override `[color].post_gamma` and enable the gamma lift |
+| `--tm-gamma-disable` | Disable the post-tonemap gamma lift for this run |
 | `--write-config` | Ensure `ROOT/config/config.toml` exists, then exit |
 | `--diagnose-paths` | Print JSON diagnostics (root, media, screens, writability) |
 | `--quiet` / `--verbose` | Adjust console verbosity |

--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -279,7 +279,7 @@
           "subtitle": "Tonemap",
           "lines": [
             "[[key]]curve[[/]]=[[value]]{tonemap.tone_curve}[[/]] [[key]]target[[/]]=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] [[key]]dst_min[[/]]=[[value]]{tonemap.dst_min_nits:.2f}[[/]] [[key]]knee[[/]]=[[value]]{tonemap.knee_offset:.2f}[[/]]",
-            "[[key]]dpd[[/]]=[[value]]{tonemap.dynamic_peak_detection|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]]) [[key]]gamma[[/]]=[[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[unit]]*[[/]]:''} [[key]]verify_luma_thresh[[/]]=[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[key]]verify_delta[[/]]=[[value]]{verify.delta.max}[[/]]:''}"
+            "[[key]]dpd[[/]]=[[value]]{tonemap.dpd|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]]) [[key]]gamma[[/]]=[[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[unit]]*[[/]]:''}"
           ]
         },
         {
@@ -324,7 +324,7 @@
         "\u2022 [[key]]Align[[/]]\n  audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]\n  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
         "\u2022 [[key]]Plan[[/]]\n  dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]\n  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
         "\u2022 [[key]]Canvas[[/]]\n  single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]\n  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
-        "\u2022 [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dst_min [[value]]{tonemap.dst_min_nits:.2f}[[/]]\n  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]])  gamma [[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[dim]]*[[/]]:''}  verify \u2264[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] \u0394=[[value]]{verify.delta.max}[[/]][[/]]:''}",
+        "\u2022 [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dst_min [[value]]{tonemap.dst_min_nits:.2f}[[/]]\n  dpd [[value]]{tonemap.dpd|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]])  gamma [[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[dim]]*[[/]]:''}{verify.delta.max? [[dim]] \u0394=[[value]]{verify.delta.max}[[/]][[/]]:''}",
         "\u2022 [[key]]Output[[/]]\n  dir [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]",
         "\u2022 [[key]]Cache[[/]]\n  file [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
         "\u2022 [[key]]Comparison[[/]]\n  [[value]]{comparison.viewer_mode}[[/]]  [[value]]{comparison.viewer_source}[[/]]",

--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -278,7 +278,8 @@
         {
           "subtitle": "Tonemap",
           "lines": [
-            "[[key]]curve[[/]]=[[value]]{tonemap.tone_curve}[[/]] dpd=[[value]]{tonemap.dynamic_peak_detection|bool}[[/]] [[key]]target[[/]]=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] [[key]]verify_luma_thresh[[/]]=[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[key]]verify_delta[[/]]=[[value]]{verify.delta.max}[[/]]:''}"
+            "[[key]]curve[[/]]=[[value]]{tonemap.tone_curve}[[/]] [[key]]target[[/]]=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] [[key]]dst_min[[/]]=[[value]]{tonemap.dst_min_nits:.2f}[[/]] [[key]]knee[[/]]=[[value]]{tonemap.knee_offset:.2f}[[/]]",
+            "[[key]]dpd[[/]]=[[value]]{tonemap.dynamic_peak_detection|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]]) [[key]]gamma[[/]]=[[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[unit]]*[[/]]:''} [[key]]verify_luma_thresh[[/]]=[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[key]]verify_delta[[/]]=[[value]]{verify.delta.max}[[/]]:''}"
           ]
         },
         {
@@ -323,7 +324,7 @@
         "\u2022 [[key]]Align[[/]]\n  audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]\n  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
         "\u2022 [[key]]Plan[[/]]\n  dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]\n  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
         "\u2022 [[key]]Canvas[[/]]\n  single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]\n  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
-        "\u2022 [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]\n  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]]  verify \u2264[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] \u0394=[[value]]{verify.delta.max}[[/]][[/]]:''}",
+        "\u2022 [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dst_min [[value]]{tonemap.dst_min_nits:.2f}[[/]]\n  dpd [[value]]{tonemap.dynamic_peak_detection|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]])  gamma [[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[dim]]*[[/]]:''}  verify \u2264[[value]]{tonemap.verify_luma_threshold}[[/]]{verify.delta.max? [[dim]] \u0394=[[value]]{verify.delta.max}[[/]][[/]]:''}",
         "\u2022 [[key]]Output[[/]]\n  dir [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]",
         "\u2022 [[key]]Cache[[/]]\n  file [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
         "\u2022 [[key]]Comparison[[/]]\n  [[value]]{comparison.viewer_mode}[[/]]  [[value]]{comparison.viewer_source}[[/]]",

--- a/cli_layout.v1.json
+++ b/cli_layout.v1.json
@@ -278,8 +278,8 @@
         {
           "subtitle": "Tonemap",
           "lines": [
-            "[[key]]curve[[/]]=[[value]]{tonemap.tone_curve}[[/]] [[key]]target[[/]]=[[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]] [[key]]dst_min[[/]]=[[value]]{tonemap.dst_min_nits:.2f}[[/]] [[key]]knee[[/]]=[[value]]{tonemap.knee_offset:.2f}[[/]]",
-            "[[key]]dpd[[/]]=[[value]]{tonemap.dpd|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]]) [[key]]gamma[[/]]=[[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[unit]]*[[/]]:''}"
+            "[[key]]curve[[/]]=[[value]]{tonemap.tone_curve}[[/]] [[key]]target[[/]]=[[value]]{tonemap.target_nits:.0f}[[/]][[unit]]nits[[/]] [[key]]dst_min[[/]]=[[value]]{tonemap.dst_min_nits:.2f}[[/]] [[key]]knee[[/]]=[[value]]{tonemap.knee_offset:.2f}[[/]]",
+            "[[key]]dpd[[/]]=[[value]]{tonemap.dpd|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]]) [[key]]cutoff[[/]]=[[value]]{tonemap.dpd_black_cutoff:.3f}[[/]] [[key]]gamma[[/]]=[[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[unit]]*[[/]]:''}"
           ]
         },
         {
@@ -324,7 +324,7 @@
         "\u2022 [[key]]Align[[/]]\n  audio [[value]]{audio_alignment.enabled|bool}[[/]]  offset [[value]]{audio_alignment.offsets_sec:+.3f}[[/]][[unit]]s[[/]]\n  file [[path]]{audio_alignment.offsets_filename.e}[[/]]",
         "\u2022 [[key]]Plan[[/]]\n  dark [[value]]{analysis.counts.dark}[[/]]  bright [[value]]{analysis.counts.bright}[[/]]  motion [[value]]{analysis.counts.motion}[[/]]\n  random [[value]]{analysis.counts.random}[[/]]  user [[value]]{analysis.counts.user}[[/]]  sep [[value]]{analysis.screen_separation_sec:.1f}[[/]][[unit]]s[[/]]",
         "\u2022 [[key]]Canvas[[/]]\n  single_res [[value]]{render.single_res|tallest}[[/]] [[unit]]px[[/]]  upscale [[value]]{render.upscale|bool}[[/]]\n  crop mod[[value]]{render.mod_crop}[[/]]  pad [[value]]{render.center_pad|bool}[[/]]",
-        "\u2022 [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits}[[/]][[unit]]nits[[/]]  dst_min [[value]]{tonemap.dst_min_nits:.2f}[[/]]\n  dpd [[value]]{tonemap.dpd|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]])  gamma [[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[dim]]*[[/]]:''}{verify.delta.max? [[dim]] \u0394=[[value]]{verify.delta.max}[[/]][[/]]:''}",
+        "\u2022 [[key]]Tonemap[[/]]\n  curve [[value]]{tonemap.tone_curve}[[/]]  target [[value]]{tonemap.target_nits:.0f}[[/]][[unit]]nits[[/]]  dst_min [[value]]{tonemap.dst_min_nits:.2f}[[/]]  knee [[value]]{tonemap.knee_offset:.2f}[[/]]\n  dpd [[value]]{tonemap.dpd|bool}[[/]] ([[value]]{tonemap.dpd_preset}[[/]])  cutoff [[value]]{tonemap.dpd_black_cutoff:.3f}[[/]]  gamma [[value]]{tonemap.post_gamma:.2f}[[/]]{tonemap.post_gamma_enabled?[[dim]]*[[/]]:''}{verify.delta.max? [[dim]] \u0394=[[value]]{verify.delta.max}[[/]][[/]]:''}",
         "\u2022 [[key]]Output[[/]]\n  dir [[path]]{render.out_dir.e}[[/]]  compression [[value]]{render.compression}[[/]]",
         "\u2022 [[key]]Cache[[/]]\n  file [[path]]{cache.file}[[/]]  status [[value]]{cache.status}[[/]]",
         "\u2022 [[key]]Comparison[[/]]\n  [[value]]{comparison.viewer_mode}[[/]]  [[value]]{comparison.viewer_source}[[/]]",

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,6 @@
 # Decisions Log
 
+- *2025-11-06:* Added BT.2390 knee/DPD controls and the limited-range post-tonemap gamma stage. Config schema now exposes `knee_offset`, `dst_min_nits=0.18` defaults, `dpd_preset`, `dpd_black_cutoff`, and optional gamma lift toggles, alongside CLI overrides (`--tm-*`) and updated presets/docs/tests to prevent near-black crush regressions.
 - *2025-11-06:* Added `[screenshots].export_range` (default `"full"`) to control final PNG range, expanding limited SDR to sRGB by default while retaining a `"limited"` escape hatch; updated screenshot writers, config templates, docs, and tests to reflect the change.
 - *2025-11-05:* Sampled tonemapped RGB clips to detect actual colour range, aligning `_ColorRange` metadata with pixel values, preserving props across overlays, and documenting/testing the harmonised path to prevent washed-out PNGs.
 - *2025-10-31:* Enhanced the offline HTML report viewer with filmstrip thumbnails, selection-category filters, new difference/blink modes, and a fullscreen toggle. Updated styles, keyboard shortcuts, and documentation to reflect the richer theatre experience while keeping persistence compatible with previous localStorage payloads.

--- a/docs/README_REFERENCE.md
+++ b/docs/README_REFERENCE.md
@@ -94,6 +94,12 @@ Dependency check:
 | `[screenshots].ffmpeg_timeout_seconds` | Per-frame FFmpeg timeout in seconds (must be >= 0; set 0 to disable). | float | `120.0` |
 | `[color].enable_tonemap` | HDR→SDR conversion toggle. | bool | `true` |
 | `[color].preset` | Tonemapping preset. | str | `"reference"` |
+| `[color].dst_min_nits` | Controls HDR toe lift before RGB export. | float | `0.18` |
+| `[color].knee_offset` | BT.2390 shoulder adjustment (0–1). | float | `0.50` |
+| `[color].dpd_preset` | libplacebo dynamic peak detection profile (`off`, `fast`, `balanced`, `high_quality`). | str | `"high_quality"` |
+| `[color].dpd_black_cutoff` | PQ fraction ignored during DPD sampling (0–0.05). | float | `0.01` |
+| `[color].post_gamma_enable` | Enables limited-range post-tonemap gamma lift. | bool | `false` |
+| `[color].post_gamma` | Gamma factor applied when the lift is enabled (≈0.90–1.10). | float | `1.0` |
 | `[color].overlay_enabled` | Tonemap overlay flag. | bool | `true` |
 | `[color].default_matrix_hd` | Preferred matrix code when HD clips omit metadata. | str\|int\|null | `null` |
 | `[color].default_matrix_sd` | Preferred matrix code when SD clips omit metadata. | str\|int\|null | `null` |

--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -62,6 +62,21 @@ run_cli(
 )
 ```
 
+## `[color].dst_min_nits`, `knee_offset`, and preset tuning
+
+- `dst_min_nits` lifts the HDR toe before the final RGB24 conversion. Values between **0.18–0.25** keep detail in crushed shadows while avoiding milky blacks. Lower values increase contrast at the cost of near-black texture.
+- `knee_offset` (default **0.50**) controls the BT.2390 shoulder; smaller values compress highlights earlier while larger values push the roll-off further out. The extended preset map (`reference`, `bt2390_spec`, `filmic`, `spline`, `contrast`) now records the preferred knee alongside target nits and DPD behaviour.
+- CLI overrides are available via `--tm-dst-min` and `--tm-knee` for ad-hoc tuning without editing the config file.
+
+## `[color].dpd_preset` and `dpd_black_cutoff`
+
+- `dpd_preset` selects libplacebo's dynamic-peak-detection profile: `off`, `fast`, `balanced`, or `high_quality`. The presets default to `high_quality` for stills, but you can switch per run with `--tm-dpd-preset`.
+- `dpd_black_cutoff` (default **0.01**) skips a fraction of PQ blacks when sampling highlights for DPD. Keep it within **0–0.05**. When `[color].dynamic_peak_detection = false`, the loader and CLI coerce the preset to `off` and zero out the cutoff.
+
+## `[color].post_gamma_enable` / `post_gamma`
+
+Set `post_gamma_enable = true` to apply a limited-range (`16`–`235`) `std.Levels` gamma adjustment after tonemapping and before overlays/geometry. This stage is disabled by default; when enabled, keep `post_gamma` close to **1.00** (for example, `0.95` for a subtle lift). The CLI provides `--tm-gamma <value>` to tweak a single run and `--tm-gamma-disable` to force the stage off without editing `config.toml`.
+
 ## `[report]`
 
 The HTML report bundles the rendered screenshots with a slider-based viewer and

--- a/docs/hdr_tonemap_overview.md
+++ b/docs/hdr_tonemap_overview.md
@@ -21,19 +21,29 @@ reference.
 ## Presets & configuration
 `[color]` defines the behaviour, defaulting to the "reference" preset:
 
-| Preset | Tone curve | Target nits | DPD |
-| ------ | ---------- | ----------- | --- |
-| reference | `bt.2390` | 100 | enabled |
-| contrast  | `mobius`  | 120 | disabled |
-| filmic    | `hable`   | 100 | enabled |
+| Preset | Tone curve | Target nits | DPD | Notes |
+| ------ | ---------- | ----------- | --- | ----- |
+| reference | `bt.2390` | 100 | enabled | Knee `0.50`, dst_min `0.18`, `dpd_preset="high_quality"` |
+| bt2390_spec | `bt.2390` | 100 | enabled | Identical to reference but with a neutral DPD cutoff |
+| contrast | `mobius` | 120 | disabled | Legacy punchy look, dst_min `0.10`, forces DPD off |
+| filmic | `bt.2446a` | 100 | enabled | Softer shoulder for well-mastered PQ |
+| spline | `spline` | 100 | enabled | Smooth roll-off for high-contrast footage |
 
 Set `preset="custom"` to honour manual `tone_curve`, `target_nits`, and `dynamic_peak_detection`. `dst_min_nits` feeds
-libplacebo's `dst_min`. Logs include `[TM INPUT]` and `[TM APPLIED]` lines showing the inferred color props and the
-resolved curve/DPD/nits.
+libplacebo's `dst_min`. `knee_offset` forwards to `tone_mapping_param` for BT.2390 curves, and `dpd_preset` selects the
+libplacebo peak-detection mode (`off`, `fast`, `balanced`, `high_quality`). Logs include `[TM INPUT]` and `[TM APPLIED]`
+lines showing the inferred color props and the resolved curve/DPD/nits. Runtime tweaks are available via CLI flags such
+as `--tm-preset`, `--tm-knee`, `--tm-dst-min`, and `--tm-dpd-preset`, making it easy to audition settings before
+committing them to `config.toml`.
 
 The screenshot writer controls the final PNG range via `[screenshots].export_range`. The default `"full"` setting expands
 limited-range SDR pixels to full-range RGB just before export (recording the original value in `_SourceColorRange`), while
 `"limited"` preserves the source range for workflows that expect video-range PNGs.
+
+The optional post-tonemap gamma stage applies a limited-range (`16`–`235`) `std.Levels` adjustment after tonemapping but
+before overlays, geometry, and dithering. Enable it with `[color].post_gamma_enable = true` (or `--tm-gamma <value>`)
+when you need a gentle lift (`post_gamma ≈ 0.95`) for especially dark masters; use `--tm-gamma-disable` to force it off
+for a single run.
 
 ## Log cheat sheet
 - `[TM INPUT]` — Source properties at the start of processing. Includes Matrix/Transfer/Primaries/Range.

--- a/docs/hdr_tonemap_overview.md
+++ b/docs/hdr_tonemap_overview.md
@@ -41,7 +41,7 @@ limited-range SDR pixels to full-range RGB just before export (recording the ori
 `"limited"` preserves the source range for workflows that expect video-range PNGs.
 
 The optional post-tonemap gamma stage applies a limited-range (`16`–`235`) `std.Levels` adjustment after tonemapping but
-before overlays, geometry, and dithering. Enable it with `[color].post_gamma_enable = true` (or `--tm-gamma <value>`)
+before overlays, geometry, and dithering, preserving video-level encoding. Enable it with `[color].post_gamma_enable = true` (or `--tm-gamma <value>`)
 when you need a gentle lift (`post_gamma ≈ 0.95`) for especially dark masters; use `--tm-gamma-disable` to force it off
 for a single run.
 

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2398,11 +2398,20 @@ def _build_legacy_summary_lines(values: Mapping[str, Any], *, emit_json_tail: bo
         f"pad={_bool_text(render.get('center_pad'))}"
     )
 
+    tonemap_curve = _string(tonemap.get("tone_curve"), "n/a")
+    tonemap_target = _format_number(tonemap.get("target_nits"), ".0f", "0")
+    tonemap_dst_min = _format_number(tonemap.get("dst_min_nits"), ".2f", "0.00")
+    tonemap_knee = _format_number(tonemap.get("knee_offset"), ".2f", "0.00")
+    tonemap_preset_label = _string(tonemap.get("dpd_preset"), "n/a")
+    tonemap_gamma = _format_number(tonemap.get("post_gamma"), ".2f", "1.00")
+    gamma_flag = "*" if bool(tonemap.get("post_gamma_enabled")) else ""
     lines.append(
         "Tonemap: "
-        f"{_string(tonemap.get('tone_curve'), 'n/a')}@"
-        f"{_format_number(tonemap.get('target_nits'), '.0f', '0')}nits "
-        f"dpd={_bool_text(tonemap.get('dynamic_peak_detection'))}  "
+        f"{tonemap_curve}@{tonemap_target}nits "
+        f"dst_min={tonemap_dst_min} knee={tonemap_knee} "
+        f"dpd={_bool_text(tonemap.get('dynamic_peak_detection'))}"
+        f" ({tonemap_preset_label})  "
+        f"gamma={tonemap_gamma}{gamma_flag}  "
         f"verify≤{_format_number(tonemap.get('verify_luma_threshold'), '.2f', '0.00')}"
     )
 
@@ -4539,6 +4548,7 @@ def run_cli(
     report_enable_override: Optional[bool] = None,
     skip_wizard: bool = False,
     debug_color: bool = False,
+    tonemap_overrides: Optional[Dict[str, Any]] = None,
 ) -> RunResult:
     """
     Orchestrate the CLI workflow.
@@ -4552,6 +4562,7 @@ def run_cli(
         verbose (bool): Enable additional diagnostic output when True.
         no_color (bool): Disable colored output when True.
         report_enable_override (Optional[bool]): Optional override for HTML report generation toggle.
+        tonemap_overrides (Optional[Dict[str, Any]]): Optional overrides for tone-mapping parameters supplied via CLI.
 
     Returns:
         RunResult: Aggregated result including processed files, selected frames, output directory, resolved root directory, configuration used, generated image paths, optional slow.pics URL, and a JSON-tail dictionary with detailed metadata and diagnostics.
@@ -4570,6 +4581,25 @@ def run_cli(
         skip_auto_wizard=skip_wizard,
     )
     cfg = preflight.config
+    if tonemap_overrides:
+        color_cfg = getattr(cfg, "color", None)
+        if color_cfg is not None:
+            if "preset" in tonemap_overrides:
+                color_cfg.preset = str(tonemap_overrides["preset"])
+            if "tone_curve" in tonemap_overrides:
+                color_cfg.tone_curve = str(tonemap_overrides["tone_curve"])
+            if "target_nits" in tonemap_overrides:
+                color_cfg.target_nits = float(tonemap_overrides["target_nits"])
+            if "dst_min_nits" in tonemap_overrides:
+                color_cfg.dst_min_nits = float(tonemap_overrides["dst_min_nits"])
+            if "knee_offset" in tonemap_overrides:
+                color_cfg.knee_offset = float(tonemap_overrides["knee_offset"])
+            if "dpd_preset" in tonemap_overrides:
+                color_cfg.dpd_preset = str(tonemap_overrides["dpd_preset"])
+            if "post_gamma" in tonemap_overrides:
+                color_cfg.post_gamma = float(tonemap_overrides["post_gamma"])
+            if "post_gamma_enable" in tonemap_overrides:
+                color_cfg.post_gamma_enable = bool(tonemap_overrides["post_gamma_enable"])
     if debug_color:
         try:
             setattr(cfg.color, "debug_color", True)
@@ -5784,9 +5814,15 @@ def run_cli(
         "tone_curve": effective_tonemap.get("tone_curve", cfg.color.tone_curve),
         "dynamic_peak_detection": bool(effective_tonemap.get("dynamic_peak_detection", cfg.color.dynamic_peak_detection)),
         "target_nits": float(effective_tonemap.get("target_nits", cfg.color.target_nits)),
+        "dst_min_nits": float(effective_tonemap.get("dst_min_nits", cfg.color.dst_min_nits)),
+        "knee_offset": float(effective_tonemap.get("knee_offset", getattr(cfg.color, "knee_offset", 0.5))),
+        "dpd_preset": effective_tonemap.get("dpd_preset", getattr(cfg.color, "dpd_preset", "")),
+        "dpd_black_cutoff": float(effective_tonemap.get("dpd_black_cutoff", getattr(cfg.color, "dpd_black_cutoff", 0.0))),
         "verify_luma_threshold": float(cfg.color.verify_luma_threshold),
         "overlay_enabled": bool(cfg.color.overlay_enabled),
         "overlay_mode": overlay_mode_value,
+        "post_gamma": float(getattr(cfg.color, "post_gamma", 1.0)),
+        "post_gamma_enabled": bool(getattr(cfg.color, "post_gamma_enable", False)),
     }
     layout_data["tonemap"] = json_tail["tonemap"]
     json_tail["overlay"] = {
@@ -6307,6 +6343,14 @@ def _run_cli_entry(
     html_report_enable: bool,
     html_report_disable: bool,
     debug_color: bool,
+    tm_preset: str | None,
+    tm_curve: str | None,
+    tm_target: float | None,
+    tm_dst_min: float | None,
+    tm_knee: float | None,
+    tm_dpd_preset: str | None,
+    tm_gamma: float | None,
+    tm_gamma_disable: bool,
 ) -> None:
     """Execute the primary CLI workflow with the provided options."""
 
@@ -6321,6 +6365,28 @@ def _run_cli_entry(
         report_override = False
     else:
         report_override = None
+
+    if tm_gamma_disable and tm_gamma is not None:
+        raise click.ClickException("Cannot use --tm-gamma-disable together with --tm-gamma.")
+
+    tonemap_override: Dict[str, Any] = {}
+    if tm_preset:
+        tonemap_override["preset"] = tm_preset
+    if tm_curve:
+        tonemap_override["tone_curve"] = tm_curve
+    if tm_target is not None:
+        tonemap_override["target_nits"] = tm_target
+    if tm_dst_min is not None:
+        tonemap_override["dst_min_nits"] = tm_dst_min
+    if tm_knee is not None:
+        tonemap_override["knee_offset"] = tm_knee
+    if tm_dpd_preset:
+        tonemap_override["dpd_preset"] = tm_dpd_preset
+    if tm_gamma is not None:
+        tonemap_override["post_gamma"] = tm_gamma
+        tonemap_override["post_gamma_enable"] = True
+    elif tm_gamma_disable:
+        tonemap_override["post_gamma_enable"] = False
 
     preflight_for_write: _PathPreflightResult | None = None
     if write_config:
@@ -6372,6 +6438,7 @@ def _run_cli_entry(
             report_enable_override=report_override,
             skip_wizard=skip_wizard,
             debug_color=debug_color,
+            tonemap_overrides=tonemap_override or None,
         )
     except CLIAppError as exc:
         print(exc.rich_message)
@@ -6566,6 +6633,29 @@ def _run_cli_entry(
     is_flag=True,
     help="Enable colour pipeline debugging (logs plane stats, dumps intermediate PNGs).",
 )
+@click.option("--tm-preset", "tm_preset", default=None, help="Override [color].preset for this run.")
+@click.option("--tm-curve", "tm_curve", default=None, help="Override [color].tone_curve for this run.")
+@click.option("--tm-target", "tm_target", type=float, default=None, help="Override [color].target_nits for this run.")
+@click.option("--tm-dst-min", "tm_dst_min", type=float, default=None, help="Override [color].dst_min_nits for this run.")
+@click.option("--tm-knee", "tm_knee", type=float, default=None, help="Override [color].knee_offset for this run.")
+@click.option(
+    "--tm-dpd-preset",
+    "tm_dpd_preset",
+    default=None,
+    help="Override [color].dpd_preset (off, fast, balanced, high_quality) for this run.",
+)
+@click.option(
+    "--tm-gamma",
+    "tm_gamma",
+    type=float,
+    default=None,
+    help="Override [color].post_gamma and enable post-tonemap gamma lift for this run.",
+)
+@click.option(
+    "--tm-gamma-disable",
+    is_flag=True,
+    help="Disable post-tonemap gamma lift for this run regardless of config.",
+)
 @click.pass_context
 def main(
     ctx: click.Context,
@@ -6584,6 +6674,14 @@ def main(
     html_report_enable: bool,
     html_report_disable: bool,
     debug_color: bool,
+    tm_preset: str | None,
+    tm_curve: str | None,
+    tm_target: float | None,
+    tm_dst_min: float | None,
+    tm_knee: float | None,
+    tm_dpd_preset: str | None,
+    tm_gamma: float | None,
+    tm_gamma_disable: bool,
 ) -> None:
     """Command group entry point that dispatches to subcommands or the default run."""
 
@@ -6602,6 +6700,14 @@ def main(
         "html_report_enable": html_report_enable,
         "html_report_disable": html_report_disable,
         "debug_color": debug_color,
+        "tm_preset": tm_preset,
+        "tm_curve": tm_curve,
+        "tm_target": tm_target,
+        "tm_dst_min": tm_dst_min,
+        "tm_knee": tm_knee,
+        "tm_dpd_preset": tm_dpd_preset,
+        "tm_gamma": tm_gamma,
+        "tm_gamma_disable": tm_gamma_disable,
     }
     params_map = cast(Dict[str, Any], ctx.ensure_object(dict))
     params_map.update(params)
@@ -6632,6 +6738,14 @@ def run_command(ctx: click.Context) -> None:
         html_report_enable=bool(params.get("html_report_enable", False)),
         html_report_disable=bool(params.get("html_report_disable", False)),
         debug_color=bool(params.get("debug_color", False)),
+        tm_preset=params.get("tm_preset"),
+        tm_curve=params.get("tm_curve"),
+        tm_target=params.get("tm_target"),
+        tm_dst_min=params.get("tm_dst_min"),
+        tm_knee=params.get("tm_knee"),
+        tm_dpd_preset=params.get("tm_dpd_preset"),
+        tm_gamma=params.get("tm_gamma"),
+        tm_gamma_disable=bool(params.get("tm_gamma_disable", False)),
     )
 
 

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -2405,12 +2405,14 @@ def _build_legacy_summary_lines(values: Mapping[str, Any], *, emit_json_tail: bo
     tonemap_preset_label = _string(tonemap.get("dpd_preset"), "n/a")
     tonemap_gamma = _format_number(tonemap.get("post_gamma"), ".2f", "1.00")
     gamma_flag = "*" if bool(tonemap.get("post_gamma_enabled")) else ""
+    dpd_enabled = bool(tonemap.get("dpd"))
+    preset_suffix = f" ({tonemap_preset_label})" if dpd_enabled and tonemap_preset_label.lower() != "n/a" else ""
     lines.append(
         "Tonemap: "
         f"{tonemap_curve}@{tonemap_target}nits "
         f"dst_min={tonemap_dst_min} knee={tonemap_knee} "
-        f"dpd={_bool_text(tonemap.get('dynamic_peak_detection'))}"
-        f" ({tonemap_preset_label})  "
+        f"dpd={_bool_text(dpd_enabled)}"
+        f"{preset_suffix}  "
         f"gamma={tonemap_gamma}{gamma_flag}  "
         f"verify≤{_format_number(tonemap.get('verify_luma_threshold'), '.2f', '0.00')}"
     )
@@ -6680,8 +6682,9 @@ def _run_cli_entry(
 @click.option(
     "--tm-dpd-preset",
     "tm_dpd_preset",
+    type=click.Choice(["off", "fast", "balanced", "high_quality"], case_sensitive=False),
     default=None,
-    help="Override [color].dpd_preset (off, fast, balanced, high_quality) for this run.",
+    help="Override [color].dpd_preset.",
 )
 @click.option(
     "--tm-dpd-black-cutoff",

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -4558,8 +4558,8 @@ def _validate_tonemap_overrides(overrides: Mapping[str, Any]) -> None:
             _bad("--tm-dst-min must be >= 0.0")
     if "post_gamma" in overrides:
         gamma_value = float(overrides["post_gamma"])
-        if gamma_value < 0.7 or gamma_value > 1.3:
-            _bad("--tm-gamma should be between 0.7 and 1.3")
+        if gamma_value < 0.9 or gamma_value > 1.1:
+            _bad("--tm-gamma must be between 0.9 and 1.1")
     if "dpd_preset" in overrides:
         dpd_value = str(overrides["dpd_preset"]).strip().lower()
         if dpd_value not in {"off", "fast", "balanced", "high_quality"}:

--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -80,7 +80,12 @@ preset = "reference"
 tone_curve = "bt.2390"
 dynamic_peak_detection = true
 target_nits = 100.0
-dst_min_nits = 0.1
+dst_min_nits = 0.18
+knee_offset = 0.50               # BT.2390 knee parameter (0-1); 0.50 matches the spec.
+dpd_preset = "high_quality"      # Dynamic peak detection preset: off, fast, balanced, high_quality
+dpd_black_cutoff = 0.01          # PQ fraction to ignore during DPD (0-0.05). Ignored when DPD is off.
+post_gamma_enable = false        # Optional limited-range gamma lift after tonemap (Levels min/max 16-235)
+post_gamma = 0.95                # Gamma factor when enabled (0.90-1.10). Stick near 1.0 to avoid haze.
 overlay_enabled = true
 overlay_text_template = "Tonemapping Algorithm: {tone_curve} dpd = {dynamic_peak_detection} dst = {target_nits} nits"
 overlay_mode = "minimal"  # Options: "minimal", "diagnostic"

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -88,7 +88,7 @@ class ColorConfig:
     tone_curve: str = "bt.2390"
     dynamic_peak_detection: bool = True
     target_nits: float = 100.0
-    dst_min_nits: float = 0.1
+    dst_min_nits: float = 0.18
     overlay_enabled: bool = True
     overlay_text_template: str = (
         "Tonemapping Algorithm: {tone_curve} dpd = {dynamic_peak_detection} dst = {target_nits} nits"
@@ -110,6 +110,11 @@ class ColorConfig:
     default_range_sdr: Optional[str] = None
     color_overrides: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     debug_color: bool = False
+    knee_offset: float = 0.5
+    dpd_preset: str = "high_quality"
+    dpd_black_cutoff: float = 0.01
+    post_gamma_enable: bool = False
+    post_gamma: float = 1.0
 
 
 @dataclass

--- a/src/vs_core.py
+++ b/src/vs_core.py
@@ -1497,7 +1497,7 @@ def _resolve_tonemap_settings(cfg: Any) -> TonemapSettings:
     dst_min = float(getattr(cfg, "dst_min_nits", 0.18))
     knee_offset = float(getattr(cfg, "knee_offset", 0.5))
     dpd_preset_value = str(getattr(cfg, "dpd_preset", "high_quality") or "").strip().lower()
-    dpd_black_cutoff = float(getattr(cfg, "dpd_black_cutoff", 0.0))
+    dpd_black_cutoff = float(getattr(cfg, "dpd_black_cutoff", 0.01))
 
     provided = getattr(cfg, "_provided_keys", None)
 
@@ -1870,7 +1870,7 @@ def process_clip_for_screenshot(
         knee_offset=tonemap_settings.knee_offset,
         dpd_preset=tonemap_settings.dpd_preset,
         dpd_black_cutoff=tonemap_settings.dpd_black_cutoff if dpd else 0.0,
-        post_gamma=post_gamma_value,
+        post_gamma=post_gamma_value if post_gamma_cfg_enabled else 1.0,
         post_gamma_enabled=False,
     )
     overlay_text = None
@@ -2033,7 +2033,7 @@ def process_clip_for_screenshot(
         knee_offset=tonemap_settings.knee_offset,
         dpd_preset=tonemap_settings.dpd_preset,
         dpd_black_cutoff=tonemap_settings.dpd_black_cutoff if dpd else 0.0,
-        post_gamma=post_gamma_value if applied_post_gamma else post_gamma_value,
+        post_gamma=post_gamma_value if applied_post_gamma else 1.0,
         post_gamma_enabled=applied_post_gamma,
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,8 +30,14 @@ def test_load_defaults(tmp_path: Path) -> None:
     assert app.color.enable_tonemap is True
     assert app.color.preset == "reference"
     assert app.color.target_nits == 100.0
+    assert app.color.dst_min_nits == 0.18
+    assert app.color.knee_offset == 0.5
+    assert app.color.dpd_preset == "high_quality"
+    assert app.color.dpd_black_cutoff == 0.01
     assert app.color.overlay_enabled is True
     assert app.color.verify_enabled is True
+    assert app.color.post_gamma_enable is False
+    assert app.color.post_gamma == pytest.approx(0.95)
     assert app.source.preferred == "lsmas"
     assert app.tmdb.api_key == ""
     assert app.tmdb.unattended is True
@@ -55,6 +61,11 @@ def test_load_defaults(tmp_path: Path) -> None:
         ("[color]\nverify_luma_threshold = 1.5\n", "color.verify_luma_threshold"),
         ("[color]\nverify_step_seconds = 0\n", "color.verify_step_seconds"),
         ("[color]\ntarget_nits = -10\n", "color.target_nits"),
+        ("[color]\ndst_min_nits = -0.1\n", "color.dst_min_nits"),
+        ("[color]\nknee_offset = 1.5\n", "color.knee_offset"),
+        ("[color]\ndpd_preset = \"invalid\"\n", "color.dpd_preset"),
+        ("[color]\ndpd_black_cutoff = 0.5\n", "color.dpd_black_cutoff"),
+        ("[color]\npost_gamma = 0.5\n", "color.post_gamma"),
         ("[screenshots]\nodd_geometry_policy = \"bogus\"\n", "screenshots.odd_geometry_policy"),
         ("[screenshots]\nrgb_dither = \"invalid\"\n", "screenshots.rgb_dither"),
         ("[source]\npreferred = \"bogus\"\n", "source.preferred"),
@@ -161,3 +172,20 @@ preferred = "ffms2"
     assert app.tmdb.category_preference == "TV"
     assert app.cli.emit_json_tail is False
     assert app.cli.progress.style == "dot"
+
+
+def test_dynamic_peak_detection_override_disables_dpd_fields(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml.template"
+    cfg_path.write_text(
+        """
+[color]
+dynamic_peak_detection = false
+dpd_preset = "high_quality"
+dpd_black_cutoff = 0.02
+        """.strip(),
+        encoding="utf-8",
+    )
+    app = load_config(str(cfg_path))
+    assert app.color.dynamic_peak_detection is False
+    assert app.color.dpd_preset == "off"
+    assert app.color.dpd_black_cutoff == 0.0

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any, ClassVar, Mapping, cast
 
+import click
 import pytest
 from click.testing import CliRunner, Result
 from rich.console import Console
@@ -89,6 +90,23 @@ def test_run_cli_rejects_subpath_escape(
         frame_compare.run_cli("ignored", None, root_override=str(tmp_path))
 
     assert field in str(excinfo.value)
+
+
+def test_validate_tonemap_overrides_accepts_valid_values() -> None:
+    frame_compare._validate_tonemap_overrides(
+        {
+            "knee_offset": 0.5,
+            "dst_min_nits": 0.0,
+            "post_gamma": 0.95,
+            "dpd_preset": "fast",
+            "dpd_black_cutoff": 0.02,
+        }
+    )
+
+
+def test_validate_tonemap_overrides_rejects_invalid_cutoff() -> None:
+    with pytest.raises(click.ClickException):
+        frame_compare._validate_tonemap_overrides({"dpd_black_cutoff": 0.2})
 
 
 def _make_config(input_dir: Path) -> AppConfig:

--- a/tests/test_frame_compare.py
+++ b/tests/test_frame_compare.py
@@ -109,6 +109,21 @@ def test_validate_tonemap_overrides_rejects_invalid_cutoff() -> None:
         frame_compare._validate_tonemap_overrides({"dpd_black_cutoff": 0.2})
 
 
+def test_validate_tonemap_overrides_rejects_bad_knee() -> None:
+    with pytest.raises(click.ClickException):
+        frame_compare._validate_tonemap_overrides({"knee_offset": 1.5})
+
+
+def test_validate_tonemap_overrides_rejects_bad_gamma() -> None:
+    with pytest.raises(click.ClickException):
+        frame_compare._validate_tonemap_overrides({"post_gamma": 1.5})
+
+
+def test_validate_tonemap_overrides_rejects_bad_preset() -> None:
+    with pytest.raises(click.ClickException):
+        frame_compare._validate_tonemap_overrides({"dpd_preset": "turbo"})
+
+
 def _make_config(input_dir: Path) -> AppConfig:
     """
     Builds a test-oriented AppConfig populated with sensible defaults and example overrides.

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -316,7 +316,7 @@ def _stub_process_clip(monkeypatch: pytest.MonkeyPatch) -> None:
     - clip: the passed-in clip
     - overlay_text: None
     - verification: None
-    - tonemap: a vs_core.TonemapInfo indicating an untonemapped SDR source (applied=False, target_nits=100.0, dst_min_nits=0.1, reason="SDR source")
+    - tonemap: a vs_core.TonemapInfo indicating an untonemapped SDR source (applied=False, target_nits=100.0, dst_min_nits=0.18, reason="SDR source")
     - source_props: an empty dict
 
     Parameters:
@@ -337,7 +337,7 @@ def _stub_process_clip(monkeypatch: pytest.MonkeyPatch) -> None:
                 tone_curve=None,
                 dpd=0,
                 target_nits=100.0,
-                dst_min_nits=0.1,
+                dst_min_nits=0.18,
                 src_csp_hint=None,
                 reason="SDR source",
             ),
@@ -529,7 +529,7 @@ def test_generate_screenshots_debug_color_disables_overlays(tmp_path: Path, monk
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -845,7 +845,7 @@ def test_compose_overlay_text_minimal_adds_resolution_and_selection() -> None:
         tone_curve="bt.2390",
         dpd=1,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
     )
 
@@ -896,7 +896,7 @@ def test_compose_overlay_text_minimal_ignores_hdr_details() -> None:
         tone_curve="bt.2390",
         dpd=1,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
     )
 
@@ -926,7 +926,7 @@ def test_compose_overlay_text_diagnostic_appends_required_lines() -> None:
         tone_curve="bt.2390",
         dpd=1,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
     )
     props = {
@@ -960,7 +960,7 @@ def test_compose_overlay_text_skips_hdr_details_for_sdr() -> None:
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -1940,7 +1940,7 @@ def test_save_frame_with_fpng_promotes_subsampled_sdr(
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -2008,7 +2008,7 @@ def test_save_frame_with_fpng_skips_promotion_on_even_geometry(
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -2075,7 +2075,7 @@ def test_geometry_preserves_colour_props(monkeypatch: pytest.MonkeyPatch, tmp_pa
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -2133,7 +2133,7 @@ def test_fpng_respects_limited_export_range(
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -2187,7 +2187,7 @@ def test_overlay_preserves_limited_range_metadata(
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )
@@ -2244,7 +2244,7 @@ def test_overlay_expands_range_when_exporting_full(
         tone_curve=None,
         dpd=0,
         target_nits=100.0,
-        dst_min_nits=0.1,
+        dst_min_nits=0.18,
         src_csp_hint=None,
         reason="SDR source",
     )


### PR DESCRIPTION
  - src/vs_core.py:1348-1915 now feeds libplacebo the new tone_mapping_param, peak_detection_preset, and black_cutoff kwargs with automatic fallback, resolves presets via the new TonemapSettings helper, and inserts a limited-range post-tonemap gamma lift (_apply_post_gamma_levels) before overlays. Overlay formatting accepts {dst_min_nits}, {knee_offset}, {dpd_preset}, {dpd_black_cutoff}, and {post_gamma*} tokens, and TonemapInfo captures the extra metadata.
  - src/datatypes.py:88-118 / src/config_loader.py:305-331 add schema defaults plus validation for dst_min_nits=0.18, knee_offset, dpd_preset, dpd_black_cutoff, and post-gamma controls so invalid values are rejected early.

  CLI, Config, and Layout
  - frame_compare.py adds --tm-* overrides, threads them into run_cli, enriches the JSON tail and summary output with knee/dst_min/dpd/preset/gamma data, and exposes them through the CLI layout.
  - Templates and docs reflect the new defaults


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced tone-mapping controls: BT.2390 knee, dynamic-peak-detection presets, post‑tonemap gamma, new presets, and dst_min_nits default 0.18.
  * Per-run CLI overrides for tonemapping (--tm-* flags) and enhanced overlay/summary display.
  * Compatibility shims to handle varying tonemap backends.

* **Documentation**
  * Expanded tonemapping docs, quick recipes, CLI reference, config/reference tables, and changelog entry.

* **Tests**
  * Added/updated tests for new tonemap fields, validation, and CLI override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->