### PR TITLE
Further slow.pics performance updates  (#145)

### DIFF
--- a/tests/test_slowpics.py
+++ b/tests/test_slowpics.py
@@ -35,16 +35,67 @@ class FakeCookies(dict):
         return dict(self)
 
 
-class FakeSession:
+class SessionRecorder:
+    """Tracks every FakeSession created during a test run."""
+
     def __init__(self, responses: List[FakeResponse], cookies: dict[str, str] | None = None) -> None:
         self._responses = responses
+        self._cookies = cookies
+        self.sessions: List["FakeSession"] = []
+        self.responses_lock = threading.Lock()
+        self.calls: list[dict[str, Any]] = []
+        self.mounts: list[tuple[str, Any]] = []
+        self._calls_lock = threading.Lock()
+        self._mounts_lock = threading.Lock()
+
+    def new_session(self) -> "FakeSession":
+        session_id = len(self.sessions)
+        session = FakeSession(
+            self._responses,
+            self._cookies,
+            session_id=session_id,
+            recorder=self,
+            responses_lock=self.responses_lock,
+        )
+        self.sessions.append(session)
+        return session
+
+    def record_call(self, entry: dict[str, Any]) -> None:
+        with self._calls_lock:
+            self.calls.append(entry)
+
+    def record_mount(self, prefix: str, adapter: Any) -> None:
+        with self._mounts_lock:
+            self.mounts.append((prefix, adapter))
+
+    @property
+    def closed(self) -> bool:
+        if not self.sessions:
+            return False
+        return self.sessions[0].closed
+
+
+class FakeSession:
+    def __init__(
+        self,
+        responses: List[FakeResponse],
+        cookies: dict[str, str] | None = None,
+        *,
+        session_id: int = 0,
+        recorder: SessionRecorder | None = None,
+        responses_lock: threading.Lock | None = None,
+    ) -> None:
+        self._responses = responses
+        self._responses_lock = responses_lock or threading.Lock()
         self.headers: dict[str, str] = {}
-        base = {"XSRF-TOKEN": "token"} if cookies is None else cookies
+        base = {"XSRF-TOKEN": "token"} if cookies is None else dict(cookies)
         self.cookies: FakeCookies = FakeCookies(base)
         self.calls: list[dict[str, Any]] = []
         self.closed = False
         self._lock = threading.Lock()
         self.mounts: list[tuple[str, Any]] = []
+        self._recorder = recorder
+        self._session_id = session_id
 
     def close(self) -> None:
         self.closed = True
@@ -62,14 +113,19 @@ class FakeSession:
         return False
 
     def _next(self) -> FakeResponse:
-        with self._lock:
+        with self._responses_lock:
             if not self._responses:
                 raise AssertionError("Unexpected request: no prepared response")
             return self._responses.pop(0)
 
-    def get(self, url: str, timeout: float | None = None) -> requests.Response:
+    def _record_call(self, entry: dict[str, Any]) -> None:
         with self._lock:
-            self.calls.append({"method": "GET", "url": url, "timeout": timeout})
+            self.calls.append(entry)
+        if self._recorder is not None:
+            self._recorder.record_call(entry)
+
+    def get(self, url: str, timeout: float | None = None) -> requests.Response:
+        self._record_call({"method": "GET", "url": url, "timeout": timeout})
         return self._next()
 
     def post(
@@ -82,33 +138,33 @@ class FakeSession:
         headers: Any | None = None,
         timeout: float | None = None,
     ) -> requests.Response:
-        with self._lock:
-            self.calls.append(
-                {
-                    "method": "POST",
-                    "url": url,
-                    "timeout": timeout,
-                    "json": json,
-                    "files": files,
-                    "data": data,
-                    "headers": headers,
-                }
-            )
+        entry = {
+            "method": "POST",
+            "url": url,
+            "timeout": timeout,
+            "json": json,
+            "files": files,
+            "data": data,
+            "headers": headers,
+        }
+        self._record_call(entry)
         return self._next()
 
     def mount(self, prefix: str, adapter: Any) -> None:
         with self._lock:
             self.mounts.append((prefix, adapter))
+        if self._recorder is not None:
+            self._recorder.record_mount(prefix, adapter)
 
 
 def _install_session(
     monkeypatch: pytest.MonkeyPatch,
     responses: List[FakeResponse],
     cookies: dict[str, str] | None = None,
-) -> FakeSession:
-    session = FakeSession(responses, cookies)
-    monkeypatch.setattr(slowpics.requests, "Session", lambda: session)
-    return session
+) -> SessionRecorder:
+    recorder = SessionRecorder(responses, cookies)
+    monkeypatch.setattr(slowpics.requests, "Session", recorder.new_session)
+    return recorder
 
 
 class DummyEncoder:
@@ -319,6 +375,39 @@ def test_progress_callback_invoked_per_image(tmp_path: Path, monkeypatch: pytest
     )
 
     assert sum(calls) == len(files)
+
+
+def test_worker_sessions_reused_for_multiple_uploads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = SlowpicsConfig(collection_name="ReusePool")
+    files = [
+        _write_image(tmp_path, "10 - ClipA.png"),
+        _write_image(tmp_path, "10 - ClipB.png"),
+        _write_image(tmp_path, "20 - ClipA.png"),
+        _write_image(tmp_path, "20 - ClipB.png"),
+    ]
+    responses = [
+        FakeResponse(200),
+        FakeResponse(
+            200,
+            {"collectionUuid": "abc", "key": "def", "images": [["img1", "img2"], ["img3", "img4"]]},
+        ),
+    ]
+    responses.extend(FakeResponse(200, text="OK") for _ in files)
+    recorder = _install_session(monkeypatch, responses)
+
+    slowpics.upload_comparison([str(path) for path in files], tmp_path, cfg, max_workers=2)
+
+    # requests.Session is called for bootstrap + collection + worker_count sessions
+    assert len(recorder.sessions) == 1 + 1 + min(2, len(files))
+    worker_sessions = recorder.sessions[2:]
+    assert len(worker_sessions) == min(2, len(files))
+    per_session_uploads = [
+        sum(1 for call in session.calls if call["url"].endswith("/upload/image"))
+        for session in worker_sessions
+    ]
+    assert sum(per_session_uploads) == len(files)
+    # At least one worker should handle multiple uploads when there are more jobs than workers.
+    assert any(count >= 2 for count in per_session_uploads)
 
 
 def test_legacy_image_upload_loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
- src/slowpics.py:45 — _SessionPool correctly preallocates the worker-count sessions, guards creation failures with close(), and returns
    sessions via a blocking queue. Using the context manager in _upload_single (src/slowpics.py:327-360) ensures each worker releases its
    session even on exceptions, preventing deadlocks or leaks.
  - src/slowpics.py:341-348 — Upload headers are now drawn from the long-lived sessions so cookies (XSRF token) persist across uploads.
    Because _SessionPool.close() runs after all futures complete, sessions are not closed while still in use.
  - tests/test_slowpics.py:38-149 — The new SessionRecorder maintains a shared response queue with locking, so multiple worker sessions
    consume the prepared responses safely. Existing tests that relied on a single FakeSession now read aggregate data from the recorder while
    still being able to inspect per-session call logs.
  - tests/test_slowpics.py:380-410 — Added regression coverage verifies that requests.Session is only invoked for bootstrap + collection +
    worker_count instances and that each worker handles multiple uploads when jobs exceed workers, demonstrating the absence of per-image session churn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and resource management during concurrent uploads
  * Enhanced error handling and cleanup for multi-threaded upload operations

* **Performance**
  * Optimized session reuse for more efficient concurrent uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->