### PR TITLE
Fix manual offset timing display

### DIFF
--- a/src/frame_compare/alignment_runner.py
+++ b/src/frame_compare/alignment_runner.py
@@ -299,7 +299,7 @@ def apply_audio_alignment(
                 continue
             delta_frames = int(vspreview_reuse[key])
             baseline_value = baseline_map.get(key, int(plan.trim_start))
-            applied_frames = max(0, baseline_value + delta_frames)
+            applied_frames = baseline_value + delta_frames
             plan.trim_start = applied_frames
             plan.has_trim_start_override = (
                 plan.has_trim_start_override or delta_frames != 0

--- a/tests/runner/test_audio_alignment_cli.py
+++ b/tests/runner/test_audio_alignment_cli.py
@@ -436,8 +436,8 @@ def test_run_cli_reuses_vspreview_manual_offsets_when_alignment_disabled(
     manual_offsets = {
         reference_path.name: {
             "status": "manual",
-            "note": "vspreview reference baseline",
-            "frames": 0,
+            "note": "vspreview reference padding",
+            "frames": -3,
         },
         target_path.name: {
             "status": "manual",
@@ -515,13 +515,16 @@ def test_run_cli_reuses_vspreview_manual_offsets_when_alignment_disabled(
     assert init_calls, "Clips should be initialised with trims applied"
     trims_by_path = {Path(path).name: trim for path, trim in init_calls}
     assert trims_by_path[target_path.name] == 8
+    assert trims_by_path[reference_path.name] == -3
     assert cache_probes and cache_probes[0].path == cache_file.resolve()
     assert result.json_tail is not None
     audio_json = _expect_mapping(result.json_tail["audio_alignment"])
     manual_map = cast(dict[str, int], audio_json.get("manual_trim_starts", {}))
     assert manual_map[target_path.name] == 8
+    assert manual_map[reference_path.name] == -3
     offsets_frames = _expect_mapping(audio_json.get("offsets_frames", {}))
     assert offsets_frames.get("Target") == 8
+    assert offsets_frames.get("Reference") == -3
     cache_json = _expect_mapping(result.json_tail["cache"])
     assert cache_json["status"] == "reused"
     analysis_json = _expect_mapping(result.json_tail["analysis"])
@@ -1331,15 +1334,18 @@ def test_vspreview_manual_offsets_negative(tmp_path: Path, monkeypatch: pytest.M
         display,
     )
 
-    assert target_plan.trim_start == 0
-    assert reference_plan.trim_start == 4
-    assert summary.manual_trim_starts[target_path.name] == 0
-    assert summary.vspreview_manual_offsets[reference_path.name] == 4
-    assert summary.vspreview_manual_deltas[target_path.name] == -3
-    assert summary.vspreview_manual_deltas[reference_path.name] == 4
+    assert target_plan.trim_start == -4
+    assert reference_plan.trim_start == 0
+    assert summary.manual_trim_starts[target_path.name] == -4
+    assert summary.vspreview_manual_offsets[reference_path.name] == 0
+    assert summary.vspreview_manual_deltas[target_path.name] == -7
+    assert summary.vspreview_manual_deltas[reference_path.name] == 0
     audio_block = json_tail["audio_alignment"]
-    assert audio_block.get("vspreview_reference_trim") == 4
-    assert any("reference adjustment" in line for line in reporter.lines)
+    manual_map = cast(dict[str, int], audio_block.get("manual_trim_starts", {}))
+    assert manual_map[target_path.name] == -4
+    assert audio_block.get("vspreview_reference_trim") == 0
+    assert not any("reference adjustment" in line for line in reporter.lines)
+    assert any("Target" in line and "-4f" in line for line in display.manual_trim_lines)
 
 def test_vspreview_manual_offsets_multiple_negative(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1405,28 +1411,28 @@ def test_vspreview_manual_offsets_multiple_negative(
         display,
     )
 
-    assert target_a_plan.trim_start == 4
-    assert target_b_plan.trim_start == 0
-    assert reference_plan.trim_start == 2
+    assert target_a_plan.trim_start == 2
+    assert target_b_plan.trim_start == -2
+    assert reference_plan.trim_start == 0
     assert summary.suggestion_mode is False
-    assert summary.manual_trim_starts[target_a_path.name] == 4
-    assert summary.manual_trim_starts[target_b_path.name] == 0
-    assert summary.vspreview_manual_offsets[target_a_path.name] == 4
-    assert summary.vspreview_manual_offsets[target_b_path.name] == 0
-    assert summary.vspreview_manual_offsets[reference_path.name] == 2
-    assert summary.vspreview_manual_deltas[target_a_path.name] == -1
-    assert summary.vspreview_manual_deltas[target_b_path.name] == -5
-    assert summary.vspreview_manual_deltas[reference_path.name] == 2
+    assert summary.manual_trim_starts[target_a_path.name] == 2
+    assert summary.manual_trim_starts[target_b_path.name] == -2
+    assert summary.vspreview_manual_offsets[target_a_path.name] == 2
+    assert summary.vspreview_manual_offsets[target_b_path.name] == -2
+    assert summary.vspreview_manual_offsets[reference_path.name] == 0
+    assert summary.vspreview_manual_deltas[target_a_path.name] == -3
+    assert summary.vspreview_manual_deltas[target_b_path.name] == -7
+    assert summary.vspreview_manual_deltas[reference_path.name] == 0
 
     audio_block = json_tail["audio_alignment"]
     offsets_map = cast(dict[str, int], audio_block.get("vspreview_manual_offsets", {}))
     deltas_map = cast(dict[str, int], audio_block.get("vspreview_manual_deltas", {}))
-    assert offsets_map[target_a_path.name] == 4
-    assert offsets_map[target_b_path.name] == 0
-    assert offsets_map[reference_path.name] == 2
-    assert deltas_map[target_a_path.name] == -1
-    assert deltas_map[target_b_path.name] == -5
-    assert deltas_map[reference_path.name] == 2
+    assert offsets_map[target_a_path.name] == 2
+    assert offsets_map[target_b_path.name] == -2
+    assert offsets_map[reference_path.name] == 0
+    assert deltas_map[target_a_path.name] == -3
+    assert deltas_map[target_b_path.name] == -7
+    assert deltas_map[reference_path.name] == 0
 
     measurements = cast(list[AlignmentMeasurement], captured["measurements"])
     assert {m.file.name for m in measurements} == {


### PR DESCRIPTION
## Summary
- ensure VSPreview's manual offset application always has a usable FPS by falling back to 24000/1001 when clip metadata has not been populated yet, so frame deltas convert into meaningful seconds in the CLI and overlay
- add regression coverage proving manual offsets now emit non-zero second values even when the clips have no FPS hints

## Testing
- `pytest tests/test_vspreview.py -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691705bff9e88321aa68133f4cb02881)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual offset handling: robust FPS validation with a fallback when metadata is missing, consistent offset seconds formatting, allowance of negative trim values (no clamp), and inclusion of reference offsets in output tails and displayed offset lines.

* **Tests**
  * Added and updated tests validating FPS-fallback behavior, negative-trim handling, and updated JSON tail and CLI alignment outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->