### PR TITLE
fix: restore manual offset timing display and HDR tonemapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * restore audio offset hints in CLI/VSPreview when FPS metadata is missing and preserve negative manual trims across summaries/manual prompts
 * preserve HDR tonemapping for negative trims, honor CLI tonemap overrides even under presets, and restore path-based `color_overrides` matching
+* detect HDR clips when only one of `_Primaries`/`_Transfer` or MDL/CLL props are present and backfill BT.2020/ST2084 defaults so libplacebo receives primaries/matrix hints before tonemapping
 
 ## [0.0.2](https://github.com/TJZine/frame-compare/compare/frame-compare-v0.0.1...frame-compare-v0.0.2) (2025-11-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * restore audio offset hints in CLI/VSPreview when FPS metadata is missing and preserve negative manual trims across summaries/manual prompts
+* preserve HDR tonemapping for negative trims, honor CLI tonemap overrides even under presets, and restore path-based `color_overrides` matching
 
 ## [0.0.2](https://github.com/TJZine/frame-compare/compare/frame-compare-v0.0.1...frame-compare-v0.0.2) (2025-11-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* restore audio offset hints in CLI/VSPreview when FPS metadata is missing and preserve negative manual trims across summaries/manual prompts
+
 ## [0.0.2](https://github.com/TJZine/frame-compare/compare/frame-compare-v0.0.1...frame-compare-v0.0.2) (2025-11-13)
 
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -558,3 +558,13 @@
       1 passed in 0.01s
       ```
     - `.venv/bin/pyright --warnings` → `0 errors, 0 warnings, 0 informations`
+- *2025-11-15:* Relaxed HDR source detection and metadata backfill to stop clips with partial HDR props (e.g., only `_Transfer=16` or MDL/CLL stats) from being treated as SDR. `_props_signal_hdr` now treats any HDR primaries/transfer flag or mastering metadata as a usable signal, and `normalise_color_metadata` injects BT.2020/ST2084 defaults (preferring `ColorConfig.default_*_hd` when set) before calling `_apply_frame_props_dict` so libplacebo always receives primaries/matrix hints documented in VapourSynth’s `ModifyFrame` property API (source:https://github.com/vapoursynth/vapoursynth/blob/master/doc/functions/video/modifyframe.rst@2025-11-15T04:07:19Z). This keeps tonemapping engaged even when containers omit `_Primaries`.
+  - `date -u +%Y-%m-%d` → `2025-11-15`
+  - `.venv/bin/pyright --warnings` → `0 errors, 0 warnings, 0 informations`
+  - `.venv/bin/ruff check` → `All checks passed!`
+  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/test_vs_core.py tests/test_screenshot.py` →
+    ```
+    ........................................................................ [ 92%]
+    ......                                                                   [100%]
+    78 passed in 0.10s
+    ```

--- a/src/frame_compare/alignment_helpers.py
+++ b/src/frame_compare/alignment_helpers.py
@@ -1,0 +1,75 @@
+"""Shared helpers for audio-alignment presentation."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from src.audio_alignment import AlignmentMeasurement
+    from src.frame_compare.alignment_runner import AudioAlignmentSummary
+
+
+def _lookup_measurement(
+    summary: "AudioAlignmentSummary",
+    clip_key: str,
+) -> "AlignmentMeasurement | None":
+    for measurement in summary.measurements:
+        file_obj = getattr(measurement, "file", None)
+        if file_obj is None:
+            continue
+        if getattr(file_obj, "name", None) == clip_key:
+            return measurement
+    return None
+
+
+def derive_frame_hint(
+    summary: "AudioAlignmentSummary | None",
+    clip_key: str,
+) -> Optional[int]:
+    """
+    Return the best-effort frame suggestion for *clip_key*.
+
+    Prefers stored suggestions and falls back to deriving one from the raw
+    measurements using reference/target FPS. Returns ``None`` when neither
+    source can provide a reliable value.
+    """
+
+    if summary is None or not clip_key:
+        return None
+
+    stored = summary.suggested_frames.get(clip_key)
+    if stored is not None:
+        try:
+            return int(stored)
+        except (TypeError, ValueError):
+            return None
+
+    measurement = _lookup_measurement(summary, clip_key)
+    if measurement is None:
+        return None
+
+    seconds_value = getattr(measurement, "offset_seconds", None)
+    if seconds_value is None:
+        return None
+
+    fps_value = getattr(measurement, "target_fps", None) or getattr(
+        measurement,
+        "reference_fps",
+        None,
+    )
+    if not fps_value:
+        return None
+
+    try:
+        fps_float = float(fps_value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(fps_float) or fps_float == 0.0:
+        return None
+
+    return int(round(float(seconds_value) * fps_float))
+
+
+__all__ = ["derive_frame_hint"]

--- a/src/frame_compare/alignment_runner.py
+++ b/src/frame_compare/alignment_runner.py
@@ -299,7 +299,7 @@ def apply_audio_alignment(
                 continue
             delta_frames = int(vspreview_reuse[key])
             baseline_value = baseline_map.get(key, int(plan.trim_start))
-            applied_frames = max(0, baseline_value + delta_frames)
+            applied_frames = baseline_value + delta_frames
             plan.trim_start = applied_frames
             plan.has_trim_start_override = (
                 plan.has_trim_start_override or delta_frames != 0

--- a/src/frame_compare/alignment_runner.py
+++ b/src/frame_compare/alignment_runner.py
@@ -27,6 +27,7 @@ import click
 from src import audio_alignment
 from src.datatypes import AppConfig
 from src.frame_compare import vspreview
+from src.frame_compare.alignment_helpers import derive_frame_hint
 from src.frame_compare.cli_runtime import (
     CLIAppError,
     ClipPlan,
@@ -353,7 +354,7 @@ def apply_audio_alignment(
             manual_trim_starts = {
                 plan.path.name: int(plan.trim_start)
                 for plan in plans
-                if plan.trim_start > 0
+                if plan.trim_start != 0
             }
             if manual_trim_starts:
                 for plan in plans:
@@ -720,10 +721,8 @@ def apply_audio_alignment(
             if desired is None:
                 continue
             adjustment = int(desired - baseline)
-            if adjustment < 0:
-                adjustment = 0
             if adjustment:
-                plan.trim_start = max(0, plan.trim_start + adjustment)
+                plan.trim_start = plan.trim_start + adjustment
                 plan.alignment_frames = adjustment
                 plan.alignment_status = statuses.get(plan.path.name, "auto")
             else:
@@ -1327,7 +1326,7 @@ def apply_audio_alignment(
         manual_trim_starts: Dict[str, int] = {}
         if vspreview_enabled:
             for plan in plans:
-                if plan.has_trim_start_override and plan.trim_start > 0:
+                if plan.has_trim_start_override and plan.trim_start != 0:
                     manual_trim_starts[plan.path.name] = int(plan.trim_start)
                     label = plan_labels.get(plan.path, plan.path.name)
                     display_data.manual_trim_lines.append(
@@ -1388,10 +1387,8 @@ def apply_audio_alignment(
             if desired is None:
                 continue
             adjustment = int(desired - baseline)
-            if adjustment < 0:
-                adjustment = 0
             if adjustment:
-                plan.trim_start = max(0, plan.trim_start + adjustment)
+                plan.trim_start = plan.trim_start + adjustment
                 plan.alignment_frames = adjustment
                 plan.alignment_status = statuses.get(plan.path.name, "auto")
             else:
@@ -1460,7 +1457,7 @@ def format_alignment_output(
     audio_block = ensure_audio_alignment_block(json_tail)
 
     vspreview_target_plan: ClipPlan | None = None
-    vspreview_suggested_frames_value = 0
+    vspreview_suggested_frames_value: int | None = None
     vspreview_suggested_seconds_value = 0.0
     if summary is not None:
         for plan in plans:
@@ -1470,7 +1467,7 @@ def format_alignment_output(
             break
         if vspreview_target_plan is not None:
             clip_key = vspreview_target_plan.path.name
-            vspreview_suggested_frames_value = int(summary.suggested_frames.get(clip_key, 0))
+            vspreview_suggested_frames_value = derive_frame_hint(summary, clip_key)
             measurement_seconds: Optional[float] = None
             if summary.measured_offsets:
                 detail = summary.measured_offsets.get(clip_key)
@@ -1487,7 +1484,11 @@ def format_alignment_output(
                 vspreview_suggested_seconds_value = measurement_seconds
 
     json_tail["vspreview_mode"] = vspreview_mode
-    json_tail["suggested_frames"] = int(vspreview_suggested_frames_value)
+    json_tail["suggested_frames"] = (
+        int(vspreview_suggested_frames_value)
+        if vspreview_suggested_frames_value is not None
+        else None
+    )
     json_tail["suggested_seconds"] = float(round(vspreview_suggested_seconds_value, 6))
 
     vspreview_enabled_for_session = _coerce_config_flag(cfg.audio_alignment.use_vspreview)

--- a/src/frame_compare/cli_runtime.py
+++ b/src/frame_compare/cli_runtime.py
@@ -191,7 +191,7 @@ class JsonTail(TypedDict):
     warnings: list[str]
     workspace: dict[str, object]
     vspreview_mode: Optional[str]
-    suggested_frames: int
+    suggested_frames: Optional[int]
     suggested_seconds: float
     vspreview_offer: Optional[dict[str, object]]
 

--- a/src/frame_compare/runner.py
+++ b/src/frame_compare/runner.py
@@ -34,6 +34,7 @@ import src.frame_compare.tmdb_workflow as tmdb_workflow
 import src.frame_compare.vspreview as vspreview_utils
 from src.datatypes import AppConfig
 from src.frame_compare import vs as vs_core
+from src.frame_compare.alignment_helpers import derive_frame_hint
 from src.frame_compare.analysis import (
     CacheLoadResult,
     SelectionDetail,
@@ -421,7 +422,7 @@ def run(request: RunRequest) -> RunResult:
         },
         "warnings": [],
         "vspreview_mode": vspreview_mode_value,
-        "suggested_frames": 0,
+        "suggested_frames": None,
         "suggested_seconds": 0.0,
         "vspreview_offer": None,
     }
@@ -444,7 +445,7 @@ def run(request: RunRequest) -> RunResult:
         "vspreview": {
             "mode": vspreview_mode_value,
             "mode_display": vspreview_mode_display,
-            "suggested_frames": 0,
+            "suggested_frames": None,
             "suggested_seconds": 0.0,
             "script_path": None,
             "script_command": "",
@@ -1027,7 +1028,7 @@ def run(request: RunRequest) -> RunResult:
         reference_label = clip_records[0]["label"]
 
     vspreview_target_plan: ClipPlan | None = None
-    vspreview_suggested_frames_value = 0
+    vspreview_suggested_frames_value: int | None = None
     vspreview_suggested_seconds_value = 0.0
     if alignment_summary is not None:
         for plan in plans:
@@ -1035,9 +1036,7 @@ def run(request: RunRequest) -> RunResult:
                 continue
             vspreview_target_plan = plan
             clip_key = plan.path.name
-            vspreview_suggested_frames_value = int(
-                alignment_summary.suggested_frames.get(clip_key, 0)
-            )
+            vspreview_suggested_frames_value = derive_frame_hint(alignment_summary, clip_key)
             detail = alignment_summary.measured_offsets.get(clip_key)
             if detail and detail.offset_seconds is not None:
                 vspreview_suggested_seconds_value = float(detail.offset_seconds)

--- a/src/frame_compare/runner.py
+++ b/src/frame_compare/runner.py
@@ -125,6 +125,53 @@ class RunRequest:
 logger = logging.getLogger('frame_compare')
 
 
+def _apply_cli_tonemap_overrides(color_cfg: Any, overrides: Mapping[str, Any]) -> None:
+    if color_cfg is None or not overrides:
+        return
+    provided_raw = getattr(color_cfg, "_provided_keys", None)
+    provided: set[str]
+    if isinstance(provided_raw, set):
+        provided = set(cast(set[Any], provided_raw))
+    else:
+        provided = set()
+    updated: set[str] = set()
+
+    def _assign(field: str, converter: Callable[[Any], Any]) -> None:
+        if field in overrides:
+            setattr(color_cfg, field, converter(overrides[field]))
+            updated.add(field)
+
+    _assign("preset", lambda value: str(value))
+    _assign("tone_curve", lambda value: str(value))
+    _assign("target_nits", lambda value: float(value))
+    _assign("dst_min_nits", lambda value: float(value))
+    _assign("knee_offset", lambda value: float(value))
+    _assign("dpd_preset", lambda value: str(value))
+    _assign("dpd_black_cutoff", lambda value: float(value))
+    _assign("post_gamma", lambda value: float(value))
+    _assign("post_gamma_enable", lambda value: bool(value))
+    _assign("smoothing_period", lambda value: float(value))
+    _assign("scene_threshold_low", lambda value: float(value))
+    _assign("scene_threshold_high", lambda value: float(value))
+    _assign("percentile", lambda value: float(value))
+    _assign("contrast_recovery", lambda value: float(value))
+    if "metadata" in overrides:
+        color_cfg.metadata = overrides["metadata"]
+        updated.add("metadata")
+    if "use_dovi" in overrides:
+        color_cfg.use_dovi = overrides["use_dovi"]
+        updated.add("use_dovi")
+    _assign("visualize_lut", lambda value: bool(value))
+    _assign("show_clipping", lambda value: bool(value))
+
+    if updated:
+        provided.update(updated)
+        try:
+            setattr(color_cfg, "_provided_keys", provided)
+        except Exception:
+            pass
+
+
 def run(request: RunRequest) -> RunResult:
     """
     Orchestrate the CLI workflow.
@@ -173,44 +220,7 @@ def run(request: RunRequest) -> RunResult:
     cfg = preflight.config
     if tonemap_overrides:
         core.validate_tonemap_overrides(tonemap_overrides)
-        color_cfg = getattr(cfg, "color", None)
-        if color_cfg is not None:
-            if "preset" in tonemap_overrides:
-                color_cfg.preset = str(tonemap_overrides["preset"])
-            if "tone_curve" in tonemap_overrides:
-                color_cfg.tone_curve = str(tonemap_overrides["tone_curve"])
-            if "target_nits" in tonemap_overrides:
-                color_cfg.target_nits = float(tonemap_overrides["target_nits"])
-            if "dst_min_nits" in tonemap_overrides:
-                color_cfg.dst_min_nits = float(tonemap_overrides["dst_min_nits"])
-            if "knee_offset" in tonemap_overrides:
-                color_cfg.knee_offset = float(tonemap_overrides["knee_offset"])
-            if "dpd_preset" in tonemap_overrides:
-                color_cfg.dpd_preset = str(tonemap_overrides["dpd_preset"])
-            if "dpd_black_cutoff" in tonemap_overrides:
-                color_cfg.dpd_black_cutoff = float(tonemap_overrides["dpd_black_cutoff"])
-            if "post_gamma" in tonemap_overrides:
-                color_cfg.post_gamma = float(tonemap_overrides["post_gamma"])
-            if "post_gamma_enable" in tonemap_overrides:
-                color_cfg.post_gamma_enable = bool(tonemap_overrides["post_gamma_enable"])
-            if "smoothing_period" in tonemap_overrides:
-                color_cfg.smoothing_period = float(tonemap_overrides["smoothing_period"])
-            if "scene_threshold_low" in tonemap_overrides:
-                color_cfg.scene_threshold_low = float(tonemap_overrides["scene_threshold_low"])
-            if "scene_threshold_high" in tonemap_overrides:
-                color_cfg.scene_threshold_high = float(tonemap_overrides["scene_threshold_high"])
-            if "percentile" in tonemap_overrides:
-                color_cfg.percentile = float(tonemap_overrides["percentile"])
-            if "contrast_recovery" in tonemap_overrides:
-                color_cfg.contrast_recovery = float(tonemap_overrides["contrast_recovery"])
-            if "metadata" in tonemap_overrides:
-                color_cfg.metadata = tonemap_overrides["metadata"]
-            if "use_dovi" in tonemap_overrides:
-                color_cfg.use_dovi = tonemap_overrides["use_dovi"]
-            if "visualize_lut" in tonemap_overrides:
-                color_cfg.visualize_lut = bool(tonemap_overrides["visualize_lut"])
-            if "show_clipping" in tonemap_overrides:
-                color_cfg.show_clipping = bool(tonemap_overrides["show_clipping"])
+        _apply_cli_tonemap_overrides(getattr(cfg, "color", None), tonemap_overrides)
     if debug_color:
         try:
             setattr(cfg.color, "debug_color", True)

--- a/src/frame_compare/vs/color.py
+++ b/src/frame_compare/vs/color.py
@@ -69,7 +69,7 @@ def _resolve_configured_color_defaults(
 
 def _resolve_color_overrides(
     color_cfg: "ColorConfig | None",
-    file_name: str | None,
+    file_name: str | Path | None,
 ) -> Dict[str, Optional[int]]:
     if color_cfg is None:
         return {}
@@ -78,9 +78,10 @@ def _resolve_color_overrides(
         return {}
 
     lookup_keys: List[str] = []
-    if file_name:
-        lookup_keys.append(file_name)
-        lookup_keys.append(Path(file_name).name)
+    normalized_name = str(file_name) if file_name else ""
+    if normalized_name:
+        lookup_keys.append(normalized_name)
+        lookup_keys.append(Path(normalized_name).name)
     lookup_keys.append("*")
 
     selected: Dict[str, Any] = {}
@@ -369,7 +370,7 @@ def _adjust_color_range_from_signal(
     *,
     color_range: Optional[int],
     warning_sink: Optional[List[str]],
-    file_name: str | None,
+    file_name: str | Path | None,
     range_inferred: bool,
     range_from_override: bool,
 ) -> Optional[int]:
@@ -419,7 +420,7 @@ def normalise_color_metadata(
     source_props: Mapping[str, Any] | None,
     *,
     color_cfg: "ColorConfig | None" = None,
-    file_name: str | None = None,
+    file_name: str | Path | None = None,
     warning_sink: Optional[List[str]] = None,
 ) -> tuple[
     Any,

--- a/tests/helpers/runner_env.py
+++ b/tests/helpers/runner_env.py
@@ -386,7 +386,7 @@ def _make_json_tail_stub() -> JsonTail:
             "destination_label": "",
         },
         "vspreview_mode": None,
-        "suggested_frames": 0,
+        "suggested_frames": None,
         "suggested_seconds": 0.0,
         "vspreview_offer": None,
     }

--- a/tests/runner/test_audio_alignment_cli.py
+++ b/tests/runner/test_audio_alignment_cli.py
@@ -436,8 +436,8 @@ def test_run_cli_reuses_vspreview_manual_offsets_when_alignment_disabled(
     manual_offsets = {
         reference_path.name: {
             "status": "manual",
-            "note": "vspreview reference baseline",
-            "frames": 0,
+            "note": "vspreview reference padding",
+            "frames": -3,
         },
         target_path.name: {
             "status": "manual",
@@ -515,13 +515,16 @@ def test_run_cli_reuses_vspreview_manual_offsets_when_alignment_disabled(
     assert init_calls, "Clips should be initialised with trims applied"
     trims_by_path = {Path(path).name: trim for path, trim in init_calls}
     assert trims_by_path[target_path.name] == 8
+    assert trims_by_path[reference_path.name] == -3
     assert cache_probes and cache_probes[0].path == cache_file.resolve()
     assert result.json_tail is not None
     audio_json = _expect_mapping(result.json_tail["audio_alignment"])
     manual_map = cast(dict[str, int], audio_json.get("manual_trim_starts", {}))
     assert manual_map[target_path.name] == 8
+    assert manual_map[reference_path.name] == -3
     offsets_frames = _expect_mapping(audio_json.get("offsets_frames", {}))
     assert offsets_frames.get("Target") == 8
+    assert offsets_frames.get("Reference") == -3
     cache_json = _expect_mapping(result.json_tail["cache"])
     assert cache_json["status"] == "reused"
     analysis_json = _expect_mapping(result.json_tail["analysis"])
@@ -1331,15 +1334,18 @@ def test_vspreview_manual_offsets_negative(tmp_path: Path, monkeypatch: pytest.M
         display,
     )
 
-    assert target_plan.trim_start == 0
-    assert reference_plan.trim_start == 4
-    assert summary.manual_trim_starts[target_path.name] == 0
-    assert summary.vspreview_manual_offsets[reference_path.name] == 4
-    assert summary.vspreview_manual_deltas[target_path.name] == -3
-    assert summary.vspreview_manual_deltas[reference_path.name] == 4
+    assert target_plan.trim_start == -4
+    assert reference_plan.trim_start == 0
+    assert summary.manual_trim_starts[target_path.name] == -4
+    assert summary.vspreview_manual_offsets[reference_path.name] == 0
+    assert summary.vspreview_manual_deltas[target_path.name] == -7
+    assert summary.vspreview_manual_deltas[reference_path.name] == 0
     audio_block = json_tail["audio_alignment"]
-    assert audio_block.get("vspreview_reference_trim") == 4
-    assert any("reference adjustment" in line for line in reporter.lines)
+    manual_map = cast(dict[str, int], audio_block.get("manual_trim_starts", {}))
+    assert manual_map[target_path.name] == -4
+    assert audio_block.get("vspreview_reference_trim") == 0
+    assert not any("reference adjustment" in line for line in reporter.lines)
+    assert any("Target" in line and "-4f" in line for line in display.manual_trim_lines)
 
 def test_vspreview_manual_offsets_multiple_negative(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1405,28 +1411,28 @@ def test_vspreview_manual_offsets_multiple_negative(
         display,
     )
 
-    assert target_a_plan.trim_start == 4
-    assert target_b_plan.trim_start == 0
-    assert reference_plan.trim_start == 2
+    assert target_a_plan.trim_start == 2
+    assert target_b_plan.trim_start == -2
+    assert reference_plan.trim_start == 0
     assert summary.suggestion_mode is False
-    assert summary.manual_trim_starts[target_a_path.name] == 4
-    assert summary.manual_trim_starts[target_b_path.name] == 0
-    assert summary.vspreview_manual_offsets[target_a_path.name] == 4
-    assert summary.vspreview_manual_offsets[target_b_path.name] == 0
-    assert summary.vspreview_manual_offsets[reference_path.name] == 2
-    assert summary.vspreview_manual_deltas[target_a_path.name] == -1
-    assert summary.vspreview_manual_deltas[target_b_path.name] == -5
-    assert summary.vspreview_manual_deltas[reference_path.name] == 2
+    assert summary.manual_trim_starts[target_a_path.name] == 2
+    assert summary.manual_trim_starts[target_b_path.name] == -2
+    assert summary.vspreview_manual_offsets[target_a_path.name] == 2
+    assert summary.vspreview_manual_offsets[target_b_path.name] == -2
+    assert summary.vspreview_manual_offsets[reference_path.name] == 0
+    assert summary.vspreview_manual_deltas[target_a_path.name] == -3
+    assert summary.vspreview_manual_deltas[target_b_path.name] == -7
+    assert summary.vspreview_manual_deltas[reference_path.name] == 0
 
     audio_block = json_tail["audio_alignment"]
     offsets_map = cast(dict[str, int], audio_block.get("vspreview_manual_offsets", {}))
     deltas_map = cast(dict[str, int], audio_block.get("vspreview_manual_deltas", {}))
-    assert offsets_map[target_a_path.name] == 4
-    assert offsets_map[target_b_path.name] == 0
-    assert offsets_map[reference_path.name] == 2
-    assert deltas_map[target_a_path.name] == -1
-    assert deltas_map[target_b_path.name] == -5
-    assert deltas_map[reference_path.name] == 2
+    assert offsets_map[target_a_path.name] == 2
+    assert offsets_map[target_b_path.name] == -2
+    assert offsets_map[reference_path.name] == 0
+    assert deltas_map[target_a_path.name] == -3
+    assert deltas_map[target_b_path.name] == -7
+    assert deltas_map[reference_path.name] == 0
 
     measurements = cast(list[AlignmentMeasurement], captured["measurements"])
     assert {m.file.name for m in measurements} == {

--- a/tests/runner/test_cli_entry.py
+++ b/tests/runner/test_cli_entry.py
@@ -33,6 +33,7 @@ from src.datatypes import (
     TMDBConfig,
 )
 from src.frame_compare import runner as runner_module
+from src.frame_compare import vs as vs_core
 from src.frame_compare.analysis import CacheLoadResult, FrameMetricsCacheInfo, SelectionDetail
 from src.frame_compare.cli_runtime import CliOutputManager
 from tests.helpers.runner_env import (
@@ -126,6 +127,21 @@ def test_validate_tonemap_overrides_rejects_bad_preset() -> None:
 def test_validate_tonemap_overrides_rejects_bad_percentile() -> None:
     with pytest.raises(click.ClickException):
         core_module._validate_tonemap_overrides({"percentile": 120.0})
+
+
+def test_cli_tonemap_overrides_mark_provided_keys() -> None:
+    cfg = ColorConfig()
+    cfg.preset = "contrast"
+    setattr(cfg, "_provided_keys", {"preset"})
+
+    runner_module._apply_cli_tonemap_overrides(cfg, {"target_nits": 150.0})
+
+    provided = getattr(cfg, "_provided_keys", set())
+    assert "target_nits" in provided
+
+    settings = vs_core._resolve_tonemap_settings(cfg)
+    assert settings.preset == "contrast"
+    assert settings.target_nits == pytest.approx(150.0)
 
 def test_validate_tonemap_overrides_rejects_scene_range() -> None:
     with pytest.raises(click.ClickException):

--- a/tests/test_vs_core.py
+++ b/tests/test_vs_core.py
@@ -4,7 +4,8 @@ import sys
 import types
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Dict, List, Sequence
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Sequence
 
 import pytest
 
@@ -12,6 +13,8 @@ from src.datatypes import ColorConfig
 from src.frame_compare import vs as vs_core
 from src.frame_compare.vs import VerificationResult
 from src.frame_compare.vs import color as vs_color
+from src.frame_compare.vs import source as vs_source
+from src.frame_compare.vs import tonemap as vs_tonemap
 
 
 @pytest.fixture(autouse=True)
@@ -521,6 +524,91 @@ class _DummyClip:
         self.std = _DummyStd(self)
 
 
+class _PaddingTestFrame:
+    def __init__(self, props: Mapping[str, Any]) -> None:
+        self.props = dict(props)
+
+
+class _PaddingTestClip:
+    def __init__(
+        self,
+        core: "_PaddingCore",
+        frames: Sequence[Mapping[str, Any]],
+        *,
+        height: int = 1080,
+        fps_num: int = 24000,
+        fps_den: int = 1001,
+    ) -> None:
+        self.core = core
+        self.std = core.std
+        self.resize = core.resize
+        self.format = types.SimpleNamespace(color_family=getattr(core.vs_module, "YUV", object()))
+        self.height = height
+        self.fps_num = fps_num
+        self.fps_den = fps_den
+        self._frames = [_PaddingTestFrame(props) for props in frames]
+        self.num_frames = len(self._frames)
+
+    def _copy_frames(self) -> List[Mapping[str, Any]]:
+        return [dict(frame.props) for frame in self._frames]
+
+    def __add__(self, other: "_PaddingTestClip") -> "_PaddingTestClip":
+        return _PaddingTestClip(
+            self.core,
+            self._copy_frames() + other._copy_frames(),
+            height=self.height,
+            fps_num=self.fps_num,
+            fps_den=self.fps_den,
+        )
+
+    def get_frame(self, index: int) -> _PaddingTestFrame:
+        if not self._frames:
+            raise RuntimeError("clip has no frames")
+        idx = min(max(index, 0), len(self._frames) - 1)
+        return self._frames[idx]
+
+    def apply_frame_props(self, props: Mapping[str, Any]) -> None:
+        for frame in self._frames:
+            frame.props.update(props)
+
+
+class _PaddingStd:
+    def __init__(self, core: "_PaddingCore") -> None:
+        self._core = core
+
+    def BlankClip(self, clip: _PaddingTestClip, length: int) -> _PaddingTestClip:
+        return _PaddingTestClip(
+            self._core,
+            [{} for _ in range(length)],
+            height=clip.height,
+            fps_num=clip.fps_num,
+            fps_den=clip.fps_den,
+        )
+
+    def SetFrameProp(self, clip: _PaddingTestClip, **kwargs: Any) -> _PaddingTestClip:
+        clip.apply_frame_props(kwargs)
+        return clip
+
+    def SetFrameProps(self, clip: _PaddingTestClip, **kwargs: Any) -> _PaddingTestClip:
+        clip.apply_frame_props(kwargs)
+        return clip
+
+
+class _PaddingResize:
+    def Spline36(self, clip: _PaddingTestClip, **kwargs: Any) -> _PaddingTestClip:
+        return clip
+
+    def Point(self, clip: _PaddingTestClip, **kwargs: Any) -> _PaddingTestClip:
+        return clip
+
+
+class _PaddingCore:
+    def __init__(self, vs_module: Any) -> None:
+        self.vs_module = vs_module
+        self.std = _PaddingStd(self)
+        self.resize = _PaddingResize()
+
+
 def _install_fake_vs(monkeypatch: Any, **overrides: int) -> Any:
     yuv_family = object()
     attributes = dict(
@@ -631,6 +719,38 @@ def test_normalise_color_metadata_honours_overrides(monkeypatch: Any) -> None:
     assert props["_ColorRange"] == 0
 
 
+def test_normalise_color_metadata_honours_path_overrides(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    fake_vs = _install_fake_vs(monkeypatch)
+    clip = _DummyClip(fake_vs, height=2160)
+    override_path = tmp_path / "shots" / "demo.mkv"
+    cfg = ColorConfig(
+        color_overrides={
+            str(override_path): {
+                "matrix": "bt2020",
+                "primaries": "bt2020",
+                "transfer": "st2084",
+                "range": "full",
+            }
+        }
+    )
+
+    _, props, color_tuple = vs_core.normalise_color_metadata(
+        clip,
+        {},
+        color_cfg=cfg,
+        file_name=override_path,
+    )
+
+    assert color_tuple == (9, 16, 9, 0)
+    assert props["_Matrix"] == 9
+    assert props["_Transfer"] == 16
+    assert props["_Primaries"] == 9
+    assert props["_ColorRange"] == 0
+
+
 def test_normalise_color_metadata_infers_limited_via_signal(monkeypatch: Any) -> None:
     fake_vs = _install_fake_vs(monkeypatch)
     clip = _DummyClip(fake_vs, height=1080)
@@ -670,3 +790,57 @@ def test_normalise_color_metadata_warns_for_mismatched_limited(monkeypatch: Any)
     # Range remains limited but a warning is emitted for the suspicious signal.
     assert props["_ColorRange"] == int(fake_vs.RANGE_LIMITED)
     assert warnings
+
+
+def test_process_clip_tonemaps_after_negative_trim(monkeypatch: Any) -> None:
+    fake_vs = _install_fake_vs(monkeypatch)
+    setattr(fake_vs, "RGB48", object())
+    setattr(fake_vs, "RGB24", object())
+    core = _PaddingCore(fake_vs)
+    hdr_props = {"_Matrix": 9, "_Primaries": 9, "_Transfer": 16, "_ColorRange": 1}
+    clip = _PaddingTestClip(core, [hdr_props])
+    padded = vs_source._extend_with_blank(clip, core, length=2, frame_props=hdr_props)
+
+    def _fake_normalise(
+        clip_obj: Any,
+        props: Mapping[str, Any],
+        **kwargs: Any,
+    ) -> tuple[Any, Mapping[str, Any], tuple[Any, Any, Any, Any]]:
+        return clip_obj, props, (
+            props.get("_Matrix"),
+            props.get("_Transfer"),
+            props.get("_Primaries"),
+            props.get("_ColorRange"),
+        )
+
+    monkeypatch.setattr(vs_tonemap, "normalise_color_metadata", _fake_normalise)
+    monkeypatch.setattr(vs_tonemap, "_normalize_rgb_props", lambda clip_obj, *args, **kwargs: clip_obj)
+    monkeypatch.setattr(vs_tonemap, "_deduce_src_csp_hint", lambda *args, **kwargs: "hdr_hint")
+    monkeypatch.setattr(vs_tonemap, "_tonemap_with_retries", lambda _core, rgb_clip, **kwargs: rgb_clip)
+    monkeypatch.setattr(
+        vs_tonemap,
+        "_detect_rgb_color_range",
+        lambda *args, **kwargs: (getattr(fake_vs, "RANGE_LIMITED"), "plane_stats"),
+    )
+    monkeypatch.setattr(
+        vs_tonemap,
+        "_apply_post_gamma_levels",
+        lambda _core, clip_obj, **kwargs: (clip_obj, False),
+    )
+
+    cfg = ColorConfig()
+    cfg.enable_tonemap = True
+    cfg.overlay_enabled = False
+    cfg.verify_enabled = False
+    cfg.strict = False
+
+    result = vs_core.process_clip_for_screenshot(
+        padded,
+        "hdr_pad.mkv",
+        cfg,
+        enable_overlay=False,
+        enable_verification=False,
+    )
+
+    assert result.tonemap.applied is True
+    assert result.tonemap.reason is None

--- a/tests/test_vspreview.py
+++ b/tests/test_vspreview.py
@@ -64,6 +64,22 @@ def test_render_script_includes_manual_trims(tmp_path: Path) -> None:
     assert "# Suggested delta +3f" in script
 
 
+def test_render_script_marks_missing_frame_hint(tmp_path: Path) -> None:
+    cfg = _make_config(tmp_path)
+    cfg.audio_alignment.use_vspreview = True
+
+    reference = _ClipPlan(path=tmp_path / "Ref.mkv", metadata={"label": "Ref"})
+    target = _ClipPlan(path=tmp_path / "Target.mkv", metadata={"label": "Target"})
+    plans = [reference, target]
+    summary = _make_summary(reference, target, tmp_path)
+    summary.suggested_frames = {}
+
+    script = vspreview_module.render_script(plans, summary, cfg, tmp_path)
+
+    assert "Suggested delta n/a" in script
+    assert "(None, 0.0)" in script
+
+
 def test_persist_vspreview_script_regenerates_filename(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """persist_script should avoid overwriting existing files with deterministic naming."""
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restore audio offset hints when FPS metadata is missing and allow "n/a" suggested frames.
  * Preserve negative manual trims across summaries and displays.
  * Preserve HDR tonemapping after negative trims; honor CLI tonemap overrides even with presets.
  * More robust HDR detection when partial metadata is present; improved path-based color override matching.

* **Documentation**
  * Expanded CHANGELOG and DECISIONS entries documenting these behaviors.

* **Tests**
  * Added regression tests covering audio alignment, manual negative trims, HDR/tonemap, and path-based overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->