### PR TITLE
fix: preserve HDR metadata during negative trim padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ All notable user-visible updates will be documented in this file in reverse chro
 - *2025-10-29:* Clarified the CLI audio alignment panel output (stream summaries, cached reuse messaging, offsets file footer) and aligned documentation; slow.pics shortcut filenames now derive from the sanitised collection name with regression tests for edge cases; README and reference tables updated.
 - *2025-10-22:* Disabled slow.pics auto-upload by default, added an upfront CLI warning when it is enabled, aligned documentation with dataclass defaults, introduced a packaged `frame-compare` console entry point, and wired Ruff linting into CI (Pyright now blocks failures).
 - *2025-10-21:* Prevented VSPreview helper crashes on Windows `cp1252` consoles by sanitising printed arrows to ASCII, preferring UTF-8 output streams, adding regression coverage, and documenting the console behaviour.
+- *2025-11-15:* Preserved HDR frame props by snapshotting them at source load (`ClipPlan.source_frame_props`) and rehydrating them inside `process_clip_for_screenshot`/`generate_screenshots`, so even negatively trimmed clips retain `_Matrix`/`_Transfer`/MasteringDisplay hints and diagnostic overlays continue to show HDR metadata. Added regression tests covering tonemap rehydration and screenshot overlays.
 - *2025-10-20:* Hardened audio alignment's optional dependency handling by surfacing clear `AudioAlignmentError` messages when
   `numpy`, `librosa`, or `soundfile` fail during onset envelope calculation, and refreshed regression coverage for the failure
   path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* hydrate cached `suggested_frames`/`suggested_seconds` when reusing offsets files so CLI+VSPreview keep prior recommendations
 * restore audio offset hints in CLI/VSPreview when FPS metadata is missing and preserve negative manual trims across summaries/manual prompts
 * preserve HDR tonemapping for negative trims, honor CLI tonemap overrides even under presets, and restore path-based `color_overrides` matching
 * detect HDR clips when only one of `_Primaries`/`_Transfer` or MDL/CLL props are present and backfill BT.2020/ST2084 defaults so libplacebo receives primaries/matrix hints before tonemapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * restore audio offset hints in CLI/VSPreview when FPS metadata is missing and preserve negative manual trims across summaries/manual prompts
 * preserve HDR tonemapping for negative trims, honor CLI tonemap overrides even under presets, and restore path-based `color_overrides` matching
 * detect HDR clips when only one of `_Primaries`/`_Transfer` or MDL/CLL props are present and backfill BT.2020/ST2084 defaults so libplacebo receives primaries/matrix hints before tonemapping
+* preserve MasteringDisplay*/ContentLightLevel* metadata when padding negative trims so HDR detection survives blank-prefix extension
 
 ## [0.0.2](https://github.com/TJZine/frame-compare/compare/frame-compare-v0.0.1...frame-compare-v0.0.2) (2025-11-13)
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -568,3 +568,13 @@
     ......                                                                   [100%]
     78 passed in 0.10s
     ```
+- *2025-11-15:* Blank-prefix padding now preserves all HDR hints (matrix/primaries/transfer/color-range plus any MasteringDisplay*/ContentLightLevel* props) when `init_clip` prepends negative trims, ensuring `_props_signal_hdr` still sees the mastering metadata once tonemapping runs. `_collect_blank_extension_props` now filters frame props with `_is_hdr_prop`, consistent with VapourSynth’s documented ability to copy frame properties via `std.SetFrameProp`/`ModifyFrame` (source:https://github.com/vapoursynth/vapoursynth/blob/master/doc/functions/video/modifyframe.rst@2025-11-15T04:07:19Z).
+  - `date -u +%Y-%m-%d` → `2025-11-15`
+  - `.venv/bin/pyright --warnings` → `0 errors, 0 warnings, 0 informations`
+  - `.venv/bin/ruff check` → `All checks passed!`
+  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/test_vs_core.py tests/test_screenshot.py` →
+    ```
+    ........................................................................ [ 90%]
+    ........                                                                 [100%]
+    80 passed in 0.11s
+    ```

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,6 +1,16 @@
 # Decisions Log
 
-# Decisions Log
+- *2025-11-15:* fix(audio): hydrate cached suggested offsets when reusing alignment files.
+  - Problem: declining the recompute prompt reapplied cached trims but dropped any stored `suggested_frames`/`suggested_seconds`, so the CLI JSON tail and VSPreview overlay no longer showed the prior guidance (e.g., `+7f (~0.291s)`), defeating the cache reuse UX.
+  - Decision: parse the cached `suggested_*` fields whenever `_maybe_reuse_cached_offsets()` or the reuse branch in `apply_audio_alignment()` iterate the offsets TOML, populate `summary.suggested_frames` plus `summary.measured_offsets` with those hints, and backstop the flow with a regression test that exercises the CLI formatter.
+  - Verification:
+    - `.venv/bin/pyright --warnings` → `0 errors, 0 warnings, 0 informations`
+    - `.venv/bin/ruff check` → `All checks passed!`
+    - `.venv/bin/pytest -q tests/runner/test_audio_alignment_cli.py` →
+      ```
+      ..........................                                               [100%]
+      26 passed in 19.66s
+      ```
 
 - *2025-11-15:* fix(audio): derive VSPreview frame hints and keep negative manual trims.
   - Problem: Alignment summaries dropped negative `trim_start` overrides and emitted `0f` for suggested offsets whenever FPS metadata was missing, so the CLI/VSPreview overlay misreported `0f (~ -1.335s)` even when the measured seconds were non-zero.

--- a/src/frame_compare/alignment_preview.py
+++ b/src/frame_compare/alignment_preview.py
@@ -118,6 +118,10 @@ def _confirm_alignment_with_screenshots(
     preview_dir = (base_dir / "audio_alignment" / preview_folder).resolve()
 
     initial_frames = _pick_preview_frames(reference_clip, 2, cfg.audio_alignment.random_seed)
+    source_props_seq = [
+        dict(plan.source_frame_props) if plan.source_frame_props is not None else None
+        for plan in plans
+    ]
 
     try:
         generated = generate_screenshots(
@@ -131,6 +135,7 @@ def _confirm_alignment_with_screenshots(
             trim_offsets=[plan.trim_start for plan in plans],
             pivot_notifier=_alignment_pivot_note,
             debug_color=bool(getattr(cfg.color, "debug_color", False)),
+            source_frame_props=source_props_seq,
         )
     except ClipProcessError as exc:
         hint = "Run 'frame-compare doctor' for dependency diagnostics."
@@ -188,6 +193,7 @@ def _confirm_alignment_with_screenshots(
             trim_offsets=[plan.trim_start for plan in plans],
             pivot_notifier=_alignment_pivot_note,
             debug_color=bool(getattr(cfg.color, "debug_color", False)),
+            source_frame_props=source_props_seq,
         )
     except ClipProcessError as exc:
         hint = "Run 'frame-compare doctor' for dependency diagnostics."

--- a/src/frame_compare/alignment_runner.py
+++ b/src/frame_compare/alignment_runner.py
@@ -226,6 +226,47 @@ def apply_audio_alignment(
 
     existing_entries_cache: tuple[str | None, Dict[str, Mapping[str, Any]]] | None = None
 
+    def _safe_float(value: object) -> float | None:
+        if isinstance(value, (int, float)):
+            float_value = float(value)
+            if math.isnan(float_value):
+                return None
+            return float_value
+        return None
+
+    def _safe_int(value: object) -> int | None:
+        if isinstance(value, (int, float)):
+            float_value = float(value)
+            if math.isnan(float_value):
+                return None
+            return int(float_value)
+        return None
+
+    def _extract_suggestion_hints(
+        entries: Mapping[str, Mapping[str, Any]],
+    ) -> Dict[str, tuple[int | None, float | None]]:
+        hints: Dict[str, tuple[int | None, float | None]] = {}
+        for name, entry in entries.items():
+            frames_hint = _safe_int(entry.get("suggested_frames"))
+            seconds_hint = _safe_float(entry.get("suggested_seconds"))
+            if frames_hint is None and seconds_hint is None:
+                continue
+            hints[name] = (frames_hint, seconds_hint)
+        return hints
+
+    def _apply_suggestion_hints_to_details(
+        detail_map: Dict[str, _AudioMeasurementDetail],
+        hints: Mapping[str, tuple[int | None, float | None]],
+    ) -> None:
+        for clip_name, (frames_hint, seconds_hint) in hints.items():
+            detail = detail_map.get(clip_name)
+            if detail is None:
+                continue
+            if frames_hint is not None:
+                detail.frames = int(frames_hint)
+            if seconds_hint is not None:
+                detail.offset_seconds = float(seconds_hint)
+
     def _load_existing_entries() -> tuple[str | None, Dict[str, Mapping[str, Any]]]:
         nonlocal existing_entries_cache
         if existing_entries_cache is None:
@@ -468,22 +509,7 @@ def apply_audio_alignment(
         )
 
         plan_map = plan_lookup
-
-        def _get_float(value: object) -> float | None:
-            if isinstance(value, (int, float)):
-                float_value = float(value)
-                if math.isnan(float_value):
-                    return None
-                return float_value
-            return None
-
-        def _get_int(value: object) -> int | None:
-            if isinstance(value, (int, float)):
-                float_value = float(value)
-                if math.isnan(float_value):
-                    return None
-                return int(float_value)
-            return None
+        suggestion_hints = _extract_suggestion_hints(existing_entries)
 
         reference_entry = existing_entries.get(reference.path.name)
         reference_manual_frames: int | None = None
@@ -492,13 +518,13 @@ def apply_audio_alignment(
             entry = reference_entry
             status_obj = entry.get("status")
             if isinstance(status_obj, str) and status_obj.strip().lower() == "manual":
-                reference_manual_frames = _get_int(entry.get("frames"))
-                reference_manual_seconds = _get_float(entry.get("seconds"))
+                reference_manual_frames = _safe_int(entry.get("frames"))
+                reference_manual_seconds = _safe_float(entry.get("seconds"))
                 if (
                     reference_manual_seconds is None
                     and reference_manual_frames is not None
                 ):
-                    fps_guess = _get_float(reference_entry.get("target_fps")) or _get_float(
+                    fps_guess = _safe_float(reference_entry.get("target_fps")) or _safe_float(
                         reference_entry.get("reference_fps")
                     )
                     if fps_guess and fps_guess > 0:
@@ -510,10 +536,10 @@ def apply_audio_alignment(
 
         def _build_measurement(name: str, entry: Mapping[str, Any]) -> "AlignmentMeasurement":
             plan = plan_map[name]
-            frames_val = _get_int(entry.get("frames")) if entry else None
-            seconds_val = _get_float(entry.get("seconds")) if entry else None
-            target_fps = _get_float(entry.get("target_fps")) if entry else None
-            reference_fps = _get_float(entry.get("reference_fps")) if entry else None
+            frames_val = _safe_int(entry.get("frames")) if entry else None
+            seconds_val = _safe_float(entry.get("seconds")) if entry else None
+            target_fps = _safe_float(entry.get("target_fps")) if entry else None
+            reference_fps = _safe_float(entry.get("reference_fps")) if entry else None
             status_obj = entry.get("status") if entry else None
             is_manual = isinstance(status_obj, str) and status_obj.strip().lower() == "manual"
             if seconds_val is None and frames_val is not None:
@@ -529,7 +555,7 @@ def apply_audio_alignment(
                     fps_val = target_fps if target_fps and target_fps > 0 else reference_fps
                     if fps_val and fps_val > 0:
                         seconds_val = frames_val / fps_val
-            correlation_val = _get_float(entry.get("correlation")) if entry else None
+            correlation_val = _safe_float(entry.get("correlation")) if entry else None
             error_obj = entry.get("error") if entry else None
             error_val = str(error_obj).strip() if isinstance(error_obj, str) and error_obj.strip() else None
             measurement = audio_alignment.AlignmentMeasurement(
@@ -688,20 +714,26 @@ def apply_audio_alignment(
 
         suggested_frames: Dict[str, int] = {}
         for measurement in measurements:
-            frames_value = measurement.frames
-            if frames_value is None:
-                frames_value = _estimate_frames_from_seconds(measurement, plan_map)
-                if frames_value is not None:
-                    measurement.frames = frames_value
+            clip_name = measurement.file.name
+            frames_value: Optional[int] = None
+            cached_hint = suggestion_hints.get(clip_name)
+            if cached_hint and cached_hint[0] is not None:
+                frames_value = int(cached_hint[0])
+            else:
+                frames_value = measurement.frames
+                if frames_value is None:
+                    frames_value = _estimate_frames_from_seconds(measurement, plan_map)
+                    if frames_value is not None:
+                        measurement.frames = frames_value
             if frames_value is not None:
-                suggested_frames[measurement.file.name] = int(frames_value)
+                suggested_frames[clip_name] = int(frames_value)
 
         applied_frames: Dict[str, int] = {}
         statuses: Dict[str, str] = {}
         for name, entry in existing_entries.items():
             if name not in plan_map:
                 continue
-            frames_val = _get_int(entry.get("frames")) if entry else None
+            frames_val = _safe_int(entry.get("frames")) if entry else None
             if frames_val is not None:
                 applied_frames[name] = frames_val
             status_obj = entry.get("status") if entry else None
@@ -761,6 +793,7 @@ def apply_audio_alignment(
             swap_map=swap_details,
             negative_notes=negative_override_notes,
         )
+        _apply_suggestion_hints_to_details(detail_map, suggestion_hints)
         summary.measured_offsets = detail_map
         _emit_measurement_lines(
             detail_map,
@@ -1072,6 +1105,11 @@ def apply_audio_alignment(
     reused_cached = _maybe_reuse_cached_offsets(reference_plan, targets)
     if reused_cached is not None:
         summary = reused_cached
+        try:
+            _, existing_entries = _load_existing_entries()
+        except CLIAppError:
+            existing_entries = {}
+        suggestion_hints = _extract_suggestion_hints(existing_entries)
         detail_map: Dict[str, _AudioMeasurementDetail] = {}
         for plan in plans:
             key = plan.path.name
@@ -1092,6 +1130,11 @@ def apply_audio_alignment(
                 status=summary.statuses.get(key, "manual"),
                 applied=True,
             )
+        _apply_suggestion_hints_to_details(detail_map, suggestion_hints)
+        for name, (frames_hint, _seconds_hint) in suggestion_hints.items():
+            if frames_hint is None:
+                continue
+            summary.suggested_frames[name] = int(frames_hint)
         summary.measured_offsets = detail_map
         display_data.measurements = {
             detail.label: detail for detail in detail_map.values()

--- a/src/frame_compare/alignment_runner.py
+++ b/src/frame_compare/alignment_runner.py
@@ -509,8 +509,6 @@ def apply_audio_alignment(
         )
 
         plan_map = plan_lookup
-        suggestion_hints = _extract_suggestion_hints(existing_entries)
-
         reference_entry = existing_entries.get(reference.path.name)
         reference_manual_frames: int | None = None
         reference_manual_seconds: float | None = None
@@ -714,19 +712,13 @@ def apply_audio_alignment(
 
         suggested_frames: Dict[str, int] = {}
         for measurement in measurements:
-            clip_name = measurement.file.name
-            frames_value: Optional[int] = None
-            cached_hint = suggestion_hints.get(clip_name)
-            if cached_hint and cached_hint[0] is not None:
-                frames_value = int(cached_hint[0])
-            else:
-                frames_value = measurement.frames
-                if frames_value is None:
-                    frames_value = _estimate_frames_from_seconds(measurement, plan_map)
-                    if frames_value is not None:
-                        measurement.frames = frames_value
+            frames_value = measurement.frames
+            if frames_value is None:
+                frames_value = _estimate_frames_from_seconds(measurement, plan_map)
+                if frames_value is not None:
+                    measurement.frames = frames_value
             if frames_value is not None:
-                suggested_frames[clip_name] = int(frames_value)
+                suggested_frames[measurement.file.name] = int(frames_value)
 
         applied_frames: Dict[str, int] = {}
         statuses: Dict[str, str] = {}
@@ -793,7 +785,6 @@ def apply_audio_alignment(
             swap_map=swap_details,
             negative_notes=negative_override_notes,
         )
-        _apply_suggestion_hints_to_details(detail_map, suggestion_hints)
         summary.measured_offsets = detail_map
         _emit_measurement_lines(
             detail_map,

--- a/src/frame_compare/cli_runtime.py
+++ b/src/frame_compare/cli_runtime.py
@@ -59,6 +59,7 @@ class _ClipPlan:
         fps_override (Optional[Tuple[int, int]]): Rational frame-rate override applied during processing.
         use_as_reference (bool): Whether the clip should drive alignment decisions.
         clip (Optional[object]): Lazily populated VapourSynth clip reference.
+        source_frame_props (Optional[Dict[str, Any]]): Snapshot of the source clip's frame props before any trims/padding.
         effective_fps (Optional[Tuple[int, int]]): Frame rate after alignment adjustments.
         applied_fps (Optional[Tuple[int, int]]): Frame rate enforced by user configuration.
         source_fps (Optional[Tuple[int, int]]): Native frame rate detected from the source file.
@@ -78,6 +79,7 @@ class _ClipPlan:
     fps_override: Optional[Tuple[int, int]] = None
     use_as_reference: bool = False
     clip: Optional[object] = None
+    source_frame_props: Optional[Dict[str, Any]] = None
     effective_fps: Optional[Tuple[int, int]] = None
     applied_fps: Optional[Tuple[int, int]] = None
     source_fps: Optional[Tuple[int, int]] = None

--- a/src/frame_compare/runner.py
+++ b/src/frame_compare/runner.py
@@ -809,6 +809,10 @@ def run(request: RunRequest) -> RunResult:
     clips = [plan.clip for plan in plans]
     if any(clip is None for clip in clips):
         raise CLIAppError("Clip initialisation failed")
+    stored_props_seq = [
+        dict(plan.source_frame_props) if plan.source_frame_props is not None else None
+        for plan in plans
+    ]
 
     clip_records: List[ClipRecord] = []
     trim_details: List[TrimSummary] = []
@@ -1615,6 +1619,7 @@ def run(request: RunRequest) -> RunResult:
                     verification_sink=verification_records,
                     pivot_notifier=_notify_pivot,
                     debug_color=bool(getattr(cfg.color, "debug_color", False)),
+                    source_frame_props=stored_props_seq,
                 )
 
                 if processed < total_screens:
@@ -1659,6 +1664,7 @@ def run(request: RunRequest) -> RunResult:
                 verification_sink=verification_records,
                 pivot_notifier=_notify_pivot,
                 debug_color=bool(getattr(cfg.color, "debug_color", False)),
+                source_frame_props=stored_props_seq,
             )
     except ClipProcessError as exc:
         hint = "Run 'frame-compare doctor' for dependency diagnostics."

--- a/src/frame_compare/vs/props.py
+++ b/src/frame_compare/vs/props.py
@@ -286,7 +286,7 @@ def _infer_frame_height(clip: Any, props: Mapping[str, Any]) -> Optional[int]:
     return None
 
 
-def _apply_frame_props_dict(clip: Any, props: Mapping[str, int]) -> Any:
+def _apply_frame_props_dict(clip: Any, props: Mapping[str, Any]) -> Any:
     if not props:
         return clip
     std_ns = getattr(clip, "std", None)

--- a/src/frame_compare/vs/source.py
+++ b/src/frame_compare/vs/source.py
@@ -324,8 +324,14 @@ def init_clip(
     cache_dir: Optional[str | Path] = None,
     core: Optional[Any] = None,
     indexing_notifier: Optional[Callable[[str], None]] = None,
+    frame_props_sink: Optional[Callable[[Mapping[str, Any]], None]] = None,
 ) -> Any:
-    """Initialise a VapourSynth clip for subsequent processing."""
+    """
+    Initialise a VapourSynth clip for subsequent processing and optionally snapshot source frame props.
+
+    When ``frame_props_sink`` is provided it will be invoked exactly once with a dictionary of frame
+    properties captured before any trims or padding are applied so callers can persist HDR metadata.
+    """
 
     resolved_core = _resolve_core(core)
 
@@ -348,8 +354,18 @@ def init_clip(
     except Exception as exc:  # pragma: no cover - defensive
         raise ClipInitError(f"Failed to open clip '{path}': {exc}") from exc
 
+    try:
+        source_frame_props = dict(_snapshot_frame_props(clip))
+    except Exception:
+        source_frame_props = {}
+    if frame_props_sink is not None:
+        try:
+            frame_props_sink(dict(source_frame_props))
+        except Exception:
+            logger.debug("Failed to record source frame props for %s", path)
+
     if trim_start < 0:
-        padding_props = _collect_blank_extension_props(_snapshot_frame_props(clip))
+        padding_props = _collect_blank_extension_props(source_frame_props)
         clip = _extend_with_blank(
             clip,
             resolved_core,

--- a/src/frame_compare/vs/source.py
+++ b/src/frame_compare/vs/source.py
@@ -18,16 +18,7 @@ _SOURCE_PLUGIN_FUNCS = {"lsmas": "LWLibavSource", "ffms2": "Source"}
 
 
 _CACHE_SUFFIX = {"lsmas": ".lwi", "ffms2": ".ffindex"}
-_BLANK_CLONE_PROP_KEYS = (
-    "_Matrix",
-    "Matrix",
-    "_Primaries",
-    "Primaries",
-    "_Transfer",
-    "Transfer",
-    "_ColorRange",
-    "ColorRange",
-)
+_HDR_PROP_BASE_NAMES = {"matrix", "primaries", "transfer", "colorrange"}
 
 
 class VSPluginError(ClipInitError):
@@ -377,10 +368,17 @@ def init_clip(
 
 def _collect_blank_extension_props(frame_props: Mapping[str, Any]) -> Dict[str, Any]:
     extracted: Dict[str, Any] = {}
-    for key in _BLANK_CLONE_PROP_KEYS:
-        if key in frame_props:
-            extracted[key] = frame_props[key]
+    for key, value in frame_props.items():
+        if _is_hdr_prop(key):
+            extracted[key] = value
     return extracted
+
+
+def _is_hdr_prop(key: str) -> bool:
+    normalized = key.lstrip("_").lower()
+    if normalized in _HDR_PROP_BASE_NAMES:
+        return True
+    return normalized.startswith("masteringdisplay") or normalized.startswith("contentlightlevel")
 
 __all__ = [
     "VSPluginError",

--- a/tests/test_vs_core.py
+++ b/tests/test_vs_core.py
@@ -978,3 +978,65 @@ def test_process_clip_tonemaps_with_mastering_metadata_only(monkeypatch: Any) ->
 
     assert result.tonemap.applied is True
     assert result.tonemap.reason is None
+
+
+def test_process_clip_rehydrates_mastering_metadata_from_plan(monkeypatch: Any) -> None:
+    fake_vs = _install_fake_vs(monkeypatch)
+    setattr(fake_vs, "RGB48", object())
+    setattr(fake_vs, "RGB24", object())
+    core = _PaddingCore(fake_vs)
+    clip = _PaddingTestClip(core, [{}])
+    stored_props = {
+        "_MasteringDisplayMinLuminance": 0.005,
+        "_MasteringDisplayMaxLuminance": 1500,
+    }
+
+    def _fake_normalise(
+        clip_obj: Any,
+        props: Mapping[str, Any],
+        **kwargs: Any,
+    ) -> tuple[Any, Mapping[str, Any], tuple[Any, Any, Any, Any]]:
+        normalized_props = dict(props)
+        normalized_props.setdefault("_Matrix", 9)
+        normalized_props.setdefault("_Transfer", 16)
+        normalized_props.setdefault("_Primaries", 9)
+        normalized_props.setdefault("_ColorRange", int(getattr(fake_vs, "RANGE_LIMITED")))
+        return clip_obj, normalized_props, (
+            normalized_props.get("_Matrix"),
+            normalized_props.get("_Transfer"),
+            normalized_props.get("_Primaries"),
+            normalized_props.get("_ColorRange"),
+        )
+
+    monkeypatch.setattr(vs_tonemap, "normalise_color_metadata", _fake_normalise)
+    monkeypatch.setattr(vs_tonemap, "_normalize_rgb_props", lambda clip_obj, *args, **kwargs: clip_obj)
+    monkeypatch.setattr(vs_tonemap, "_deduce_src_csp_hint", lambda *args, **kwargs: "hdr_hint")
+    monkeypatch.setattr(vs_tonemap, "_tonemap_with_retries", lambda _core, rgb_clip, **kwargs: rgb_clip)
+    monkeypatch.setattr(
+        vs_tonemap,
+        "_detect_rgb_color_range",
+        lambda *args, **kwargs: (getattr(fake_vs, "RANGE_LIMITED"), "plane_stats"),
+    )
+    monkeypatch.setattr(
+        vs_tonemap,
+        "_apply_post_gamma_levels",
+        lambda _core, clip_obj, **kwargs: (clip_obj, False),
+    )
+
+    cfg = ColorConfig()
+    cfg.enable_tonemap = True
+    cfg.overlay_enabled = False
+    cfg.verify_enabled = False
+    cfg.strict = False
+
+    result = vs_core.process_clip_for_screenshot(
+        clip,
+        "rehydrated_hdr.mkv",
+        cfg,
+        enable_overlay=False,
+        enable_verification=False,
+        stored_source_props=stored_props,
+    )
+
+    assert result.tonemap.applied is True
+    assert result.tonemap.reason is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HDR metadata preservation when applying negative trims and padding operations.
  * Fixed caching of frame and offset recommendations to persist across CLI and preview sessions.

* **Tests**
  * Added regression tests for HDR metadata rehydration during screenshot generation.
  * Added tests validating cached recommendations are properly restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->