### PR TITLE
fix: guard tonemap CLI overrides from implicit defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Bug Fixes
 
+* guard tonemap CLI overrides so Click `default_map`/env-provided values defer to config until a `--tm-*` flag is provided, and extend CLI regression tests for `--tm-target` plus overlay/verify telemetry
 * keep release-please commits passing commitlint by forcing `chore(ci): release…` pull-request titles
 * prevent the Click CLI from forcing Dolby Vision tonemapping off unless `--tm-use-dovi`/`--tm-no-dovi` is explicitly provided so CLI and direct runs agree
 * ensure tonemap presets override template defaults when configs match reference values and expose preset matrices/comments in `config.toml.template`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Bug Fixes
 
+* gate every non-`--tm-*` CLI override (paths/cache/report/audio/debug flags) on explicit command-line sources so `frame_compare.run_cli` and the Click entrypoint respect config precedence, and fix `json_tail.render.writer` so debug-color runs accurately report the VS fallback (tests/runner/test_cli_entry.py)
 * guard tonemap CLI overrides so Click `default_map`/env-provided values defer to config until a `--tm-*` flag is provided, and extend CLI regression tests for `--tm-target` plus overlay/verify telemetry
 * keep release-please commits passing commitlint by forcing `chore(ci): release…` pull-request titles
 * prevent the Click CLI from forcing Dolby Vision tonemapping off unless `--tm-use-dovi`/`--tm-no-dovi` is explicitly provided so CLI and direct runs agree
@@ -47,8 +48,10 @@
 
 ### Chores
 
+- *2025-11-18:* document the Phase 3–6 Track B flag/config review (Screenshots → TMDB domains), check off the Global Invariants in `docs/refactor/flag_audit.md`, and log the verification commands in `docs/DECISIONS.md`.
 - *2025-11-18:* add a `FRAME_COMPARE_DOVI_DEBUG` telemetry mode that emits JSON-formatted logs from both the runner and VapourSynth tonemap resolver so entrypoints can compare config roots, cache status, tonemap overrides, and brightness-affecting parameters when diagnosing DOVI drift.
 - *2025-11-18:* convert the docs/refactor/flag_audit.md template placeholders into ATX headings with per-track prefixes so markdownlint (MD003/MD024) passes and rendered navigation stays unique.
+- *2025-11-18:* document the Phase 1–2 config/tonemap audit review results in `docs/refactor/flag_audit.md` (A3/B4) and `docs/DECISIONS.md`, confirming Click CLI vs `frame_compare.run_cli` parity for DoVi and tonemap overrides.
 
 ## [0.0.2](https://github.com/TJZine/frame-compare/compare/frame-compare-v0.0.1...frame-compare-v0.0.2) (2025-11-13)
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,5 +1,29 @@
 # Decisions Log
 
+- *2025-11-18:* chore(review): sign off Track B Phases 3–6 config + flag invariants.
+  - Problem: The remaining domains in docs/refactor/flag_audit.md (Screenshots/Render through TMDB/Source/Runtime) still needed a review agent to confirm “config wins unless a CLI flag explicitly overrides” and to fill the Track B → B4 + Global Invariants sections before Phase 2 could close.
+  - Decision: Compared each B3 checklist against the implemented behaviour in `frame_compare.py` and `src/frame_compare/runner.py` (writer selection, cache probes, audio-alignment JSON seeds, HTML report/slow.pics handling, path precedence, TMDB/runtime flags) plus the regression suites in `tests/runner/test_cli_entry.py`, `tests/runner/test_audio_alignment_cli.py`, and `tests/runner/test_dovi_flags.py`. Updated docs/refactor/flag_audit.md to capture per-domain findings, checked all Global Invariant checkboxes, and noted that README.md + CHANGELOG.md already describe the precedence rules.
+  - Verification:
+    - `./.venv/bin/pyright --warnings`
+    - `./.venv/bin/ruff check`
+    - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/pytest -q tests/runner/test_cli_entry.py tests/runner/test_audio_alignment_cli.py tests/runner/test_dovi_flags.py`
+
+- *2025-11-18:* chore(audit): review Phase 1–2 config inventory and tonemap overrides.
+  - Problem: Phase 1 (schema/load/CLI inventory) and Phase 2 (color/tonemap/DoVi) fixes needed verification that docs, code, and CLI behaviour now align and that “flag not passed” truly preserves config values.
+  - Decision: Cross-checked the Track B inventory against `src/datatypes.py` and `src/frame_compare/preflight.py`, then validated `_cli_override_value()`/`_run_cli_entry()`/`runner.run()` so tonemap overrides only apply when Click reports `ParameterSource.COMMANDLINE`—per Click’s own guidance on `Context.get_parameter_source` (source:https://github.com/pallets/click/blob/main/docs/commands-and-groups.rst@2025-11-18T10:57:24Z via Context7). Recorded the review outcome in `docs/refactor/flag_audit.md` (A3/B4) and confirmed overlay/verify telemetry still mirrors config defaults in both entrypoints.
+  - Verification:
+    - `.venv/bin/pyright --warnings`
+    - `.venv/bin/ruff check`
+    - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/runner/test_dovi_flags.py`
+
+- *2025-11-18:* fix(cli): extend default-map guards beyond tonemap and keep render metadata honest under debug fallbacks.
+  - Problem: Even after the tonemap fixes, Click `default_map` values for path/cache/report/audio flags plus `--debug-color` still reached `_run_cli_entry()`, overriding config-driven behaviour and diverging `frame_compare.run_cli` from the Click CLI. Additionally, the JSON `render.writer` field stayed `ffmpeg` whenever `[screenshots].use_ffmpeg` was true, even though debug-color runs force VapourSynth rendering.
+  - Decision: Introduced `_cli_flag_value()` so boolean options honour Click’s documented parameter-source semantics (source:https://github.com/pallets/click/blob/main/docs/commands-and-groups.rst@2025-11-18T12:10:00Z via Context7) and wired it up for `--root/--config/--input`, cache toggles, HTML-report flags, audio-track overrides, and `--debug-color`. Updated `runner.py` to derive the render writer from both `[screenshots].use_ffmpeg` and the effective debug flag so JSON tails reflect the actual renderer. Logged the audit + verification steps in `docs/refactor/flag_audit.md` (Track B → B2/B3) and `CHANGELOG.md`.
+  - Verification:
+    - `./.venv/bin/pyright --warnings`
+    - `./.venv/bin/ruff check`
+    - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/pytest -q tests/runner`
+
 - *2025-11-18:* fix(cli): ignore Click `default_map`/env-provided tonemap defaults unless the user passes a `--tm-*` flag.
   - Problem: `CliRunner` populates Click defaults via `default_map`/environment, so `frame_compare.main` kept treating inherited values as CLI overrides and overwrote `[color]` config even when the user never opted in.
   - Decision: Added `_cli_override_value()` so `_run_cli_entry()` only forwards tonemap overrides when `ctx.get_parameter_source(name)` reports `COMMANDLINE`, per the Click docs (source:https://github.com/pallets/click/blob/main/docs/commands-and-groups.rst@2025-11-18T08:28:30Z). Refreshed `tests/runner/test_dovi_flags.py` with new `CliRunner` width hints to keep Rich from wrapping JSON, plus coverage for `--tm-target`, default-map inheritance, and overlay/verify telemetry.

--- a/docs/refactor/flag_audit.md
+++ b/docs/refactor/flag_audit.md
@@ -51,11 +51,26 @@
 
 ### A1. Inventory & Baseline
 
-- [ ] List `[color]` fields from config schema.
-- [ ] List all `--tm-*` CLI flags and how they map into `tonemap_overrides`.
-- [ ] Confirm current DoVi behaviour:
-  - [ ] Direct `run_cli` path.
-  - [ ] Click CLI path.
+- [x] List `[color]` fields from config schema.
+- [x] List all `--tm-*` CLI flags and how they map into `tonemap_overrides`.
+- [x] Confirm current DoVi behaviour:
+  - [x] Direct `run_cli` path.
+  - [x] Click CLI path. (Covered by `tests/runner/test_dovi_flags.py` default/explicit flag cases.)
+
+#### `[color]` schema snapshot
+
+- Tonemap core: `enable_tonemap`, `preset`, `tone_curve`, `dynamic_peak_detection`, `target_nits`, `dst_min_nits`, `knee_offset`, `dpd_preset`, `dpd_black_cutoff`.
+- Per-frame tuning: `post_gamma_enable`, `post_gamma`, `smoothing_period`, `scene_threshold_low`, `scene_threshold_high`, `percentile`, `contrast_recovery`.
+- Metadata and HDR toggles: `metadata`, `use_dovi`, `visualize_lut`, `show_clipping`, `dynamic_peak_detection` (stored twice as `dpd`/`dynamic_peak_detection` in JSON tail for CLI layout folding).
+- Overlay controls: `overlay_enabled`, `overlay_mode`, `overlay_text_template`.
+- Verification controls: `verify_enabled`, `verify_frame`, `verify_auto`, `verify_start_seconds`, `verify_step_seconds`, `verify_max_seconds`, `verify_luma_threshold`, `strict`.
+- Debug/defaulting helpers: `default_matrix_hd/sd`, `default_primaries_hd/sd`, `default_transfer_sdr`, `default_range_sdr`, `color_overrides`, `debug_color`.
+
+#### CLI `--tm-*` surface → `tonemap_overrides[...]`
+
+- Scalar overrides map 1:1 to color config fields: `--tm-preset`, `--tm-curve`, `--tm-target` → `target_nits`, `--tm-dst-min`, `--tm-knee`, `--tm-dpd-preset`, `--tm-dpd-black-cutoff`, `--tm-gamma` (pairs with `--tm-gamma-disable` to flip `post_gamma_enable`), `--tm-smoothing`, `--tm-scene-low`, `--tm-scene-high`, `--tm-percentile`, `--tm-contrast`, `--tm-metadata`.
+- Tri-state toggles write explicit booleans only when the user passes a flag: `--tm-use-dovi/--tm-no-dovi` → `use_dovi`, `--tm-visualize-lut/--tm-no-visualize-lut` → `visualize_lut`, `--tm-show-clipping/--tm-no-show-clipping` → `show_clipping`.
+- `_run_cli_entry()` coalesces all of the above into a `tonemap_override` dict that feeds `runner.run(request)`; direct `frame_compare.run_cli(..., tonemap_overrides=None)` matches the unmodified config path.
 
 #### DV sanity commands (reference)
 
@@ -91,21 +106,21 @@ Use these commands to compare direct vs Click CLI behaviour for a given config:
 ### A2. Implementation Notes (Dev Agent)
 
 - Summary of changes:
-  - [ ] `tm_use_dovi`, `tm_visualize_lut`, `tm_show_clipping` only override when flags are explicitly passed (use Click `ParameterSource`).
-  - [ ] Any similar tri-state flags updated to follow the same pattern.
+  - [x] `tm_use_dovi`, `tm_visualize_lut`, `tm_show_clipping` only override when flags are explicitly passed (use Click `ParameterSource`).
+  - [x] Any similar tri-state flags updated to follow the same pattern.
 - Tests added/updated:
-  - [ ] `tests/runner/test_dovi_flags.py` (or similar).
-  - [ ] Any snapshot/JSON-tail tests that assert `use_dovi` behaviour.
+  - [x] `tests/runner/test_dovi_flags.py` (or similar).
+  - [x] Any snapshot/JSON-tail tests that assert `use_dovi` behaviour.
 - Commands run:
-  - [ ] `.venv/Scripts/pyright --warnings`
-  - [ ] `.venv/Scripts/ruff check`
-  - [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/Scripts/pytest -q tests/runner/test_dovi_flags.py`
+  - [x] `.venv/Scripts/pyright --warnings`
+  - [x] `.venv/Scripts/ruff check`
+  - [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/Scripts/pytest -q tests/runner/test_dovi_flags.py`
 
 #### A2 Notes
 
-- Date:
-- Dev Agent:
-- Short summary of scenarios tested and results.
+- Date: 2025-11-18
+- Dev Agent: Codex (implementation persona)
+- Short summary: Introduced `_cli_override_value()` so every `--tm-*` option defers to config unless `ctx.get_parameter_source()` reports a real CLI flag, matching the tested DoVi behaviour for default-map runs while still allowing explicit overrides. Extended `tests/runner/test_dovi_flags.py` to cover default-map vs `--tm-target` flags plus overlay/verify JSON-tail parity so regression tests capture the end-to-end tonemap/overlay surfaces.
 
 ### A3. Review Notes (Review Agent)
 
@@ -138,14 +153,46 @@ Use these commands to compare direct vs Click CLI behaviour for a given config:
 
 ### B1. Schema & Load Path
 
-- [ ] Enumerate `AppConfig` and sub-configs (Analysis, Screenshots, AudioAlignment, Slowpics, Report, Paths, Runtime, Overrides, Source, TMDB, CLI).
-- [ ] Document how `load_config` and `prepare_preflight` resolve:
-  - [ ] Config path.
-  - [ ] Workspace root.
-  - [ ] Input dir.
-  - [ ] Legacy config.
+- [x] Enumerate `AppConfig` and sub-configs (Analysis, Screenshots, AudioAlignment, Slowpics, Report, Paths, Runtime, Overrides, Source, TMDB, CLI).
+- [x] Document how `load_config` and `prepare_preflight` resolve:
+  - [x] Config path.
+  - [x] Workspace root.
+  - [x] Input dir.
+  - [x] Legacy config.
+
+#### AppConfig section inventory (source: `src/datatypes.py`)
+
+- **`[analysis]`** – dark/bright/motion frame counts, random sampling, downscale resolution, frame-step, SDR analysis toggle, thresholds (mode + quantiles/ranges), motion heuristics, windowing, frame-data filename, ignore-lead/trail windows.
+- **`[screenshots]`** – `directory_name`, `use_ffmpeg`, `add_frame_info`, `single_res`, `upscale`, `mod_crop`, letterbox handling (`auto_letterbox_crop`, `pad_to_canvas`, `center_pad`, `letterbox_px_tolerance`, `letterbox_pillarbox_aware`), `compression_level`, `ffmpeg_timeout_seconds`, `odd_geometry_policy`, `rgb_dither`, `export_range`.
+- **`[color]`** – tonemap, overlay, verification, and DoVi controls (full list captured in Track A → A1).
+- **`[audio_alignment]`** – enable flag, reference clip label, VSPreview toggles/mode, prompt reuse, STFT parameters (`sample_rate`, `hop_length`), optional start/duration, `correlation_threshold`, `max_offset_seconds`, offsets filename, preview confirmations, `random_seed`, `frame_offset_bias`.
+- **`[slowpics]`** – upload automation options (`auto_upload`, privacy, `collection_name/suffix`, `tmdb_id/category`), lifecycle toggles (`remove_after_days`, `delete_screen_dir_after_upload`), webhook + timeout knobs, open-in-browser + shortcut toggles.
+- **`[report]`** – HTML report gating (`enable`, `open_after_generate`), `output_dir`, `title`, default labels, metadata verbosity, thumbnail height, slider/overlay default mode.
+- **`[paths]`** – `input_dir` root (relative to workspace by default).
+- **`[runtime]`** – `ram_limit_mb`, extra `vapoursynth_python_paths`.
+- **`[overrides]`** – clip-specific `trim`, `trim_end`, `change_fps` dictionaries.
+- **`[source]`** – preferred VapourSynth source plugin (`lsmas` vs `ffms2`).
+- **`[tmdb]`** – API key, unattended flag, confirmation behaviour, `year_tolerance`, anime parsing, cache TTL/size, optional `category_preference`.
+- **`[cli]`** – `emit_json_tail` plus nested `progress.style`.
+- **`[naming]`** – filename parsing toggles (`always_full_filename`, `prefer_guessit`).
+
+#### Config loader + preflight notes (sources: `src/config_loader.py`, `src/frame_compare/preflight.py`)
+
+- **Workspace root precedence**: `--root` CLI arg ➜ `FRAME_COMPARE_ROOT` ➜ sentinel discovery (walk up until `pyproject.toml`, `.git`, or `comparison_videos` found) ➜ current working directory. `resolve_workspace_root()` throws if the resolved path sits under `site-packages`.
+- **Config path resolution**: `--config` ➜ `FRAME_COMPARE_CONFIG` ➜ `<workspace>/config/config.toml`. `_seed_default_config()` writes `config/config.toml` from the packaged template when `ensure_config=True` and nothing exists. Legacy `<workspace>/config.toml` still loads but `prepare_preflight()` appends a warning encouraging migration.
+- **Media/input directory**: CLI `--input` overrides `[paths].input_dir`, otherwise `resolve_subdir()` expands the configured value relative to the workspace input root (unless CLI forced an absolute path). The helper rejects paths that escape the workspace.
+- **Environment toggles**: `FRAME_COMPARE_NO_WIZARD` skips the auto-wizard for fresh workspaces, `FRAME_COMPARE_CONFIG`/`FRAME_COMPARE_ROOT` act as documented above.
+- **`load_config()` coercions**: normalises booleans/enums, clamps tonemap values (gamma, knee, dpd cutoff), parses metadata (`auto`, named HDR formats, or ints 0–4), ensures `[report].output_dir` stays relative, validates audio alignment ranges, and tracks `_provided_keys` on each dataclass so tonemap presets know which fields the user explicitly set.
 
 ### B2. Domain Checklists
+
+#### CLI flag catalog (non-`--tm-*`)
+
+- **Path + config**: `--root`, `--config`, `--input` feed directly into `prepare_preflight()` (root override ➜ workspace discovery ➜ config path ➜ media root). `--diagnose-paths` short-circuits the run to print `collect_path_diagnostics()`. `--write-config`/`--no-wizard` control config seeding/autowizard.
+- **Cache / render toggles**: `--no-cache` (force recompute), `--from-cache-only` (serve snapshots, error when cache missing), `--show-partial`, paired `--show-missing/--hide-missing` (propagate to `RunRequest.show_{partial,missing}_sections`), `--no-color`, `--quiet`, `--verbose`, `--json-pretty`.
+- **Report + slow.pics**: `--html-report` / `--no-html-report` toggle `report_enable_override`, `--debug-color` injects `cfg.color.debug_color=True`, and slow.pics automation inherits `[slowpics]` config (no direct CLI flags today).
+- **Audio alignment**: `--audio-align-track label=index` forwards tuples to `runner.run(request).audio_track_overrides`; selection/confirmation flows patch CLI runtime structures accordingly.
+- **Misc runtime**: `--diagnose-paths`, `--write-config`, `--doctor`, `wizard/preset` commands, and `--run` subcommand all funnel through `_run_cli_entry()` so `frame_compare.run_cli()` stays authoritative for runtime behaviour.
 
 #### Screenshots / Render
 
@@ -185,15 +232,18 @@ Use these commands to compare direct vs Click CLI behaviour for a given config:
 ### B3. Implementation Notes (Dev Agent)
 
 - For each domain, record:
-  - [ ] Issues found (if any) and fixes applied.
-  - [ ] Tests updated/added.
-  - [ ] Any decisions on intentional precedence.
+  - [x] Issues found (if any) and fixes applied.
+  - [x] Tests updated/added.
+  - [x] Any decisions on intentional precedence.
 
 #### B3 Notes
 
-- Date:
-- Dev Agent:
+- Date: 2025-11-18
+- Dev Agent: Codex (implementation persona)
 - Key changes & rationale:
+  - Documented every `AppConfig` section plus CLI flag/load-precedence mapping so Phase 3 can reference a single index (Track B → B1/B2).
+  - Tightened CLI tonemap overrides to ignore `default_map`/implicit values, keeping control inside config/env for “flag not passed” cases.
+  - Extended `tests/runner/test_dovi_flags.py` to pin `--tm-target` CLI overrides vs default-map behaviour and to assert overlay + verify telemetry stays config-driven in both CLI and direct-run entrypoints.
 
 ### B4. Review Notes (Review Agent)
 

--- a/docs/refactor/flag_audit.md
+++ b/docs/refactor/flag_audit.md
@@ -289,3 +289,86 @@ When closing a track or major sub-task, run:
 ## Open Issues / TODO
 
 - [ ] …
+
+---
+
+## Track C – Overlay Diagnostics Expansion
+
+> Scope: Enhance the overlay’s diagnostic mode with additional HDR/DV metadata (DoVi L2 summary, MaxCLL/MaxFALL, dynamic range labels, per-frame nit metrics, etc.).
+
+### C1. Discovery & Data Mapping (Phase 1)
+
+- [ ] Inventory existing metadata sources:
+  - [ ] DV metadata (L1/L2) in `metadata_utils` / `vs_core`.
+  - [ ] HDR mastering metadata (MaxCLL/MaxFALL) stored per clip.
+  - [ ] Dynamic range detection logs (`limited` vs `full`).
+  - [ ] Cached per-frame metrics (analysis caches, selection details).
+- [ ] Document overlay pipeline:
+  - [ ] Where `json_tail["overlay"]` is built (`runner.py`).
+  - [ ] How `overlay_text_template`/`overlay_mode` influence rendering.
+  - [ ] Where overlay text is rendered in screenshot pipeline.
+- [ ] Identify gating options:
+  - [ ] Existing diagnostic/`overlay_mode` toggles.
+  - [ ] Potential new config/CLI flags for expensive metrics (per-frame nits).
+- [ ] Record findings (files, fields, perf notes) below.
+
+> Notes (discovery summary):
+> - DV metadata source:
+> - HDR metadata source:
+> - Dynamic range detection:
+> - Cached per-frame metrics:
+> - Overlay template path:
+> - Gating strategy:
+
+### C2. Implementation Plan
+
+- [ ] DV diagnostics:
+  - [ ] Include `use_dovi_label` in overlay diagnostics context.
+  - [ ] Surface DV L2 summary (block info, brightness target) when available.
+- [ ] HDR metadata:
+  - [ ] Expose MaxCLL/MaxFALL per clip.
+  - [ ] Add dynamic range classification (limited/full) to overlay data.
+- [ ] Per-frame metrics (gated):
+  - [ ] Determine data availability (cached vs recompute).
+  - [ ] Add config/CLI toggle for expensive computations.
+  - [ ] Surface frame max/avg nits and DV RPI Level 1 stats when enabled.
+- [ ] Update overlay context:
+  - [ ] Extend `json_tail["overlay"]["diagnostics"]` with structured data.
+  - [ ] Provide default diagnostic template (multi-line) when `overlay_mode == "diagnostic"`.
+- [ ] Tests & docs:
+  - [ ] Add unit/integration tests covering new diagnostics.
+  - [ ] Update README + docs/DECISIONS.md describing diagnostic overlay features/perf costs.
+
+### C3. Implementation Notes (Dev Agent)
+
+- Work performed:
+  - [ ] DV diagnostics added.
+  - [ ] HDR metadata added.
+  - [ ] Per-frame metrics gated + added.
+  - [ ] Overlay template updated.
+  - [ ] Tests/docs updated.
+- Commands run:
+  - [ ] `.venv/Scripts/pyright --warnings`
+  - [ ] `.venv/Scripts/ruff check`
+  - [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/Scripts/pytest -q tests/runner/test_overlay_diagnostics.py`
+
+> Notes:
+> - Date:
+> - Dev Agent:
+> - Summary of metrics availability/gating decisions:
+
+### C4. Review Notes (Review Agent)
+
+- [ ] Verified overlay diagnostics show DV/HDR data when expected.
+- [ ] Confirmed per-frame metrics gating prevents regressions.
+- [ ] Tested CLI/config toggles for diagnostic overlay.
+- [ ] Docs accurately describe new behaviour and perf considerations.
+
+> Findings:
+> -
+> Follow-ups:
+> -
+> Reviewer:
+> -
+> Date:
+> -

--- a/docs/refactor/flag_audit.md
+++ b/docs/refactor/flag_audit.md
@@ -24,26 +24,26 @@
 
 ## Global Invariants (Target State)
 
-- [ ] Config + env + CLI precedence is well defined and documented.
-- [ ] "Flag not passed" means "no override"; config values still apply.
-- [ ] `frame_compare.run_cli` and `frame_compare.py` produce the same effective settings for the same config + flags.
-- [ ] All tri-state/boolean fields that can be set from CLI have explicit tests for:
+- [x] Config + env + CLI precedence is well defined and documented.
+- [x] "Flag not passed" means "no override"; config values still apply.
+- [x] `frame_compare.run_cli` and `frame_compare.py` produce the same effective settings for the same config + flags.
+- [x] All tri-state/boolean fields that can be set from CLI have explicit tests for:
   - [ ] No flags
   - [ ] Explicit enable flag
   - [ ] Explicit disable flag
 
 **Critical toggles to verify across config + CLI:**
 
-- [ ] `color.use_dovi` (DoVi)
-- [ ] `color.visualize_lut`
-- [ ] `color.show_clipping`
-- [ ] `screenshots.use_ffmpeg`
-- [ ] `analysis` enable / thresholds (where applicable)
-- [ ] `audio_alignment.enable` / `audio_alignment.use_vspreview`
-- [ ] `slowpics.auto_upload`
-- [ ] `report.enable`
-- [ ] `cli.emit_json_tail`
-- [ ] Cache flags: `--no-cache`, `--from-cache-only`, `--show-partial`, `--show-missing/--hide-missing`
+- [x] `color.use_dovi` (DoVi)
+- [x] `color.visualize_lut`
+- [x] `color.show_clipping`
+- [x] `screenshots.use_ffmpeg`
+- [x] `analysis` enable / thresholds (where applicable)
+- [x] `audio_alignment.enable` / `audio_alignment.use_vspreview`
+- [x] `slowpics.auto_upload`
+- [x] `report.enable`
+- [x] `cli.emit_json_tail`
+- [x] Cache flags: `--no-cache`, `--from-cache-only`, `--show-partial`, `--show-missing/--hide-missing`
 
 ---
 
@@ -124,28 +124,30 @@ Use these commands to compare direct vs Click CLI behaviour for a given config:
 
 ### A3. Review Notes (Review Agent)
 
-- [ ] Verified `frame_compare.run_cli` vs `frame_compare.py` behaviour for:
-  - [ ] DoVi on via config only.
-  - [ ] DoVi off via config only.
-  - [ ] Explicit `--tm-use-dovi` vs `--tm-no-dovi`.
-- [ ] Confirmed no other `--tm-*` flags implicitly override config when not passed.
-- [ ] Documentation aligned (README/CHANGELOG/DECISIONS).
+- [x] Verified `frame_compare.run_cli` vs `frame_compare.py` behaviour for:
+  - [x] DoVi on via config only.
+  - [x] DoVi off via config only.
+  - [x] Explicit `--tm-use-dovi` vs `--tm-no-dovi`.
+- [x] Confirmed no other `--tm-*` flags implicitly override config when not passed.
+- [x] Documentation aligned (README/CHANGELOG/DECISIONS).
 
 #### A3 Findings
 
--
+- `_cli_override_value()` gates all `--tm-*` overrides on Click `ParameterSource.COMMANDLINE`, so default_map/env values never override config when the user stays silent (`frame_compare.py:494-733`). Click’s docs confirm `Context.get_parameter_source()` only reports `COMMANDLINE` for explicit flags (source:https://github.com/pallets/click/blob/main/docs/commands-and-groups.rst@2025-11-18T10:57:24Z via Context7), which matches the behaviour under review.
+- `_apply_cli_tonemap_overrides()` only mutates keys present in `tonemap_overrides`, and `json_tail["tonemap"]`/`["overlay"]`/`["verify"]` reuse the config-backed values emitted by `vs_core.resolve_effective_tonemap` (`src/frame_compare/runner.py:290-333`, `1696-1781`, `1985-2018`). That keeps DoVi, overlay, and verify telemetry identical between direct `frame_compare.run_cli` and the Click CLI.
+- Regression tests cover “no flag vs `--tm-use-dovi/--tm-no-dovi`/`--tm-visualize-lut`/`--tm-show-clipping` plus overlay & verify parity), and they pass alongside static analysis: `.venv/bin/pyright --warnings`, `.venv/bin/ruff check`, and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/runner/test_dovi_flags.py`.
 
 #### A3 Open Questions
 
--
+- None for Phase 1–2; later tracks (render/screenshots, analysis/cache, etc.) will be re-evaluated during Phase 3.
 
 #### A3 Reviewer
 
--
+- Codex review agent
 
 #### A3 Date
 
--
+- 2025-11-18
 
 ---
 
@@ -196,38 +198,38 @@ Use these commands to compare direct vs Click CLI behaviour for a given config:
 
 #### Screenshots / Render
 
-- [ ] Confirm `[screenshots]` fields: directory, writer, scaling, pad, compression, etc.
-- [ ] Map any CLI flags that touch screenshots.
-- [ ] Verify:
-  - [ ] No hidden defaults override config.
-  - [ ] JSON `render` block matches effective settings.
+- [x] Confirm `[screenshots]` fields: directory, writer, scaling, pad, compression, etc. (`src/datatypes.py:120-171` continues to mirror `cli_layout` render sections.)
+- [x] Map any CLI flags that touch screenshots. (No direct CLI flags today; `debug_color` w/ tonemap pipeline is the only writer-affecting toggle.)
+- [x] Verify:
+  - [x] No hidden defaults override config — runner now derives the render writer from both `cfg.screenshots.use_ffmpeg` **and** `cfg.color.debug_color`, so CLI `--debug-color` no longer forces a silent writer swap (`src/frame_compare/runner.py:1658-1679`).
+  - [x] JSON `render` block matches effective settings — added `tests/runner/test_cli_entry.py::test_render_writer_matches_debug_color` to exercise both `frame_compare.run_cli()` and the Click CLI with/without `--debug-color`.
 
 #### Analysis / Cache
 
-- [ ] Review `[analysis]` config.
-- [ ] Verify `--no-cache`, `--from-cache-only`, `--show-partial`, `--show-missing`:
-  - [ ] Only affect behaviour when explicitly passed.
-  - [ ] Match documentation.
+- [x] Review `[analysis]` config. (`src/datatypes.py:32-119` reconfirmed as source of truth for cache/save settings.)
+- [x] Verify `--no-cache`, `--from-cache-only`, `--show-partial`, `--show-missing`:
+  - [x] Only affect behaviour when explicitly passed — `_cli_flag_value()` now ignores Click `default_map` / env sources so `RunRequest.force_cache_refresh`, `from_cache_only`, and `RenderOptions` toggles only flip when the user provides a flag (`frame_compare.py:714-749`).
+  - [x] Match documentation — regression tests `tests/runner/test_cli_entry.py::test_cli_cache_flags_ignore_default_map` and `::test_cli_cache_flags_follow_commandline` assert both the default-map safety net and the explicit-flag path.
 
 #### Audio Alignment
 
-- [ ] Review `[audio_alignment]` config and overrides (manual trims, vspreview).
-- [ ] Verify CLI flags (e.g., `--audio-align-track`) don't reset config when absent.
+- [x] Review `[audio_alignment]` config and overrides (manual trims, vspreview). (`src/datatypes.py:222-256` + `src/frame_compare/runner.py:590-672` confirmed the config-driven JSON tail fields for enable + VSPreview flags.)
+- [x] Verify CLI flags (e.g., `--audio-align-track`) don't reset config when absent. Added `_cli_override_value` gating for multi-value `--audio-align-track` plus `tests/runner/test_cli_entry.py::test_cli_audio_align_track_requires_flag` to prove default_map values are ignored while explicit flags still propagate.
 
 #### Slowpics / Report / Viewer
 
-- [ ] Review `[slowpics]`, `[report]`, and viewer-related fields.
-- [ ] Verify override semantics for `--html-report`, `--no-html-report`, etc.
+- [x] Review `[slowpics]`, `[report]`, and viewer-related fields (`src/datatypes.py:180-220` + `src/frame_compare/runner.py:536-687`).
+- [x] Verify override semantics for `--html-report`, `--no-html-report`, etc. Gated both flags via `_cli_flag_value()` so config `[report].enable` remains authoritative unless the user passes an override, and covered with `tests/runner/test_cli_entry.py::test_cli_html_report_flags_ignore_default_map` + `::test_cli_html_report_flags_follow_commandline`. Slowpics auto-upload continues to rely solely on `cfg.slowpics.auto_upload`; CLI never injects overrides (`runner.py:536-584` warning path validated during manual trace).
 
 #### Paths / Root / Input
 
-- [ ] Verify precedence: `--root` / `FRAME_COMPARE_ROOT` / sentinel search.
-- [ ] Confirm `--config` / `FRAME_COMPARE_CONFIG` overrides and no surprise fallbacks.
+- [x] Verify precedence: `--root` / `FRAME_COMPARE_ROOT` / sentinel search. `_cli_override_value()` now drops CLI `default_map` values for `--root`, `--config`, and `--input` so preflight discovery continues to resolve root + config path from env/sentinel unless the user passes a flag (`frame_compare.py:700-732`). Tests `test_cli_input_override_requires_flag` / `test_cli_input_flag_overrides_config` exercise both default and explicit behaviour.
+- [x] Confirm `--config` / `FRAME_COMPARE_CONFIG` overrides and no surprise fallbacks. Manual trace (`src/frame_compare/preflight.py:215-411`) + request recorder demonstrate that config path/root overrides only flow through when `ctx.get_parameter_source()==COMMANDLINE`.
 
 #### TMDB / Source / Runtime / CLI
 
-- [ ] Review `[tmdb]`, `[source]`, `[runtime]`, `[cli]`, `[overrides]`.
-- [ ] Ensure fields like `cli.emit_json_tail`, runtime flags, etc., are only overridden intentionally.
+- [x] Review `[tmdb]`, `[source]`, `[runtime]`, `[cli]`, `[overrides]`.
+- [x] Ensure fields like `cli.emit_json_tail`, runtime flags, etc., are only overridden intentionally. Stitched `_cli_flag_value()` into `--debug-color` so the tonemap pipeline only flips into debug mode when asked, leaving `[color].debug_color` and `[cli].emit_json_tail` untouched by default maps or env. Regression tests `test_cli_debug_color_requires_flag` plus the render-writer assertions confirm both CLI entry points preserve config defaults while still honoring explicit flags.
 
 ### B3. Implementation Notes (Dev Agent)
 
@@ -244,28 +246,53 @@ Use these commands to compare direct vs Click CLI behaviour for a given config:
   - Documented every `AppConfig` section plus CLI flag/load-precedence mapping so Phase 3 can reference a single index (Track B → B1/B2).
   - Tightened CLI tonemap overrides to ignore `default_map`/implicit values, keeping control inside config/env for “flag not passed” cases.
   - Extended `tests/runner/test_dovi_flags.py` to pin `--tm-target` CLI overrides vs default-map behaviour and to assert overlay + verify telemetry stays config-driven in both CLI and direct-run entrypoints.
+  - Expanded `_cli_override_value` with `_cli_flag_value` and gated every remaining override-capable CLI flag (`--root/--config/--input`, cache toggles, HTML report, audio track, `--debug-color`) so Click `default_map`/env sources can't silently supersede config/preflight precedence (`frame_compare.py:700-757`). Backed by new tests in `tests/runner/test_cli_entry.py` (`test_cli_cache_flags_ignore_default_map`, `test_cli_html_report_flags_ignore_default_map`, `test_cli_input_override_requires_flag`, `test_cli_audio_align_track_requires_flag`, `test_cli_debug_color_requires_flag`).
+  - Synced render JSON metadata with the actual writer selected when color-debug mode disables ffmpeg (`runner.py:1658-1679`) and validated both entrypoints via `tests/runner/test_cli_entry.py::test_render_writer_matches_debug_color`.
+  - Commands executed for verification:
+    - `./.venv/bin/pyright --warnings`
+    - `./.venv/bin/ruff check`
+    - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/pytest -q tests/runner`
 
 ### B4. Review Notes (Review Agent)
 
-- [ ] Verified behaviour against docs and expectations for each domain.
-- [ ] Confirmed no remaining "implicit override" patterns.
-- [ ] Suggested any follow-up tasks (if necessary).
+- [x] Verified behaviour against docs and expectations for each domain.
+- [x] Confirmed no remaining "implicit override" patterns.
+- [x] Suggested any follow-up tasks (if necessary).
 
 #### B4 Findings
 
--
+##### Screenshots / Render
+- Debug toggles now respect config-first precedence: `_cli_flag_value()` only forwards `--debug-color` when a user actually passes the flag, and `runner.run` derives the render writer from `[screenshots].use_ffmpeg` gated by the effective debug flag (`frame_compare.py:739-752`, `src/frame_compare/runner.py:360-420`, `:1659-1679`). `tests/runner/test_cli_entry.py::test_cli_debug_color_requires_flag` plus `::test_render_writer_matches_debug_color` cover both Click CLI sources and direct `frame_compare.run_cli`.
+
+##### Analysis / Cache
+- `--no-cache`, `--from-cache-only`, `--show-partial`, and `--show-missing/--hide-missing` only mutate `RunRequest` when a command-line flag is present (`frame_compare.py:739-747`). `tests/runner/test_cli_entry.py::test_cli_cache_flags_ignore_default_map` / `::follow_commandline` prove the guard rails, and `src/frame_compare/runner.py:500-580` / `:1120-1188` show the corresponding cache probe + recompute paths that honour those flags.
+
+##### Audio Alignment
+- CLI audio-track overrides require explicit `--audio-align-track` inputs, so config-defined trims and offsets remain intact unless the user opts in (`frame_compare.py:708-717`, `tests/runner/test_cli_entry.py::test_cli_audio_align_track_requires_flag`). JSON tail fields for `enable`, `use_vspreview`, preview/manual offsets, and VSPreview commands all come directly from config in `src/frame_compare/runner.py:592-630`, and `tests/runner/test_audio_alignment_cli.py` exercises both config-only and CLI-override scenarios (including vspreview scripts and manual trims).
+
+##### Slowpics / Report / Viewer
+- HTML report toggles only override config when `--html-report`/`--no-html-report` is supplied (`frame_compare.py:748-752`, `tests/runner/test_cli_entry.py::test_cli_html_report_flags_*`). Slowpics upload, shortcut, and cleanup workflows remain config-driven (`frame_compare.py:322-386`, `src/frame_compare/runner.py:640-720`) with no CLI surface, matching Track B’s expectations.
+
+##### Paths / Root / Input
+- Precedence order is CLI flag → env var → sentinel search inside `src/frame_compare/preflight.py:210-333`. `_cli_override_value()` prevents `default_map` values from masquerading as overrides for `--root`, `--config`, or `--input` (`frame_compare.py:703-708`), and `tests/runner/test_cli_entry.py::test_cli_input_override_requires_flag` / `::test_cli_input_flag_overrides_config` validate both cases.
+
+##### TMDB / Source / Runtime / CLI
+- CLI runtime toggles stop at `--quiet/--verbose/--json-pretty`; `[cli].emit_json_tail` and progress styles only respect config (`src/frame_compare/runner.py:500-520`), with `tests/runner/test_cli_entry.py::test_cli_disables_json_tail_output` confirming the Click CLI obeys config defaults. TMDB/source/runtime behaviour stays config-driven (`src/frame_compare/runner.py:700-990`), and no remaining CLI knobs silently mutate `[tmdb]`, `[source]`, or `[runtime]` settings.
+
+##### Cross-entrypoint consistency, docs, and verification
+- `tests/runner/test_dovi_flags.py` plus `tests/runner/test_cli_entry.py::test_render_writer_matches_debug_color` show `frame_compare.run_cli` and the Click CLI emitting identical tonemap/debug metadata for Phases 3–6 toggles. README cache/CLI sections (README.md:340-390) and `CHANGELOG.md` (“Unreleased → Features/Bug Fixes/Chores”) describe the precedence rules documented in Track B, so docs/tests now match code. Re-ran `.venv/bin/pyright --warnings`, `.venv/bin/ruff check`, and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/runner/test_cli_entry.py tests/runner/test_audio_alignment_cli.py tests/runner/test_dovi_flags.py` to sign off on the behaviour.
 
 #### B4 Follow-ups
 
--
+- No open issues for Track B Phases 3–6; future work can focus on net-new flags or UX.
 
 #### B4 Reviewer
 
--
+- Codex review agent
 
 #### B4 Date
 
--
+- 2025-11-18
 
 ---
 
@@ -288,4 +315,4 @@ When closing a track or major sub-task, run:
 
 ## Open Issues / TODO
 
-- [ ] …
+- [ ] None (no outstanding Track B items after Phase 3–6 review)

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -12,7 +12,7 @@ import webbrowser
 from collections.abc import Mapping
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, MutableMapping, Optional, cast
+from typing import Any, Callable, Dict, Iterable, MutableMapping, Optional, TypeVar, cast
 
 import click
 from click.core import ParameterSource
@@ -488,11 +488,15 @@ def _run_cli_entry(
         print(json_output)
 
 
-def _normalize_tm_toggle(ctx: click.Context, name: str, value: bool | None) -> bool | None:
-    """
-    Treat Click toggles as overrides only when explicitly provided on the command line.
+T = TypeVar("T")
 
-    Returning ``None`` defers to the underlying config so tri-state options stay intact.
+
+def _cli_override_value(ctx: click.Context, name: str, value: T | None) -> T | None:
+    """
+    Return ``value`` only when the corresponding CLI option originated from the command line.
+
+    Click's ``default_map`` and other implicit sources should defer to config defaults so the
+    runtime path mirrors ``frame_compare.run_cli`` unless the user explicitly passes a flag.
     """
 
     get_source = getattr(ctx, "get_parameter_source", None)
@@ -710,9 +714,23 @@ def main(
 ) -> None:
     """Command group entry point that dispatches to subcommands or the default run."""
 
-    tm_use_dovi = _normalize_tm_toggle(ctx, "tm_use_dovi", tm_use_dovi)
-    tm_visualize_lut = _normalize_tm_toggle(ctx, "tm_visualize_lut", tm_visualize_lut)
-    tm_show_clipping = _normalize_tm_toggle(ctx, "tm_show_clipping", tm_show_clipping)
+    tm_preset = _cli_override_value(ctx, "tm_preset", tm_preset)
+    tm_curve = _cli_override_value(ctx, "tm_curve", tm_curve)
+    tm_target = _cli_override_value(ctx, "tm_target", tm_target)
+    tm_dst_min = _cli_override_value(ctx, "tm_dst_min", tm_dst_min)
+    tm_knee = _cli_override_value(ctx, "tm_knee", tm_knee)
+    tm_dpd_preset = _cli_override_value(ctx, "tm_dpd_preset", tm_dpd_preset)
+    tm_dpd_black_cutoff = _cli_override_value(ctx, "tm_dpd_black_cutoff", tm_dpd_black_cutoff)
+    tm_gamma = _cli_override_value(ctx, "tm_gamma", tm_gamma)
+    tm_smoothing = _cli_override_value(ctx, "tm_smoothing", tm_smoothing)
+    tm_scene_low = _cli_override_value(ctx, "tm_scene_low", tm_scene_low)
+    tm_scene_high = _cli_override_value(ctx, "tm_scene_high", tm_scene_high)
+    tm_percentile = _cli_override_value(ctx, "tm_percentile", tm_percentile)
+    tm_contrast = _cli_override_value(ctx, "tm_contrast", tm_contrast)
+    tm_metadata = _cli_override_value(ctx, "tm_metadata", tm_metadata)
+    tm_use_dovi = _cli_override_value(ctx, "tm_use_dovi", tm_use_dovi)
+    tm_visualize_lut = _cli_override_value(ctx, "tm_visualize_lut", tm_visualize_lut)
+    tm_show_clipping = _cli_override_value(ctx, "tm_show_clipping", tm_show_clipping)
 
     params = {
         "root_path": root_path,

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -508,6 +508,19 @@ def _cli_override_value(ctx: click.Context, name: str, value: T | None) -> T | N
     return None
 
 
+def _cli_flag_value(ctx: click.Context, name: str, value: bool, *, default: bool) -> bool:
+    """
+    Return the flag value only when the user explicitly passed the option.
+
+    Click's ``default_map`` and env-provided values should not override config-driven defaults.
+    """
+
+    override = _cli_override_value(ctx, name, value)
+    if override is None:
+        return default
+    return bool(override)
+
+
 @click.group(invoke_without_command=True)
 @click.option(
     "--root",
@@ -714,6 +727,30 @@ def main(
 ) -> None:
     """Command group entry point that dispatches to subcommands or the default run."""
 
+    root_path = _cli_override_value(ctx, "root_path", root_path)
+    config_path = _cli_override_value(ctx, "config_path", config_path)
+    input_dir = _cli_override_value(ctx, "input_dir", input_dir)
+    track_override = _cli_override_value(
+        ctx,
+        "audio_align_track_option",
+        audio_align_track_option if audio_align_track_option else None,
+    )
+    audio_align_track_option = tuple(track_override or ())
+    quiet = _cli_flag_value(ctx, "quiet", quiet, default=False)
+    verbose = _cli_flag_value(ctx, "verbose", verbose, default=False)
+    no_color = _cli_flag_value(ctx, "no_color", no_color, default=False)
+    json_pretty = _cli_flag_value(ctx, "json_pretty", json_pretty, default=False)
+    no_cache = _cli_flag_value(ctx, "no_cache", no_cache, default=False)
+    from_cache_only = _cli_flag_value(ctx, "from_cache_only", from_cache_only, default=False)
+    show_partial = _cli_flag_value(ctx, "show_partial", show_partial, default=False)
+    show_missing = _cli_flag_value(ctx, "show_missing", show_missing, default=True)
+    diagnose_paths = _cli_flag_value(ctx, "diagnose_paths", diagnose_paths, default=False)
+    write_config = _cli_flag_value(ctx, "write_config", write_config, default=False)
+    skip_wizard_flag = _cli_flag_value(ctx, "no_wizard", no_wizard, default=False)
+    html_report_enable = _cli_flag_value(ctx, "html_report_enable", html_report_enable, default=False)
+    html_report_disable = _cli_flag_value(ctx, "html_report_disable", html_report_disable, default=False)
+    debug_color = _cli_flag_value(ctx, "debug_color", debug_color, default=False)
+
     tm_preset = _cli_override_value(ctx, "tm_preset", tm_preset)
     tm_curve = _cli_override_value(ctx, "tm_curve", tm_curve)
     tm_target = _cli_override_value(ctx, "tm_target", tm_target)
@@ -747,7 +784,7 @@ def main(
         "show_missing": show_missing,
         "diagnose_paths": diagnose_paths,
         "write_config": write_config,
-        "skip_wizard": no_wizard,
+        "skip_wizard": skip_wizard_flag,
         "html_report_enable": html_report_enable,
         "html_report_disable": html_report_disable,
         "debug_color": debug_color,

--- a/src/frame_compare/render/naming.py
+++ b/src/frame_compare/render/naming.py
@@ -5,8 +5,11 @@ import re
 from collections.abc import Mapping
 from pathlib import Path
 
+SAFE_LABEL_META_KEY = "_safe_label"
+
 __all__ = [
     "INVALID_LABEL_PATTERN",
+    "SAFE_LABEL_META_KEY",
     "derive_labels",
     "prepare_filename",
     "sanitise_label",
@@ -30,7 +33,11 @@ def derive_labels(source: str, metadata: Mapping[str, str]) -> tuple[str, str]:
     """Return the raw+cleaned labels for *source* using optional metadata."""
 
     raw = metadata.get("label") or Path(source).stem
-    cleaned = sanitise_label(raw)
+    override = metadata.get(SAFE_LABEL_META_KEY)
+    if isinstance(override, str) and override.strip():
+        cleaned = sanitise_label(override)
+    else:
+        cleaned = sanitise_label(raw)
     return raw.strip() or cleaned, cleaned
 
 

--- a/src/frame_compare/runner.py
+++ b/src/frame_compare/runner.py
@@ -393,6 +393,7 @@ def run(request: RunRequest) -> RunResult:
             setattr(cfg.color, "debug_color", True)
         except AttributeError:
             pass
+    debug_color_enabled = bool(getattr(cfg.color, "debug_color", False))
     report_enabled = (
         bool(report_enable_override)
         if report_enable_override is not None
@@ -1655,7 +1656,7 @@ def run(request: RunRequest) -> RunResult:
 
     total_screens = len(frames) * len(plans)
 
-    writer_name = "ffmpeg" if cfg.screenshots.use_ffmpeg else "vs"
+    writer_name = "ffmpeg" if (cfg.screenshots.use_ffmpeg and not debug_color_enabled) else "vs"
     overlay_mode_value = getattr(cfg.color, "overlay_mode", "minimal")
     auto_letterbox_raw = getattr(cfg.screenshots, "auto_letterbox_crop", "off")
     if isinstance(auto_letterbox_raw, Enum):
@@ -1918,7 +1919,7 @@ def run(request: RunRequest) -> RunResult:
                     warnings_sink=collected_warnings,
                     verification_sink=verification_records,
                     pivot_notifier=_notify_pivot,
-                    debug_color=bool(getattr(cfg.color, "debug_color", False)),
+                    debug_color=debug_color_enabled,
                     source_frame_props=stored_props_seq,
                 )
 
@@ -1963,7 +1964,7 @@ def run(request: RunRequest) -> RunResult:
                 warnings_sink=collected_warnings,
                 verification_sink=verification_records,
                 pivot_notifier=_notify_pivot,
-                debug_color=bool(getattr(cfg.color, "debug_color", False)),
+                debug_color=debug_color_enabled,
                 source_frame_props=stored_props_seq,
             )
     except ClipProcessError as exc:

--- a/src/frame_compare/runner.py
+++ b/src/frame_compare/runner.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, cast
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, cast
 
 from rich.console import Console
 from rich.markup import escape
@@ -50,6 +50,8 @@ from src.frame_compare.analysis import (
     write_selection_cache_file,
 )
 from src.frame_compare.env_flags import env_flag_enabled
+from src.frame_compare.render.naming import SAFE_LABEL_META_KEY
+from src.frame_compare.render.naming import sanitise_label as _render_sanitise_label
 from src.frame_compare.result_snapshot import (
     RenderOptions,
     ResultSource,
@@ -113,6 +115,19 @@ def _emit_dovi_debug(payload: Mapping[str, Any]) -> None:
     print("[DOVI_DEBUG]", message, file=sys.stderr)
 
 ReporterFactory = Callable[['RunRequest', Path, Console], CliOutputManagerProtocol]
+
+
+def _assign_unique_safe_labels(plans: Sequence[ClipPlan]) -> None:
+    """Populate per-plan safe labels used for filenames and reports."""
+
+    counts: Dict[str, int] = {}
+    for plan in plans:
+        raw_label = plan.metadata.get("label") or plan.path.stem
+        base = _render_sanitise_label(raw_label)
+        occurrence = counts.get(base, 0) + 1
+        counts[base] = occurrence
+        safe_label = base if occurrence == 1 else f"{base}_{occurrence}"
+        plan.metadata[SAFE_LABEL_META_KEY] = safe_label
 
 
 @dataclass
@@ -997,6 +1012,7 @@ def run(request: RunRequest) -> RunResult:
         )
 
     plans = planner_utils.build_plans(files, metadata, cfg)
+    _assign_unique_safe_labels(plans)
     analyze_path = core.pick_analyze_file(files, metadata, cfg.analysis.analyze_clip, cache_dir=root)
 
     try:

--- a/tests/runner/test_dovi_flags.py
+++ b/tests/runner/test_dovi_flags.py
@@ -17,6 +17,7 @@ from tests.helpers.runner_env import (
     _make_json_tail_stub,
 )
 
+_CLI_JSON_ENV = {"COLUMNS": "200"}
 
 def _install_stubbed_runner(
     monkeypatch: pytest.MonkeyPatch,
@@ -30,24 +31,46 @@ def _install_stubbed_runner(
         captured.append(request)
         cfg = cli_runner_env.cfg
         overrides = request.tonemap_overrides or {}
+        color_cfg = cfg.color
         override_value = overrides.get("use_dovi")
         if override_value is None:
-            override_value = getattr(cfg.color, "use_dovi", None)
+            override_value = getattr(color_cfg, "use_dovi", None)
         visualize_lut_value = overrides.get("visualize_lut")
         if visualize_lut_value is None:
-            visualize_lut_value = bool(getattr(cfg.color, "visualize_lut", False))
+            visualize_lut_value = bool(getattr(color_cfg, "visualize_lut", False))
         show_clipping_value = overrides.get("show_clipping")
         if show_clipping_value is None:
-            show_clipping_value = bool(getattr(cfg.color, "show_clipping", False))
+            show_clipping_value = bool(getattr(color_cfg, "show_clipping", False))
+        target_nits_value = overrides.get("target_nits", getattr(color_cfg, "target_nits", 100.0))
+        preset_value = overrides.get("preset", getattr(color_cfg, "preset", "reference"))
+        tone_curve_value = overrides.get("tone_curve", getattr(color_cfg, "tone_curve", "bt.2390"))
+        metadata_value = overrides.get("metadata", getattr(color_cfg, "metadata", "auto"))
         json_tail = _make_json_tail_stub()
         tonemap_block = json_tail.setdefault("tonemap", {})
+        tonemap_block["preset"] = preset_value
+        tonemap_block["tone_curve"] = tone_curve_value
+        tonemap_block["target_nits"] = float(target_nits_value)
         tonemap_block["use_dovi"] = override_value
+        tonemap_block["metadata"] = metadata_value
         tonemap_block["visualize_lut"] = visualize_lut_value
         tonemap_block["show_clipping"] = show_clipping_value
+        tonemap_block["overlay_enabled"] = bool(getattr(color_cfg, "overlay_enabled", True))
+        tonemap_block["overlay_mode"] = getattr(color_cfg, "overlay_mode", "minimal")
+        tonemap_block["verify_luma_threshold"] = float(getattr(color_cfg, "verify_luma_threshold", 0.1))
         if override_value is None:
             tonemap_block["use_dovi_label"] = "auto"
         else:
             tonemap_block["use_dovi_label"] = "on" if override_value else "off"
+        overlay_block = json_tail.setdefault("overlay", {})
+        overlay_block["enabled"] = bool(getattr(color_cfg, "overlay_enabled", True))
+        overlay_block["template"] = getattr(
+            color_cfg,
+            "overlay_text_template",
+            "Tonemapping Algorithm: bt.2390",
+        )
+        overlay_block["mode"] = getattr(color_cfg, "overlay_mode", "minimal")
+        verify_block = json_tail.setdefault("verify", {})
+        verify_block["threshold"] = float(getattr(color_cfg, "verify_luma_threshold", 0.1))
         cache_block = json_tail.setdefault("cache", {})
         cache_block.setdefault("reason", "stub")
 
@@ -101,7 +124,11 @@ def test_cli_without_tm_flags_inherits_config(
     assert len(captured) == 1
     assert (captured[0].tonemap_overrides or {}).get("use_dovi") is None
 
-    cli_result = runner.invoke(frame_compare.main, ["--no-color", "--json-pretty"])
+    cli_result = runner.invoke(
+        frame_compare.main,
+        ["--no-color", "--json-pretty"],
+        env=dict(_CLI_JSON_ENV),
+    )
     assert cli_result.exit_code == 0, cli_result.output
     cli_tail = _extract_json_tail(cli_result.output)
     tonemap_cli = cli_tail["tonemap"]
@@ -127,6 +154,7 @@ def test_cli_tm_no_dovi_overrides_config(
     result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty", "--tm-no-dovi"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert result.exit_code == 0, result.output
     tonemap_cli = _extract_json_tail(result.output)["tonemap"]
@@ -153,6 +181,7 @@ def test_cli_tm_use_dovi_can_force_override(
     result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty", "--tm-use-dovi"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert result.exit_code == 0, result.output
     tonemap_cli = _extract_json_tail(result.output)["tonemap"]
@@ -179,6 +208,7 @@ def test_cli_visualize_lut_flags_respect_cli_source(
     default_result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert default_result.exit_code == 0, default_result.output
     tonemap_default = _extract_json_tail(default_result.output)["tonemap"]
@@ -188,6 +218,7 @@ def test_cli_visualize_lut_flags_respect_cli_source(
     disable_result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty", "--tm-no-visualize-lut"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert disable_result.exit_code == 0, disable_result.output
     tonemap_disable = _extract_json_tail(disable_result.output)["tonemap"]
@@ -198,6 +229,7 @@ def test_cli_visualize_lut_flags_respect_cli_source(
     enable_result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty", "--tm-visualize-lut"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert enable_result.exit_code == 0, enable_result.output
     tonemap_enable = _extract_json_tail(enable_result.output)["tonemap"]
@@ -221,6 +253,7 @@ def test_cli_show_clipping_flags_respect_cli_source(
     default_result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert default_result.exit_code == 0, default_result.output
     tonemap_default = _extract_json_tail(default_result.output)["tonemap"]
@@ -230,6 +263,7 @@ def test_cli_show_clipping_flags_respect_cli_source(
     enable_result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty", "--tm-show-clipping"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert enable_result.exit_code == 0, enable_result.output
     tonemap_enable = _extract_json_tail(enable_result.output)["tonemap"]
@@ -240,9 +274,96 @@ def test_cli_show_clipping_flags_respect_cli_source(
     disable_result = runner.invoke(
         frame_compare.main,
         ["--no-color", "--json-pretty", "--tm-no-show-clipping"],
+        env=dict(_CLI_JSON_ENV),
     )
     assert disable_result.exit_code == 0, disable_result.output
     tonemap_disable = _extract_json_tail(disable_result.output)["tonemap"]
     assert tonemap_disable["show_clipping"] is False
     overrides = captured[2].tonemap_overrides
     assert overrides is not None and overrides["show_clipping"] is False
+
+
+def test_cli_tm_target_default_map_defer_to_config(
+    cli_runner_env: _CliRunnerEnv,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """Values from Click default maps should not override the loaded config."""
+
+    cfg = _make_config(cli_runner_env.media_root)
+    cfg.color.target_nits = 203.0
+    cli_runner_env.reinstall(cfg)
+    captured = _install_stubbed_runner(monkeypatch, cli_runner_env)
+
+    result = runner.invoke(
+        frame_compare.main,
+        ["--no-color", "--json-pretty"],
+        default_map={"tm_target": 321.0},
+        env=dict(_CLI_JSON_ENV),
+    )
+    assert result.exit_code == 0, result.output
+    tonemap_cli = _extract_json_tail(result.output)["tonemap"]
+    assert tonemap_cli["target_nits"] == pytest.approx(203.0)
+    overrides = captured[0].tonemap_overrides or {}
+    assert "target_nits" not in overrides
+
+
+def test_cli_tm_target_flag_overrides_config(
+    cli_runner_env: _CliRunnerEnv,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """Explicit --tm-target flags must override config defaults."""
+
+    cfg = _make_config(cli_runner_env.media_root)
+    cfg.color.target_nits = 150.0
+    cli_runner_env.reinstall(cfg)
+    captured = _install_stubbed_runner(monkeypatch, cli_runner_env)
+
+    result = runner.invoke(
+        frame_compare.main,
+        ["--no-color", "--json-pretty", "--tm-target", "275.0"],
+        env=dict(_CLI_JSON_ENV),
+    )
+    assert result.exit_code == 0, result.output
+    tonemap_cli = _extract_json_tail(result.output)["tonemap"]
+    assert tonemap_cli["target_nits"] == pytest.approx(275.0)
+    overrides = captured[0].tonemap_overrides
+    assert overrides is not None and overrides["target_nits"] == pytest.approx(275.0)
+
+
+def test_cli_overlay_and_verify_blocks_follow_config(
+    cli_runner_env: _CliRunnerEnv,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """Overlay + verify telemetry should reflect config-driven defaults in both entry points."""
+
+    cfg = _make_config(cli_runner_env.media_root)
+    cfg.color.overlay_enabled = False
+    cfg.color.overlay_mode = "diagnostic"
+    cfg.color.overlay_text_template = "Overlay {tone_curve}"
+    cfg.color.verify_luma_threshold = 0.42
+    cli_runner_env.reinstall(cfg)
+    _install_stubbed_runner(monkeypatch, cli_runner_env)
+
+    direct_result = frame_compare.run_cli(None, None)
+    assert direct_result.json_tail is not None
+    overlay_direct = direct_result.json_tail["overlay"]
+    verify_direct = direct_result.json_tail["verify"]
+    assert overlay_direct == {
+        "enabled": False,
+        "template": "Overlay {tone_curve}",
+        "mode": "diagnostic",
+    }
+    assert verify_direct["threshold"] == pytest.approx(0.42)
+
+    cli_result = runner.invoke(
+        frame_compare.main,
+        ["--no-color", "--json-pretty"],
+        env=dict(_CLI_JSON_ENV),
+    )
+    assert cli_result.exit_code == 0, cli_result.output
+    cli_tail = _extract_json_tail(cli_result.output)
+    assert cli_tail["overlay"] == overlay_direct
+    assert cli_tail["verify"]["threshold"] == pytest.approx(0.42)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI flag precedence now defers to configuration unless an explicit command-line flag is provided; debug-color reporting fallback corrected.
  * Tonemap/DoVi overrides no longer unintentionally override config defaults.

* **Documentation**
  * Expanded decision logs and flag-audit docs with review findings, verification steps, and updated guidance.

* **Refactor**
  * Consistent handling of debug-color and safer per-item label derivation for reports.

* **Tests**
  * Added CLI and report tests to verify flag precedence, tonemap overlays, and duplicate-label reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->