### PR TITLE
feat(diagnostics): wire overlay JSON tail, CLI gating, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-
   pull_request:
-
 
 jobs:
   tests:

--- a/.github/workflows/decision-minute.yml
+++ b/.github/workflows/decision-minute.yml
@@ -1,23 +1,62 @@
 name: decision-minute
+permissions:
+  contents: write
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened, closed]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 jobs:
   extract-and-store:
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Load PR metadata
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.workflow_run.pull_requests?.[0];
+            if (!pr) {
+              core.setFailed('workflow_run payload missing pull request data');
+              return;
+            }
+
+            const fullPr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            if (!fullPr.data.merged_at) {
+              core.notice(`PR #${pr.number} is not merged; skipping Decision Minute creation.`);
+              core.setOutput('result', '');
+              return;
+            }
+
+            const payload = {
+              number: fullPr.data.number,
+              title: fullPr.data.title ?? '',
+              body: fullPr.data.body ?? '',
+              merged_at: fullPr.data.merged_at ?? '',
+            };
+
+            core.setOutput('result', JSON.stringify(payload));
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          repository: ${{ github.repository }}
 
       - name: Write Decision Minute to docs/notes
+        if: ${{ steps.pr.outputs.result != '' }}
         shell: bash
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY:  ${{ github.event.pull_request.body }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          PR_TITLE: ${{ fromJson(steps.pr.outputs.result).title }}
+          PR_BODY:  ${{ fromJson(steps.pr.outputs.result).body }}
+          PR_NUMBER: ${{ fromJson(steps.pr.outputs.result).number }}
+          PR_MERGED_AT: ${{ fromJson(steps.pr.outputs.result).merged_at }}
         run: |
           mkdir -p docs/notes
           slug="$(echo "${PR_TITLE,,}" | tr -cd '[:alnum:]- ' | tr ' ' '-' | sed 's/--*/-/g')"
@@ -29,9 +68,11 @@ jobs:
           echo "${PR_BODY}" >> "$file"
 
       - name: Create PR with note
+        if: ${{ steps.pr.outputs.result != '' }}
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "docs(notes): add Decision Minute for PR #${{ github.event.pull_request.number }}"
-          title: "docs: add Decision Minute for PR #${{ github.event.pull_request.number }}"
+          commit-message: "docs(notes): add Decision Minute for PR #${{ fromJson(steps.pr.outputs.result).number }}"
+          title: "docs: add Decision Minute for PR #${{ fromJson(steps.pr.outputs.result).number }}"
           body: "Automated Decision Minute extracted from PR body."
-          branch: "docs/decision-minute-pr-${{ github.event.pull_request.number }}"
+          branch: "docs/decision-minute-pr-${{ fromJson(steps.pr.outputs.result).number }}"
+          token: ${{ secrets.BOT_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Bug Fixes
 
+- *2025-11-19:* harden the Decision Minute workflow by fetching PR metadata via the API, skipping unmerged runs, and reading data from the github-script `result` output to avoid invalid contexts when CI completes.
 - *2025-11-19:* enforce default HTTPX timeouts for TMDB requests, switch slow.pics publishers to a lock-protected O(1) byte accumulator, and raise a CLI error when planner metadata trails the discovered files.
 * prevent `--service-mode` and `--legacy-runner` from being used together, loosen `RunContext.metadata` typing, guard metadata indexing in `pick_analyze_file`, and treat malformed probe-cache payloads (missing cache keys, bad field types) as cache misses instead of hard errors
 * coerce local report viewer destinations/labels to strings before serializing cached run metadata, refresh the `probe_clip_metadata` docstring to describe cache reuse, and fix docs that referenced the non-existent `src/datatype` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Bug Fixes
 
+- *2025-11-19:* enforce default HTTPX timeouts for TMDB requests, switch slow.pics publishers to a lock-protected O(1) byte accumulator, and raise a CLI error when planner metadata trails the discovered files.
 * prevent `--service-mode` and `--legacy-runner` from being used together, loosen `RunContext.metadata` typing, guard metadata indexing in `pick_analyze_file`, and treat malformed probe-cache payloads (missing cache keys, bad field types) as cache misses instead of hard errors
 * coerce local report viewer destinations/labels to strings before serializing cached run metadata, refresh the `probe_clip_metadata` docstring to describe cache reuse, and fix docs that referenced the non-existent `src/datatype` module
 * gate every non-`--tm-*` CLI override (paths/cache/report/audio/debug flags) on explicit command-line sources so `frame_compare.run_cli` and the Click entrypoint respect config precedence, and fix `json_tail.render.writer` so debug-color runs accurately report the VS fallback (tests/runner/test_cli_entry.py)

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Fine-grained overrides (`smoothing_period`, `scene_threshold_*`, `percentile`, `
 | `[runner].enable_service_mode` | Default `true`. Set `false` in `config.toml` to keep the legacy inline publishers until the services finish burn-in (CLI flags still override per run). |
 | `--show-partial` | Display sections marked as partial when rendering cached runs |
 | `--show-missing` / `--hide-missing` | Show (default) or suppress banners for sections missing from cached runs |
+| `--diagnostic-frame-metrics` / `--no-diagnostic-frame-metrics` | Override `[diagnostics].per_frame_nits` for the current run to enable or block per-frame nit estimates inside diagnostic overlays. |
 | `--quiet` / `--verbose` / `--no-color` / `--json-pretty` | Adjust console behavior |
 | `wizard`, `preset`, `doctor` | Subcommands for guided setup, presets, dependency checks |
 
@@ -360,6 +361,17 @@ Each snapshot records whether a CLI section rendered fully, partially, or not at
 Corrupt or truncated snapshots are treated as cache misses, so `--from-cache-only` aborts with the standard "No cached run result found" message rather than raising a decoder error.
 
 Cached runs display a banner letting operators know when the output comes from disk and how to force a fresh pass. Legacy cache files are treated as missing, so older workspaces fall back to live runs unless you rerun once to seed the snapshot.
+
+#### Diagnostic overlay metrics
+
+The `[diagnostics]` section in `config.toml` gates opt-in overlay work that can increase render time. Currently the single flag is:
+
+```toml
+[diagnostics]
+per_frame_nits = false
+```
+
+When `per_frame_nits` is `true` and `[color].overlay_mode = "diagnostic"`, the runner converts each selection score into a per-frame brightness estimate, adds a `Frame Nits:` line to the overlay, and records the data under `json_tail["overlay"]["diagnostics"]["frame_metrics"]`. Operators can toggle the behaviour without editing config by passing `--diagnostic-frame-metrics` / `--no-diagnostic-frame-metrics` on the CLI. The diagnostics block also captures Dolby Vision (DoVi) L2 metadata, HDR mastering info (MaxCLL/MaxFALL), and the detected color range so downstream consumers can safely ignore missing fields.
 
 ### Examples
 

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
       2, 'always',
       [
         'hdr','sdr','vs','cli','report','html','analysis','audio',
-        'tonemap','overlay','tmdb','geometry','color','ci','docs'
+        'tonemap','overlay','tmdb','geometry','color','ci','docs', 'diagnostics'
       ]
     ],
     'header-max-length': [2, 'always', 100],

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -5,6 +5,10 @@
   - Decision: Retargeted the refactor checklist to point at `src/datatypes.py`, coerced any report paths to strings before computing relative labels so both `destination` and `destination_label` stay JSON-safe, and refreshed the `probe_clip_metadata` docstring to mention cached snapshots plus the follow-up initialization performed by `init_clips`.
   - Verification:
     - `.venv/bin/pyright --warnings`
+- *2025-11-19:* ci(decision-minute): harden workflow_run context access for Decision Minute generation (source:https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow@2025-11-19).
+  - Problem: VS Code/GitHub Actions diagnostics flagged invalid context usage in `.github/workflows/decision-minute.yml` (`pull_requests[0]` without a guard and undeclared `steps.pr.outputs.*` fields), risking runtime errors when CI completed for non-merged PRs.
+  - Decision: Kept the job gated to successful pull_request workflow_run events, fetched the full PR via `actions/github-script` before proceeding, short-circuited with a notice and empty output when the PR is not merged, and funneled all metadata through the action's `result` output (parsed with `fromJson`) so downstream steps are guarded on actual data rather than implicit outputs.
+  - Verification: Not run (YAML/workflow-only change).
     - `.venv/bin/ruff check`
     - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q`
 - *2025-11-19:* fix(net+slowpics+planner): enforce HTTPX timeouts, lock slow.pics progress, guard metadata mismatches.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -793,3 +793,10 @@
   - Problem: Track C’s checklist still showed unchecked tasks with no Implementation/Review notes, operators couldn’t discover the `runner.enable_service_mode` flag outside the CLI, and `run()` never logged whether the publisher services or the legacy path executed, making flag validation difficult.
   - Decision: Filled in Track C planning/implementation/review sections (docs/refactor/runner_service_split.md) with concrete scope, dates, and verification evidence; documented `[runner].enable_service_mode` inside `src/data/config.toml.template` plus README’s CLI/config table; and taught `src/frame_compare/runner.py` to mark a `service_mode_enabled` reporter flag while logging/printing the active publishing mode for each run.
   - Verification: Leveraged the existing Track C command set (pyright/ruff/pytest recorded earlier on 2025-11-19); no code paths outside logging/docs changed and no additional execution was required.
+- *2025-11-19:* feat(diagnostics): extend overlay JSON with DV/HDR/range metadata and gated per-frame metrics.
+  - Problem: the diagnostic overlay roadmap (Track C) left `json_tail["overlay"]["diagnostics"]` empty beyond simple overlays, CLI flag coverage for per-frame metrics was missing, and tests/docs didn’t describe the new data contract.
+  - Decision: centralized the diagnostics helpers (DoVi/HDR/range/frame metrics) to avoid circular imports, taught the runner to always populate the diagnostics block (including gating metadata and per-clip HDR/dynamic-range summaries), added the `[diagnostics].per_frame_nits` config with CLI overrides, and refreshed README + flag audit guidance. New suites cover runner JSON output, CLI flag propagation, overlay text rendering, and the helper module itself.
+  - Verification:
+    - `.venv/bin/pyright --warnings`
+    - `.venv/bin/ruff check`
+    - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/runner/test_overlay_diagnostics.py tests/runner/test_cli_entry.py tests/runner/test_dovi_flags.py tests/render/test_overlay_text.py tests/frame_compare/test_diagnostics.py`

--- a/docs/IMPLEMENTATION_NOTES.md
+++ b/docs/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,26 @@
+# Implementation Notes
+
+## 2025-11-19 – HTTP timeout hardening, slow.pics progress tracker, planner guard
+
+- Files touched: `src/frame_compare/net.py`, `src/tmdb.py`, `tests/net/test_httpx_backoff.py`, `tests/net/test_httpx_helpers.py`, `src/frame_compare/services/publishers.py`, `src/frame_compare/runner.py`, `src/frame_compare/slowpics.py`, `tests/runner/test_slowpics_workflow.py`, `src/frame_compare/planner.py`, `tests/test_planner.py`, `CHANGELOG.md`, `docs/DECISIONS.md`.
+- Commands executed:
+  - `.venv/bin/pyright --warnings` → `0 errors, 0 warnings, 0 informations`
+  - `.venv/bin/ruff check` → `All checks passed!`
+  - `.venv/bin/pytest tests/net -q` → `13 passed in 0.03s`
+  - `.venv/bin/pytest tests/runner/test_slowpics_workflow.py -k "progress or upload" -q` → `3 passed, 11 deselected in 0.06s`
+  - `.venv/bin/pytest tests/test_planner.py -q` → `3 passed in 0.01s`
+- Follow-ups / TODOs: none.
+
+## Review Notes – MetaSentinel
+
+- Date: 2025-11-19
+- Reviewer: MetaSentinel
+- Commands re-run:
+  - [x] `.venv/bin/pyright --warnings`
+  - [x] `.venv/bin/ruff check`
+  - [x] `.venv/bin/pytest tests/net -q`
+  - [x] `.venv/bin/pytest tests/runner/test_slowpics_workflow.py -k "progress or upload" -q`
+  - [x] `.venv/bin/pytest tests/test_planner.py -q`
+- Findings:
+  - None – verified HTTP timeout defaults, slow.pics progress tracking, and planner metadata guards behave as documented.
+- Follow-ups / TODOs: none.

--- a/docs/refactor/refactor_cleanup.md
+++ b/docs/refactor/refactor_cleanup.md
@@ -129,3 +129,4 @@ You are “GuardRail,” a skeptical reviewer. You confirm the new default flow 
 - [ ] (Optional) Evaluate introducing a formal `RunResult` DTO for JSON tail to reduce mutation.
 - [ ] (Optional) Consider consolidating interface definitions (`TMDBClient`, `SlowpicsClient`, `PublisherIO`) into a shared module.
 - [ ] (Optional) Further integration tests to compare CLI output with golden files.
+- [ ] VSPreview overlay regression: `layout_data["vspreview"]` no longer shows alignment “suggested frame/seconds” offsets (always 0f / 0.000s). Restore the pre-refactor behaviour so manual alignment has actionable hints.

--- a/frame_compare.py
+++ b/frame_compare.py
@@ -140,6 +140,7 @@ def run_cli(
     show_partial_sections: bool = False,
     show_missing_sections: bool = True,
     service_mode_override: bool | None = None,
+    diagnostic_frame_metrics: bool | None = None,
 ) -> RunResult:
     """Delegate to the shared runner module."""
     request = RunRequest(
@@ -160,6 +161,7 @@ def run_cli(
         show_partial_sections=show_partial_sections,
         show_missing_sections=show_missing_sections,
         service_mode_override=service_mode_override,
+        diagnostic_frame_metrics=diagnostic_frame_metrics,
     )
     return runner.run(request)
 
@@ -185,6 +187,7 @@ def _run_cli_entry(
     html_report_enable: bool,
     html_report_disable: bool,
     debug_color: bool,
+    diagnostic_frame_metrics: bool | None,
     tm_preset: str | None,
     tm_curve: str | None,
     tm_target: float | None,
@@ -318,6 +321,7 @@ def _run_cli_entry(
             show_partial_sections=show_partial,
             show_missing_sections=show_missing,
             service_mode_override=service_mode_override,
+            diagnostic_frame_metrics=diagnostic_frame_metrics,
         )
     except CLIAppError as exc:
         print(exc.rich_message)
@@ -621,6 +625,19 @@ def _cli_flag_value(ctx: click.Context, name: str, value: bool, *, default: bool
     is_flag=True,
     help="Enable colour pipeline debugging (logs plane stats, dumps intermediate PNGs).",
 )
+@click.option(
+    "--diagnostic-frame-metrics",
+    "diagnostic_frame_metrics",
+    flag_value=True,
+    default=None,
+    help="Enable per-frame diagnostic metric overlay for this run regardless of config.",
+)
+@click.option(
+    "--no-diagnostic-frame-metrics",
+    "diagnostic_frame_metrics",
+    flag_value=False,
+    help="Disable per-frame diagnostic metric overlay regardless of config.",
+)
 @click.option("--tm-preset", "tm_preset", default=None, help="Override [color].preset for this run.")
 @click.option("--tm-curve", "tm_curve", default=None, help="Override [color].tone_curve for this run.")
 @click.option("--tm-target", "tm_target", type=float, default=None, help="Override [color].target_nits for this run.")
@@ -726,6 +743,7 @@ def main(
     html_report_enable: bool,
     html_report_disable: bool,
     debug_color: bool,
+    diagnostic_frame_metrics: bool | None,
     tm_preset: str | None,
     tm_curve: str | None,
     tm_target: float | None,
@@ -770,6 +788,11 @@ def main(
     html_report_enable = _cli_flag_value(ctx, "html_report_enable", html_report_enable, default=False)
     html_report_disable = _cli_flag_value(ctx, "html_report_disable", html_report_disable, default=False)
     debug_color = _cli_flag_value(ctx, "debug_color", debug_color, default=False)
+    diagnostic_frame_metrics = _cli_override_value(
+        ctx,
+        "diagnostic_frame_metrics",
+        diagnostic_frame_metrics,
+    )
     service_mode_selected = _cli_override_value(ctx, "service_mode_flag", service_mode_flag)
     legacy_runner_selected = _cli_override_value(ctx, "legacy_runner_flag", legacy_runner_flag)
     if service_mode_selected and legacy_runner_selected:
@@ -819,6 +842,7 @@ def main(
         "html_report_enable": html_report_enable,
         "html_report_disable": html_report_disable,
         "debug_color": debug_color,
+        "diagnostic_frame_metrics": diagnostic_frame_metrics,
         "tm_preset": tm_preset,
         "tm_curve": tm_curve,
         "tm_target": tm_target,
@@ -872,6 +896,7 @@ def run_command(ctx: click.Context) -> None:
         html_report_enable=bool(params.get("html_report_enable", False)),
         html_report_disable=bool(params.get("html_report_disable", False)),
         debug_color=bool(params.get("debug_color", False)),
+        diagnostic_frame_metrics=params.get("diagnostic_frame_metrics"),
         tm_preset=params.get("tm_preset"),
         tm_curve=params.get("tm_curve"),
         tm_target=params.get("tm_target"),

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -20,6 +20,7 @@ from .datatypes import (
     AutoLetterboxCropMode,
     CLIConfig,
     ColorConfig,
+    DiagnosticsConfig,
     NamingConfig,
     OverridesConfig,
     PathsConfig,
@@ -429,6 +430,7 @@ def load_config(path: str) -> AppConfig:
             raw.get("audio_alignment", {}), "audio_alignment", AudioAlignmentConfig
         ),
         report=_sanitize_section(raw.get("report", {}), "report", ReportConfig),
+        diagnostics=_sanitize_section(raw.get("diagnostics", {}), "diagnostics", DiagnosticsConfig),
     )
 
     normalized_style = str(app.cli.progress.style).strip().lower()

--- a/src/data/config.toml.template
+++ b/src/data/config.toml.template
@@ -133,6 +133,10 @@ verify_luma_threshold = 0.10
 strict = false
 debug_color = false          # Enable colour pipeline debug logging and intermediate frame dumps
 
+[diagnostics]
+# Controls opt-in diagnostic computations that may add overhead to render runs.
+per_frame_nits = false  # Compute per-frame nit estimates (diagnostic overlay only) when true.
+
 [slowpics]
 # Auto-upload settings. Disabled by default to avoid unintentional sharing; opt in explicitly.
 auto_upload = false

--- a/src/datatypes.py
+++ b/src/datatypes.py
@@ -252,6 +252,13 @@ class ReportConfig:
 
 
 @dataclass
+class DiagnosticsConfig:
+    """Diagnostic overlay computation controls."""
+
+    per_frame_nits: bool = False
+
+
+@dataclass
 class AudioAlignmentConfig:
     """Audio-based offset estimation to help align clips before analysis."""
 
@@ -300,3 +307,4 @@ class AppConfig:
     source: SourceConfig
     audio_alignment: AudioAlignmentConfig
     report: ReportConfig
+    diagnostics: DiagnosticsConfig

--- a/src/frame_compare/diagnostics.py
+++ b/src/frame_compare/diagnostics.py
@@ -1,0 +1,324 @@
+"""Helper utilities for extracting and formatting overlay diagnostic metadata."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+
+def _normalize_key(key: object) -> str:
+    if isinstance(key, bytes):
+        try:
+            key = key.decode("utf-8", "ignore")
+        except Exception:
+            key = str(key)
+    return str(key or "").strip().lower()
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    number = _coerce_float(value)
+    if number is None:
+        return None
+    try:
+        return int(round(number))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_luminance_values(value: Any) -> list[float]:
+    if value is None:
+        return []
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8", "ignore")
+        except Exception:
+            return []
+    if isinstance(value, str):
+        matches = re.findall(r"[-+]?\d+(?:\.\d+)?", value)
+        return [float(match) for match in matches]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        iterable = cast(Sequence[Any], value)
+        results: list[float] = []
+        for item in iterable:
+            results.extend(_coerce_luminance_values(item))
+        return results
+    return []
+
+
+def extract_mastering_display_luminance(props: Mapping[str, Any]) -> tuple[float | None, float | None]:
+    """
+    Extract mastering display luminance metadata (min/max) from frame props.
+    """
+
+    min_keys = (
+        "_MasteringDisplayMinLumi",
+        "_MasteringDisplayMinLuminance",
+        "MasteringDisplayMinLumi",
+        "MasteringDisplayMinLuminance",
+        "MasteringDisplayMinimumLuminance",
+    )
+    max_keys = (
+        "_MasteringDisplayMaxLumi",
+        "_MasteringDisplayMaxLuminance",
+        "MasteringDisplayMaxLumi",
+        "MasteringDisplayMaxLuminance",
+        "MasteringDisplayMaximumLuminance",
+    )
+
+    min_value: float | None = None
+    max_value: float | None = None
+
+    for key in min_keys:
+        if key in props:
+            values = _coerce_luminance_values(props.get(key))
+            if values:
+                min_value = values[0]
+                break
+    for key in max_keys:
+        if key in props:
+            values = _coerce_luminance_values(props.get(key))
+            if values:
+                max_value = values[0]
+                break
+
+    if min_value is None or max_value is None:
+        combined_keys = ("_MasteringDisplayLuminance", "MasteringDisplayLuminance")
+        for key in combined_keys:
+            values = _coerce_luminance_values(props.get(key))
+            if len(values) >= 2:
+                if min_value is None:
+                    min_value = min(values)
+                if max_value is None:
+                    max_value = max(values)
+                break
+
+    return min_value, max_value
+
+
+def format_luminance_value(value: float) -> str:
+    """Format luminance values with context-aware precision."""
+
+    if value < 1.0:
+        text = f"{value:.4f}"
+        if "." in text:
+            text = text.rstrip("0").rstrip(".")
+        return text or "0"
+    return f"{value:.1f}"
+
+
+def format_mastering_display_line(props: Mapping[str, Any]) -> str:
+    """Return a human readable mastering display summary line."""
+
+    min_value, max_value = extract_mastering_display_luminance(props)
+    if min_value is None or max_value is None:
+        return "MDL: Insufficient data"
+    return (
+        f"MDL: min: {format_luminance_value(min_value)} cd/m², "
+        f"max: {format_luminance_value(max_value)} cd/m²"
+    )
+
+
+def _has_dovi_hint(normalized: str) -> bool:
+    return "dovi" in normalized or "dolbyvision" in normalized or "dolby" in normalized
+
+
+def _matches_all(text: str, needles: tuple[str, ...]) -> bool:
+    return all(needle in text for needle in needles)
+
+
+def extract_dovi_metadata(props: Mapping[str, Any]) -> dict[str, float | int | None]:
+    """Return Dolby Vision metadata extracted from frame props when available."""
+
+    result: dict[str, float | int | None] = {
+        "block_index": None,
+        "block_total": None,
+        "target_nits": None,
+        "l1_average": None,
+        "l1_maximum": None,
+    }
+    for key, value in props.items():
+        normalized = _normalize_key(key)
+        if not normalized or not _has_dovi_hint(normalized):
+            continue
+        if _matches_all(normalized, ("block", "index")):
+            result.setdefault("block_index", None)
+            if result["block_index"] is None:
+                result["block_index"] = _coerce_int(value)
+        elif _matches_all(normalized, ("block", "total")) or _matches_all(normalized, ("block", "count")):
+            if result["block_total"] is None:
+                result["block_total"] = _coerce_int(value)
+        elif "target" in normalized and ("nit" in normalized or "pq" in normalized or "brightness" in normalized):
+            if result["target_nits"] is None:
+                result["target_nits"] = _coerce_float(value)
+        elif "l1" in normalized and ("avg" in normalized or "average" in normalized or "mean" in normalized):
+            if result["l1_average"] is None:
+                result["l1_average"] = _coerce_float(value)
+        elif "l1" in normalized and "max" in normalized:
+            if result["l1_maximum"] is None:
+                result["l1_maximum"] = _coerce_float(value)
+    return result
+
+
+def extract_hdr_metadata(props: Mapping[str, Any]) -> dict[str, float | None]:
+    """Extract HDR mastering metadata (MDL/CLL/FALL) from frame props."""
+
+    min_lum, max_lum = extract_mastering_display_luminance(props)
+    cll = None
+    fall = None
+    for key, value in props.items():
+        normalized = _normalize_key(key)
+        if "cll" in normalized or _matches_all(normalized, ("contentlightlevel", "max")):
+            if cll is None:
+                cll = _coerce_float(value)
+        if "fall" in normalized or _matches_all(normalized, ("contentlightlevel", "fall")):
+            if fall is None:
+                fall = _coerce_float(value)
+    return {
+        "min_luminance": min_lum,
+        "max_luminance": max_lum,
+        "max_cll": cll,
+        "max_fall": fall,
+    }
+
+
+def classify_color_range(props: Mapping[str, Any]) -> str | None:
+    """Classify the encoded colour range (limited/full) based on frame props."""
+
+    for key, value in props.items():
+        normalized = _normalize_key(key)
+        if normalized not in {"_colorrange", "colorrange"}:
+            continue
+        if value is None:
+            continue
+        try:
+            code = int(value)
+        except (TypeError, ValueError):
+            continue
+        if code == 0:
+            return "full"
+        if code == 1:
+            return "limited"
+    return None
+
+
+def _format_nits(value: float | None) -> str | None:
+    if value is None:
+        return None
+    if abs(value - round(value)) < 1e-3:
+        return f"{round(value):.0f}"
+    return f"{value:.1f}"
+
+
+def format_dovi_line(label: str | None, metadata: Mapping[str, Any]) -> str | None:
+    """Return a DoVi summary line for diagnostic overlays."""
+
+    parts: list[str] = []
+    if label:
+        parts.append(f"DoVi: {label}")
+    block_index = metadata.get("block_index")
+    block_total = metadata.get("block_total")
+    if isinstance(block_index, int) and block_index >= 0:
+        if isinstance(block_total, int) and block_total > 0:
+            parts.append(f"L2 {block_index}/{block_total}")
+        else:
+            parts.append(f"L2 block {block_index}")
+    elif isinstance(block_total, int) and block_total > 0:
+        parts.append(f"L2 blocks={block_total}")
+    target = metadata.get("target_nits")
+    target_label = _format_nits(target if isinstance(target, (int, float)) else None)
+    if target_label:
+        parts.append(f"target {target_label} nits")
+    if not parts:
+        return None
+    return " ".join(parts)
+
+
+def format_hdr_line(metadata: Mapping[str, Any]) -> str | None:
+    """Return an HDR metadata summary (MaxCLL/MaxFALL) line."""
+
+    segments: list[str] = []
+    cll_label = _format_nits(metadata.get("max_cll") if isinstance(metadata.get("max_cll"), (int, float)) else None)
+    fall_label = _format_nits(metadata.get("max_fall") if isinstance(metadata.get("max_fall"), (int, float)) else None)
+    if cll_label:
+        segments.append(f"MaxCLL {cll_label}")
+    if fall_label:
+        segments.append(f"MaxFALL {fall_label}")
+    if not segments:
+        return None
+    return f"HDR: {' / '.join(segments)}"
+
+
+def format_dynamic_range_line(range_label: str | None) -> str | None:
+    """Return a limited/full range summary if available."""
+
+    if not range_label:
+        return None
+    text = range_label.strip()
+    if not text:
+        return None
+    return f"Range: {text.capitalize()}"
+
+
+def build_frame_metric_entry(frame: int, score: float | None, category: str | None, *, target_nits: float) -> dict[str, Any] | None:
+    """Convert a selection score into a per-frame brightness estimate."""
+
+    if score is None:
+        return None
+    try:
+        numeric_score = float(score)
+    except (TypeError, ValueError):
+        return None
+    if not (numeric_score == numeric_score):  # NaN check
+        return None
+    clamped = max(0.0, min(numeric_score, 1.0))
+    avg = clamped * max(float(target_nits), 0.0)
+    entry = {
+        "frame": int(frame),
+        "score": numeric_score,
+        "avg_nits": avg,
+        "max_nits": avg,
+        "category": category,
+    }
+    return entry
+
+
+def format_frame_metrics_line(entry: Mapping[str, Any] | None) -> str | None:
+    """Return a human-readable per-frame nit summary."""
+
+    if not entry:
+        return None
+    avg = entry.get("avg_nits")
+    max_value = entry.get("max_nits")
+    if not isinstance(avg, (int, float)) and not isinstance(max_value, (int, float)):
+        return None
+    avg_label = _format_nits(float(avg)) if isinstance(avg, (int, float)) else None
+    max_label = _format_nits(float(max_value)) if isinstance(max_value, (int, float)) else None
+    parts: list[str] = []
+    if avg_label:
+        parts.append(f"avg {avg_label}")
+    if max_label:
+        parts.append(f"max {max_label}")
+    if not parts:
+        return None
+    suffix = ""
+    category = entry.get("category")
+    if isinstance(category, str) and category.strip():
+        suffix = f" ({category.strip()})"
+    return f"Frame Nits: {' / '.join(parts)}{suffix}"

--- a/src/frame_compare/planner.py
+++ b/src/frame_compare/planner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Dict, Sequence
 
 from src.datatypes import AppConfig
-from src.frame_compare.cli_runtime import ClipPlan
+from src.frame_compare.cli_runtime import CLIAppError, ClipPlan
 from src.frame_compare.metadata import match_override, normalise_override_mapping
 
 MetadataRecord = Dict[str, str]
@@ -32,6 +32,22 @@ def build_plans(
     trim_map = normalise_override_mapping(cfg.overrides.trim)
     trim_end_map = normalise_override_mapping(cfg.overrides.trim_end)
     fps_map = normalise_override_mapping(cfg.overrides.change_fps)
+
+    if len(metadata) < len(files):
+        missing = len(files) - len(metadata)
+        preview = ", ".join(str(path) for path in files[len(metadata) : len(metadata) + 3])
+        message = (
+            f"metadata entries missing for {missing} file(s); "
+            f"only provided {len(metadata)} entries for {len(files)} inputs"
+        )
+        raise CLIAppError(
+            message,
+            rich_message=(
+                "[red]metadata entries missing:[/red] provided "
+                f"{len(metadata)} entries for {len(files)} files. "
+                f"Add metadata for: {preview}"
+            ),
+        )
 
     plans: list[ClipPlan] = []
     for idx, file in enumerate(files):

--- a/src/frame_compare/preflight.py
+++ b/src/frame_compare/preflight.py
@@ -19,6 +19,7 @@ from src.datatypes import (
     AudioAlignmentConfig,
     CLIConfig,
     ColorConfig,
+    DiagnosticsConfig,
     NamingConfig,
     OverridesConfig,
     PathsConfig,
@@ -294,6 +295,7 @@ def _fresh_app_config() -> AppConfig:
         source=SourceConfig(),
         audio_alignment=AudioAlignmentConfig(),
         report=ReportConfig(),
+        diagnostics=DiagnosticsConfig(),
     )
 
 

--- a/src/frame_compare/runner.py
+++ b/src/frame_compare/runner.py
@@ -45,6 +45,12 @@ from src.frame_compare.analysis import (
     selection_hash_for_config,
     write_selection_cache_file,
 )
+from src.frame_compare.diagnostics import (
+    build_frame_metric_entry,
+    classify_color_range,
+    extract_dovi_metadata,
+    extract_hdr_metadata,
+)
 from src.frame_compare.env_flags import env_flag_enabled
 from src.frame_compare.result_snapshot import (
     RenderOptions,
@@ -164,6 +170,7 @@ class RunRequest:
     show_partial_sections: bool = False
     show_missing_sections: bool = True
     service_mode_override: bool | None = None
+    diagnostic_frame_metrics: bool | None = None
 
 
 @dataclass(slots=True)
@@ -911,7 +918,7 @@ def run(request: RunRequest, *, dependencies: RunDependencies | None = None) -> 
 
     clip_records: List[ClipRecord] = []
     trim_details: List[TrimSummary] = []
-    for plan in plans:
+    for idx, plan in enumerate(plans):
         label = (plan.metadata.get("label") or plan.path.name).strip()
         frames_total = int(plan.source_num_frames or getattr(plan.clip, "num_frames", 0) or 0)
         width = int(plan.source_width or getattr(plan.clip, "width", 0) or 0)
@@ -931,18 +938,24 @@ def run(request: RunRequest, *, dependencies: RunDependencies | None = None) -> 
                 "path": str(plan.path),
             }
         )
-        json_tail["clips"].append(
-            {
-                "label": label,
-                "width": width,
-                "height": height,
-                "fps": fps_float,
-                "frames": frames_total,
-                "duration_s": duration_seconds,
-                "duration_tc": runtime_utils.format_seconds(duration_seconds),
-                "path": str(plan.path),
-            }
-        )
+        clip_entry: dict[str, Any] = {
+            "label": label,
+            "width": width,
+            "height": height,
+            "fps": fps_float,
+            "frames": frames_total,
+            "duration_s": duration_seconds,
+            "duration_tc": runtime_utils.format_seconds(duration_seconds),
+            "path": str(plan.path),
+        }
+        props_snapshot = stored_props_seq[idx] or {}
+        hdr_meta = extract_hdr_metadata(props_snapshot)
+        if any(value is not None for value in hdr_meta.values()):
+            clip_entry["hdr_metadata"] = {k: v for k, v in hdr_meta.items() if v is not None}
+        range_label = classify_color_range(props_snapshot)
+        if range_label:
+            clip_entry["dynamic_range"] = {"label": range_label, "source": "frame_props"}
+        json_tail["clips"].append(clip_entry)
 
         lead_frames = max(0, int(plan.trim_start))
         lead_seconds = lead_frames / fps_float if fps_float > 0 else 0.0
@@ -1419,7 +1432,7 @@ def run(request: RunRequest, *, dependencies: RunDependencies | None = None) -> 
     clip_paths = [plan.path for plan in plans]
     selection_sidecar_dir = cache_info.path.parent if cache_info is not None else root
     selection_sidecar_path = selection_sidecar_dir / "generated.selection.v1.json"
-    selection_overlay_details = {
+    selection_overlay_details: dict[int, dict[str, Any]] = {
         frame: {
             "label": detail.label,
             "timecode": detail.timecode,
@@ -1632,6 +1645,68 @@ def run(request: RunRequest, *, dependencies: RunDependencies | None = None) -> 
         "mode": overlay_mode_value,
     }
     layout_data["overlay"] = json_tail["overlay"]
+
+    diagnostics_cfg = getattr(cfg, "diagnostics", None)
+    per_frame_config_enabled = bool(getattr(diagnostics_cfg, "per_frame_nits", False))
+    per_frame_override = request.diagnostic_frame_metrics
+    per_frame_requested = per_frame_override if per_frame_override is not None else per_frame_config_enabled
+    per_frame_enabled = bool(per_frame_requested and overlay_mode_value == "diagnostic")
+
+    tonemap_block = json_tail["tonemap"]
+    tonemap_target_value = tonemap_block.get("target_nits")
+    if isinstance(tonemap_target_value, (int, float)):
+        tonemap_target = float(tonemap_target_value)
+    else:
+        tonemap_target = float(getattr(cfg.color, "target_nits", 0.0))
+    per_frame_metrics: dict[int, dict[str, Any]] = {}
+    if per_frame_enabled:
+        for frame_idx, detail in selection_details.items():
+            entry = build_frame_metric_entry(
+                frame_idx,
+                detail.score,
+                detail.label,
+                target_nits=tonemap_target,
+            )
+            if entry is not None:
+                per_frame_metrics[frame_idx] = entry
+
+    for frame_idx, overlay_detail in selection_overlay_details.items():
+        metric_entry = per_frame_metrics.get(frame_idx)
+        if metric_entry is None:
+            continue
+        diagnostics_block = overlay_detail.setdefault("diagnostics", {})
+        diagnostics_block["frame_metrics"] = metric_entry
+
+    analyze_props = stored_props_seq[analyze_index] or {}
+    dovi_meta = extract_dovi_metadata(analyze_props)
+    hdr_meta = extract_hdr_metadata(analyze_props)
+    range_label = classify_color_range(analyze_props)
+    frame_metrics_json = {str(frame): entry for frame, entry in per_frame_metrics.items()}
+    dv_summary = {k: v for k, v in dovi_meta.items() if v is not None}
+    dv_block: dict[str, Any] = {
+        "label": json_tail["tonemap"].get("use_dovi_label"),
+        "enabled": json_tail["tonemap"].get("use_dovi"),
+    }
+    if dv_summary:
+        dv_block["l2_summary"] = dv_summary
+    hdr_summary = {k: v for k, v in hdr_meta.items() if v is not None}
+    overlay_diag: dict[str, Any] = {
+        "dv": dv_block,
+        "frame_metrics": {
+            "enabled": per_frame_enabled,
+            "per_frame": frame_metrics_json,
+            "gating": {
+                "config": per_frame_config_enabled,
+                "cli_override": per_frame_override,
+                "overlay_mode": overlay_mode_value,
+            },
+        },
+    }
+    if hdr_summary:
+        overlay_diag["hdr"] = hdr_summary
+    if range_label:
+        overlay_diag["dynamic_range"] = {"label": range_label, "source": "frame_props"}
+    json_tail["overlay"]["diagnostics"] = overlay_diag
 
     reporter.update_values(layout_data)
 

--- a/src/frame_compare/slowpics.py
+++ b/src/frame_compare/slowpics.py
@@ -458,7 +458,9 @@ def upload_comparison(
         multiple worker threads. Callers should ensure the callback is thread-safe
         (for example, by using ``threading.Lock`` or other synchronization
         primitives) if they mutate shared state or emit UI updates inside the
-        callback.
+        callback. The CLI publishers use a dedicated lock-protected progress
+        tracker so file counts/byte totals stay consistent while worker threads
+        emit callbacks.
     """
 
     if not image_files:

--- a/tests/frame_compare/test_diagnostics.py
+++ b/tests/frame_compare/test_diagnostics.py
@@ -1,0 +1,54 @@
+"""Unit tests for the diagnostics helper utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.frame_compare import diagnostics as diag
+
+
+def test_extract_dovi_metadata_handles_common_props() -> None:
+    props = {
+        "DolbyVision_Block_Index": 2,
+        "DolbyVision_Block_Total": "8",
+        "DolbyVision_Target_Nits": "550",
+        "DolbyVision_L1_Average": "0.12",
+        "DolbyVision_L1_Maximum": 0.5,
+    }
+    metadata = diag.extract_dovi_metadata(props)
+    assert metadata["block_index"] == 2
+    assert metadata["block_total"] == 8
+    assert metadata["target_nits"] == pytest.approx(550.0)
+    assert metadata["l1_average"] == pytest.approx(0.12)
+    assert metadata["l1_maximum"] == pytest.approx(0.5)
+
+
+def test_extract_hdr_metadata_merges_mdl_and_cll() -> None:
+    props = {
+        "MasteringDisplayLuminance": "0.002 1000",
+        "ContentLightLevelMax": 900,
+        "ContentLightLevelFall": 300,
+    }
+    metadata = diag.extract_hdr_metadata(props)
+    assert metadata["min_luminance"] == pytest.approx(0.002)
+    assert metadata["max_luminance"] == pytest.approx(1000.0)
+    assert metadata["max_cll"] == pytest.approx(900.0)
+    assert metadata["max_fall"] == pytest.approx(300.0)
+
+
+def test_format_frame_metrics_line_includes_category() -> None:
+    entry = {
+        "avg_nits": 120.0,
+        "max_nits": 160.0,
+        "category": "bright",
+    }
+    line = diag.format_frame_metrics_line(entry)
+    assert line == "Frame Nits: avg 120 / max 160 (bright)"
+
+
+def test_build_frame_metric_entry_clamps_scores() -> None:
+    entry = diag.build_frame_metric_entry(5, 1.25, "Auto", target_nits=500.0)
+    assert entry is not None
+    assert entry["frame"] == 5
+    assert entry["avg_nits"] == pytest.approx(500.0)
+    assert entry["max_nits"] == pytest.approx(500.0)

--- a/tests/helpers/runner_env.py
+++ b/tests/helpers/runner_env.py
@@ -31,6 +31,7 @@ from src.datatypes import (
     AudioAlignmentConfig,
     CLIConfig,
     ColorConfig,
+    DiagnosticsConfig,
     NamingConfig,
     OverridesConfig,
     PathsConfig,
@@ -332,7 +333,23 @@ def _make_json_tail_stub() -> JsonTail:
         "analysis": {},
         "render": {},
         "tonemap": {},
-        "overlay": {},
+        "overlay": {
+            "enabled": True,
+            "template": "",
+            "mode": "minimal",
+            "diagnostics": {
+                "dv": {"enabled": None, "label": "auto"},
+                "frame_metrics": {
+                    "enabled": False,
+                    "per_frame": {},
+                    "gating": {
+                        "config": False,
+                        "cli_override": None,
+                        "overlay_mode": "minimal",
+                    },
+                },
+            },
+        },
         "verify": {
             "count": 0,
             "threshold": 0.0,
@@ -439,6 +456,7 @@ def _make_config(input_dir: Path) -> AppConfig:
         audio_alignment=AudioAlignmentConfig(enable=False),
         report=ReportConfig(enable=False),
         runner=RunnerConfig(),
+        diagnostics=DiagnosticsConfig(),
     )
 
 

--- a/tests/net/test_httpx_backoff.py
+++ b/tests/net/test_httpx_backoff.py
@@ -18,7 +18,12 @@ class StubAsyncClient:
         self.calls = 0
         self.base_url = base_url
 
-    async def get(self, path: str, params: dict[str, object]) -> httpx.Response:
+    async def get(
+        self,
+        path: str,
+        params: dict[str, object],
+        timeout: float | httpx.Timeout | None = None,
+    ) -> httpx.Response:
         self.calls += 1
         response = self._responses.pop(0)
         return response

--- a/tests/net/test_httpx_helpers.py
+++ b/tests/net/test_httpx_helpers.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+import httpx
+import pytest
+
+from src.frame_compare import net
+
+TimeoutException = getattr(httpx, "TimeoutException")  # type: ignore[attr-defined]
+ReadTimeout = getattr(httpx, "ReadTimeout")  # type: ignore[attr-defined]
+Request = getattr(httpx, "Request")  # type: ignore[attr-defined]
+
+
+class HangingClient:
+    def __init__(self) -> None:
+        self.base_url = "https://example.com"
+        self.timeouts: list[float | httpx.Timeout | None] = []
+
+    async def get(
+        self,
+        path: str,
+        params: dict[str, object],
+        timeout: float | httpx.Timeout | None = None,
+    ) -> httpx.Response:
+        self.timeouts.append(timeout)
+        seconds = _coerce_timeout(timeout)
+        event = asyncio.Event()
+        request = Request("GET", path)
+        try:
+            await asyncio.wait_for(event.wait(), timeout=seconds)
+        except asyncio.TimeoutError as exc:
+            raise ReadTimeout(f"Timeout after {seconds}s", request=request) from exc
+        raise AssertionError("event wait unexpectedly completed")
+
+
+class RecordingClient:
+    def __init__(self) -> None:
+        self.base_url = "https://example.com"
+        self.timeouts: list[float | httpx.Timeout | None] = []
+
+    async def get(
+        self,
+        path: str,
+        params: dict[str, object],
+        timeout: float | httpx.Timeout | None = None,
+    ) -> httpx.Response:
+        self.timeouts.append(timeout)
+        return httpx.Response(status_code=200)
+
+
+def _coerce_timeout(value: float | httpx.Timeout | None) -> float:
+    if value is None:
+        return 0.1
+    if isinstance(value, (int, float)):
+        return float(value)
+    for attr in (getattr(value, "read", None), getattr(value, "connect", None)):
+        if isinstance(attr, (int, float)):
+            return float(attr)
+    return 0.1
+
+
+def test_httpx_backoff_propagates_timeout_errors() -> None:
+    hanging_client = HangingClient()
+    client = cast(httpx.AsyncClient, hanging_client)
+
+    with pytest.raises(TimeoutException):
+        asyncio.run(
+            net.httpx_get_json_with_backoff(
+                client,
+                path="https://example.com/api",
+                params={},
+                retries=0,
+                timeout=httpx.Timeout(0.01, connect=0.01, read=0.01),
+            )
+        )
+
+    assert hanging_client.timeouts, "client should capture the configured timeout"
+
+
+def test_httpx_backoff_uses_default_timeout_when_unspecified() -> None:
+    recording_client = RecordingClient()
+    client = cast(httpx.AsyncClient, recording_client)
+
+    response = asyncio.run(
+        net.httpx_get_json_with_backoff(
+            client,
+            path="https://example.com/api",
+            params={},
+            retries=0,
+        )
+    )
+
+    assert response.status_code == 200
+    assert recording_client.timeouts == [net.DEFAULT_HTTP_TIMEOUT]

--- a/tests/render/test_overlay_text.py
+++ b/tests/render/test_overlay_text.py
@@ -74,6 +74,65 @@ def test_mastering_display_extraction_falls_back_to_combined_keys() -> None:
     assert max_value == 950
 
 
+def test_compose_overlay_text_includes_diagnostics_details() -> None:
+    cfg = ColorConfig()
+    cfg.overlay_mode = "diagnostic"
+    tonemap = cast("TonemapInfo", SimpleNamespace(applied=True, use_dovi=True))
+    props = {
+        "MasteringDisplayLuminance": "0.005 1000",
+        "ContentLightLevelMax": "900",
+        "ContentLightLevelFall": "300",
+        "DolbyVision_Block_Index": 2,
+        "DolbyVision_Block_Total": 10,
+        "DolbyVision_Target_Nits": "800",
+        "_colorrange": 1,
+    }
+    selection_detail = {
+        "diagnostics": {
+            "frame_metrics": {
+                "avg_nits": 120.5,
+                "max_nits": 180.0,
+                "category": "highlight",
+            }
+        }
+    }
+
+    text = overlay.compose_overlay_text(
+        "Base",
+        cfg,
+        _make_plan(),
+        "bright",
+        props,
+        tonemap_info=tonemap,
+        selection_detail=selection_detail,
+    )
+    assert text is not None
+    lines = text.splitlines()
+    assert any(line.startswith("HDR:") for line in lines)
+    assert any(line.startswith("DoVi:") for line in lines)
+    assert any("Range: Limited" in line for line in lines)
+    assert any("Frame Nits:" in line and "highlight" in line for line in lines)
+
+
+def test_compose_overlay_text_skips_frame_metrics_without_entry() -> None:
+    cfg = ColorConfig()
+    cfg.overlay_mode = "diagnostic"
+    tonemap = cast("TonemapInfo", SimpleNamespace(applied=True, use_dovi=False))
+    props = {"MasteringDisplayLuminance": "0.001 1000", "_ColorRange": 0}
+
+    text = overlay.compose_overlay_text(
+        None,
+        cfg,
+        _make_plan(),
+        "dark",
+        props,
+        tonemap_info=tonemap,
+        selection_detail={"diagnostics": {}},
+    )
+    assert text is not None
+    assert "Frame Nits:" not in text
+
+
 def test_overlay_warning_helpers_record_messages() -> None:
     state = overlay.new_overlay_state()
     overlay.append_overlay_warning(state, "issue")

--- a/tests/runner/test_overlay_diagnostics.py
+++ b/tests/runner/test_overlay_diagnostics.py
@@ -1,0 +1,299 @@
+"""Runner-level regression tests for overlay diagnostics JSON output."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+from typing import Any, Dict, List, cast
+
+import pytest
+
+from src.datatypes import AppConfig
+from src.frame_compare import runner as runner_module
+from src.frame_compare.analysis import CacheLoadResult, FrameMetricsCacheInfo, SelectionDetail
+from src.frame_compare.cli_runtime import ClipPlan, SlowpicsTitleInputs
+from src.frame_compare.services.alignment import AlignmentRequest, AlignmentResult
+from src.frame_compare.services.metadata import MetadataResolveRequest, MetadataResolveResult
+from tests.helpers.runner_env import (
+    _make_config,
+    _make_runner_preflight,
+    _patch_core_helper,
+    _selection_details_to_json,
+)
+
+pytestmark = pytest.mark.usefixtures("runner_vs_core_stub", "dummy_progress")  # type: ignore[attr-defined]
+
+
+class _StubMetadataResolver:
+    def __init__(self, result: MetadataResolveResult) -> None:
+        self._result = result
+        self.request: MetadataResolveRequest | None = None
+
+    def resolve(self, request: MetadataResolveRequest) -> MetadataResolveResult:
+        self.request = request
+        return self._result
+
+
+class _StubAlignmentWorkflow:
+    def __init__(self) -> None:
+        self.request: AlignmentRequest | None = None
+
+    def run(self, request: AlignmentRequest) -> AlignmentResult:
+        self.request = request
+        return AlignmentResult(plans=list(request.plans), summary=None, display=None)
+
+
+class _NullReportPublisher:
+    def publish(self, _request: object) -> types.SimpleNamespace:
+        return types.SimpleNamespace(report_path=None)
+
+
+class _NullSlowpicsPublisher:
+    def publish(self, _request: object) -> types.SimpleNamespace:
+        return types.SimpleNamespace(url=None)
+
+
+def _build_dependencies(result: MetadataResolveResult) -> tuple[runner_module.RunDependencies, _StubMetadataResolver, _StubAlignmentWorkflow]:
+    resolver = _StubMetadataResolver(result)
+    workflow = _StubAlignmentWorkflow()
+    deps = runner_module.RunDependencies(
+        metadata_resolver=cast(runner_module.MetadataResolver, resolver),
+        alignment_workflow=cast(runner_module.AlignmentWorkflow, workflow),
+        report_publisher=cast(runner_module.ReportPublisher, _NullReportPublisher()),
+        slowpics_publisher=cast(runner_module.SlowpicsPublisher, _NullSlowpicsPublisher()),
+    )
+    return deps, resolver, workflow
+
+
+def _seed_media(root: Path) -> List[Path]:
+    files = [root / "Alpha.mkv", root / "Beta.mkv"]
+    for file in files:
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_bytes(b"0")
+    return files
+
+
+def _make_plans(files: List[Path]) -> List[ClipPlan]:
+    props = {
+        "MasteringDisplayLuminance": "0.005 1000",
+        "ContentLightLevelMax": "850",
+        "ContentLightLevelFall": "350",
+        "DolbyVision_Block_Index": 3,
+        "DolbyVision_Block_Total": 7,
+        "DolbyVision_Target_Nits": "700",
+        "_colorrange": 0,
+    }
+    plans = [
+        ClipPlan(
+            path=files[0],
+            metadata={"label": "Alpha"},
+            trim_start=0,
+            trim_end=None,
+            use_as_reference=True,
+            source_frame_props=dict(props),
+            source_width=3840,
+            source_height=2160,
+            source_num_frames=120,
+        ),
+        ClipPlan(
+            path=files[1],
+            metadata={"label": "Beta"},
+            trim_start=0,
+            trim_end=None,
+            source_frame_props={"_ColorRange": 1},
+            source_width=3840,
+            source_height=2160,
+            source_num_frames=120,
+        ),
+    ]
+    return plans
+
+
+def _make_metadata_result(files: List[Path]) -> MetadataResolveResult:
+    plans = _make_plans(files)
+    title_inputs: SlowpicsTitleInputs = {
+        "resolved_base": None,
+        "collection_name": None,
+        "collection_suffix": "",
+    }
+    return MetadataResolveResult(
+        plans=list(plans),
+        metadata=[{"label": "Alpha"}, {"label": "Beta"}],
+        metadata_title="Alpha vs Beta",
+        analyze_path=files[0],
+        slowpics_title_inputs=title_inputs,
+        slowpics_final_title="Alpha vs Beta",
+        slowpics_resolved_base=None,
+        slowpics_tmdb_disclosure_line=None,
+        slowpics_verbose_tmdb_tag=None,
+    )
+
+
+def _install_analysis_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    score: float | None,
+) -> None:
+    def fake_select(*_args: object, **_kwargs: object):
+        details = {
+            10: SelectionDetail(
+                frame_index=10,
+                label="Auto",
+                score=score,
+                source="auto",
+                timecode="00:00:10.000",
+                notes=None,
+            )
+        }
+        return [10], {10: "Auto"}, details
+
+    monkeypatch.setattr(runner_module, "select_frames", fake_select)
+    monkeypatch.setattr(runner_module, "selection_details_to_json", _selection_details_to_json)
+    monkeypatch.setattr(
+        runner_module,
+        "probe_cached_metrics",
+        lambda *_args, **_kwargs: CacheLoadResult(metrics=None, status="missing", reason=None),
+    )
+    monkeypatch.setattr(runner_module, "selection_hash_for_config", lambda *_args, **_kwargs: "hash")
+    monkeypatch.setattr(runner_module, "export_selection_metadata", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(runner_module, "write_selection_cache_file", lambda *_args, **_kwargs: None)
+
+
+def _install_render_stubs(monkeypatch: pytest.MonkeyPatch, out_dir: Path) -> None:
+    def fake_generate(
+        clips: List[object],
+        frames: List[int],
+        files_for_run: List[Path],
+        metadata_list: List[Dict[str, Any]],
+        out_dir_param: Path,
+        cfg_screens: object,
+        color_cfg: object,
+        **_kwargs: object,
+    ) -> List[str]:
+        out_dir_param.mkdir(parents=True, exist_ok=True)
+        shot = out_dir_param / "shot.png"
+        shot.write_text("img", encoding="utf-8")
+        return [str(shot)]
+
+    def fake_init_clips(plans: List[ClipPlan], *_args: object, **_kwargs: object) -> None:
+        for plan in plans:
+            plan.clip = types.SimpleNamespace(width=plan.source_width, height=plan.source_height, num_frames=plan.source_num_frames or 120)
+
+    monkeypatch.setattr(runner_module, "generate_screenshots", fake_generate)
+    monkeypatch.setattr(runner_module.selection_utils, "init_clips", fake_init_clips)
+    monkeypatch.setattr(
+        runner_module.cache_utils,
+        "build_cache_info",
+        lambda *_args, **_kwargs: FrameMetricsCacheInfo(
+            path=out_dir / "generated.compframes",
+            files=["Alpha.mkv", "Beta.mkv"],
+            analyzed_file="Alpha.mkv",
+            release_group="grp",
+            trim_start=0,
+            trim_end=None,
+            fps_num=24000,
+            fps_den=1001,
+        ),
+    )
+    monkeypatch.setattr(
+        runner_module.vs_core,
+        "resolve_effective_tonemap",
+        lambda color_cfg: {
+            "preset": getattr(color_cfg, "preset", "reference"),
+            "tone_curve": getattr(color_cfg, "tone_curve", "bt.2390"),
+            "target_nits": getattr(color_cfg, "target_nits", 100.0),
+            "metadata": getattr(color_cfg, "metadata", "auto"),
+            "use_dovi": getattr(color_cfg, "use_dovi", None),
+        },
+    )
+
+
+def _prepare_config(workspace: Path, media_root: Path, *, per_frame_nits: bool) -> tuple[AppConfig, Path]:
+    cfg = _make_config(media_root)
+    cfg.analysis.frame_count_dark = 0
+    cfg.analysis.frame_count_bright = 0
+    cfg.analysis.frame_count_motion = 0
+    cfg.analysis.random_frames = 0
+    cfg.analysis.save_frames_data = False
+    cfg.color.overlay_mode = "diagnostic"
+    cfg.color.overlay_enabled = True
+    cfg.color.target_nits = 900.0
+    cfg.color.use_dovi = True
+    cfg.diagnostics.per_frame_nits = per_frame_nits
+    cfg.slowpics.auto_upload = False
+    cfg.report.enable = False
+    cfg.runner.enable_service_mode = False
+    preflight = _make_runner_preflight(workspace, media_root, cfg)
+    return cfg, preflight.config_path
+
+
+def _common_setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    per_frame_nits: bool,
+    cli_override: bool | None,
+) -> tuple[runner_module.RunRequest, runner_module.RunDependencies, MetadataResolveResult]:
+    workspace = tmp_path / "workspace"
+    media_root = workspace / "media"
+    files = _seed_media(media_root)
+    cfg, config_path = _prepare_config(workspace, media_root, per_frame_nits=per_frame_nits)
+    preflight = _make_runner_preflight(workspace, media_root, cfg)
+    _patch_core_helper(monkeypatch, "prepare_preflight", lambda **_kwargs: preflight)
+    monkeypatch.setattr(runner_module.media_utils, "discover_media", lambda _root: list(files))
+    metadata_result = _make_metadata_result(files)
+    deps, _, _ = _build_dependencies(metadata_result)
+    _install_analysis_stubs(monkeypatch, score=0.6)
+    _install_render_stubs(monkeypatch, out_dir=media_root / cfg.screenshots.directory_name)
+
+    request = runner_module.RunRequest(
+        config_path=str(config_path),
+        root_override=str(workspace),
+        diagnostic_frame_metrics=cli_override,
+        service_mode_override=False,
+    )
+    return request, deps, metadata_result
+
+
+def test_runner_emits_overlay_diagnostics_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request, deps, _ = _common_setup(tmp_path, monkeypatch, per_frame_nits=True, cli_override=None)
+
+    result = runner_module.run(request, dependencies=deps)
+
+    assert result.json_tail is not None
+    tail_overlay = cast(Dict[str, Any], result.json_tail["overlay"])
+    overlay_diag = cast(Dict[str, Any], tail_overlay["diagnostics"])
+    dv_block = cast(Dict[str, Any], overlay_diag["dv"])
+    assert dv_block["enabled"] is True
+    assert dv_block["label"] == "on"
+    assert dv_block["l2_summary"]["block_index"] == 3
+    hdr_block = cast(Dict[str, Any], overlay_diag["hdr"])
+    assert hdr_block["max_cll"] == 850.0
+    assert hdr_block["max_fall"] == 350.0
+    range_block = cast(Dict[str, Any], overlay_diag["dynamic_range"])
+    assert range_block["label"] == "full"
+    frame_metrics = cast(Dict[str, Any], overlay_diag["frame_metrics"])
+    assert frame_metrics["enabled"] is True
+    assert frame_metrics["gating"]["config"] is True
+    assert frame_metrics["gating"]["cli_override"] is None
+    per_frame = cast(Dict[str, Any], frame_metrics["per_frame"])
+    assert per_frame["10"]["category"] == "Auto"
+    assert per_frame["10"]["avg_nits"] == pytest.approx(540.0)
+    clips_block = cast(List[Dict[str, Any]], result.json_tail["clips"])
+    clip_entry = clips_block[0]
+    assert clip_entry["hdr_metadata"]["max_cll"] == 850.0
+    assert clip_entry["dynamic_range"]["label"] == "full"
+
+
+def test_cli_override_disables_frame_metrics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    request, deps, _ = _common_setup(tmp_path, monkeypatch, per_frame_nits=True, cli_override=False)
+
+    result = runner_module.run(request, dependencies=deps)
+
+    assert result.json_tail is not None
+    tail_overlay = cast(Dict[str, Any], result.json_tail["overlay"])
+    overlay_diag = cast(Dict[str, Any], tail_overlay["diagnostics"])
+    frame_metrics = cast(Dict[str, Any], overlay_diag["frame_metrics"])
+    assert frame_metrics["enabled"] is False
+    assert cast(Dict[str, Any], frame_metrics["per_frame"]) == {}
+    assert frame_metrics["gating"]["cli_override"] is False

--- a/tests/runner/test_slowpics_workflow.py
+++ b/tests/runner/test_slowpics_workflow.py
@@ -19,6 +19,7 @@ from src.datatypes import (
     AudioAlignmentConfig,
     CLIConfig,
     ColorConfig,
+    DiagnosticsConfig,
     NamingConfig,
     OverridesConfig,
     PathsConfig,
@@ -76,6 +77,7 @@ def test_cli_input_override_and_cleanup(
         source=SourceConfig(),
         audio_alignment=AudioAlignmentConfig(enable=False),
         report=ReportConfig(enable=False),
+        diagnostics=DiagnosticsConfig(),
     )
 
     _patch_load_config(monkeypatch, cfg)

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -12,6 +12,7 @@ from src.datatypes import (
     AudioAlignmentConfig,
     CLIConfig,
     ColorConfig,
+    DiagnosticsConfig,
     NamingConfig,
     OverridesConfig,
     PathsConfig,
@@ -100,6 +101,7 @@ def build_service_config(root: Path) -> AppConfig:
         audio_alignment=AudioAlignmentConfig(enable=False),
         report=ReportConfig(enable=False),
         runner=RunnerConfig(),
+        diagnostics=DiagnosticsConfig(),
     )
 
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -24,6 +24,7 @@ from src.datatypes import (
     TMDBConfig,
 )
 from src.frame_compare import planner
+from src.frame_compare.cli_runtime import CLIAppError
 
 
 def _make_config(
@@ -96,3 +97,14 @@ def test_build_plans_rejects_unsupported_fps_override(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         planner.build_plans(files, metadata, cfg)
+
+
+def test_build_plans_rejects_missing_metadata(tmp_path: Path) -> None:
+    files = [tmp_path / "Alpha.mkv", tmp_path / "Beta.mkv"]
+    metadata = [{"label": "Alpha"}]
+    cfg = _make_config()
+
+    with pytest.raises(CLIAppError) as excinfo:
+        planner.build_plans(files, metadata, cfg)
+
+    assert "metadata entries missing" in str(excinfo.value)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -11,6 +11,7 @@ from src.datatypes import (
     AudioAlignmentConfig,
     CLIConfig,
     ColorConfig,
+    DiagnosticsConfig,
     NamingConfig,
     OverridesConfig,
     PathsConfig,
@@ -58,6 +59,7 @@ def _make_config(
         source=SourceConfig(preferred="lsmas"),
         audio_alignment=AudioAlignmentConfig(enable=False),
         report=ReportConfig(enable=False),
+        diagnostics=DiagnosticsConfig(),
     )
 
 

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1030,10 +1030,22 @@ def test_compose_overlay_text_diagnostic_appends_required_lines() -> None:
         target_nits=100.0,
         dst_min_nits=0.18,
         src_csp_hint=None,
+        use_dovi=True,
     )
     props = {
         "_MasteringDisplayMinLuminance": 0.0001,
         "_MasteringDisplayMaxLuminance": 1000.0,
+        "DolbyVision_BlockIndex": 2,
+        "DolbyVision_BlockCount": 8,
+        "DolbyVision_TargetNits": 400.0,
+        "ContentLightLevelMax": 1200,
+        "MaxFALL": 400,
+        "_ColorRange": 1,
+    }
+    selection_detail = {
+        "diagnostics": {
+            "frame_metrics": {"avg_nits": 45.0, "max_nits": 50.0, "category": "Bright"}
+        }
     }
 
     composed = screenshot._compose_overlay_text(
@@ -1043,6 +1055,7 @@ def test_compose_overlay_text_diagnostic_appends_required_lines() -> None:
         selection_label="Dark",
         source_props=props,
         tonemap_info=tonemap_info,
+        selection_detail=selection_detail,
     )
 
     assert composed is not None
@@ -1050,7 +1063,11 @@ def test_compose_overlay_text_diagnostic_appends_required_lines() -> None:
     assert lines[0] == base_text
     assert lines[1] == "1920 × 1080 → 3840 × 2160  (original → target)"
     assert lines[2] == "MDL: min: 0.0001 cd/m², max: 1000.0 cd/m²"
-    assert lines[3] == "Frame Selection Type: Dark"
+    assert lines[3] == "HDR: MaxCLL 1200 / MaxFALL 400"
+    assert lines[4] == "DoVi: on L2 2/8 target 400 nits"
+    assert lines[5] == "Range: Limited"
+    assert lines[6] == "Frame Nits: avg 45 / max 50 (Bright)"
+    assert lines[7] == "Frame Selection Type: Dark"
 
 
 def test_compose_overlay_text_skips_hdr_details_for_sdr() -> None:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flags to enable/disable per-frame nit estimates in diagnostic overlays
  * New config flag to gate per-frame diagnostic metrics

* **Bug Fixes**
  * Enforced sensible HTTP request timeouts for external lookups
  * Thread-safe upload progress tracking for slow.pics publishers
  * CLI now errors when supplied metadata count does not match discovered files

* **Improvements**
  * Diagnostic overlays now include HDR and Dolby Vision metadata and clearer messaging

* **Documentation**
  * Updated README and docs describing diagnostic overlay metrics and CLI usage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->